### PR TITLE
Fix CI: biome formatting, Node 20 compat, pre-commit parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 25
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 25
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npx biome check --error-on-warnings .
 bash test.sh

--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -183,7 +183,10 @@ export default function presetExtension(dreb: ExtensionAPI) {
 		const presetNames = Object.keys(presets);
 
 		if (presetNames.length === 0) {
-			ctx.ui.notify("No presets defined. Add presets to ~/.dreb/agent/presets.json or .dreb/presets.json", "warning");
+			ctx.ui.notify(
+				"No presets defined. Add presets to ~/.dreb/agent/presets.json or .dreb/presets.json",
+				"warning",
+			);
 			return;
 		}
 
@@ -283,7 +286,10 @@ export default function presetExtension(dreb: ExtensionAPI) {
 	async function cyclePreset(ctx: ExtensionContext): Promise<void> {
 		const presetNames = getPresetOrder();
 		if (presetNames.length === 0) {
-			ctx.ui.notify("No presets defined. Add presets to ~/.dreb/agent/presets.json or .dreb/presets.json", "warning");
+			ctx.ui.notify(
+				"No presets defined. Add presets to ~/.dreb/agent/presets.json or .dreb/presets.json",
+				"warning",
+			);
 			return;
 		}
 

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -171,7 +171,6 @@ export const VERSION: string = pkg.version;
 // e.g., DREB_CODING_AGENT_DIR
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
 
-
 // =============================================================================
 // User Config Paths (~/.dreb/agent/*)
 // =============================================================================

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -37,14 +37,7 @@ import {
 	visibleWidth,
 } from "@dreb/tui";
 import { spawn, spawnSync } from "child_process";
-import {
-	APP_NAME,
-	getAgentDir,
-	getAuthPath,
-	getDebugLogPath,
-	getUpdateInstruction,
-	VERSION,
-} from "../../config.js";
+import { APP_NAME, getAgentDir, getAuthPath, getDebugLogPath, getUpdateInstruction, VERSION } from "../../config.js";
 import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import type {


### PR DESCRIPTION
## Summary

- Fixed 3 biome formatting errors (preset.ts, config.ts, interactive-mode.ts) that CI caught but local development missed
- Bumped CI from Node 20 → Node 25 to match local dev — `lazy-module-load.test.ts` uses `registerHooks` (Node 23.1+)
- **Pre-commit hook now runs biome check before tests**, matching CI's check sequence — this was the root cause of the lint/test gap

## Root cause

The pre-commit hook only ran `bash test.sh` (tests), not `npx biome check --error-on-warnings .` (lint). CI runs both. Now they match.

## Test plan

- [x] `npx biome check --error-on-warnings .` passes
- [x] `npm test` passes (512 tests, 0 failures)
- [x] Pre-commit hook runs both lint and tests on commit
- [ ] CI passes on Node 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
