### PR TITLE
Bump version to 1.2.0 and add release protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,22 @@ This builds all packages in dependency order: tui → ai → agent → coding-ag
 - `packages/coding-agent` — CLI tool, tools, model resolution, TUI
 - `packages/tui` — Terminal UI components
 
+## Release Protocol
+
+**Every release MUST follow these steps in order. No exceptions.**
+
+1. **Bump version**: Update `version` in the root `package.json`
+2. **Sync**: Run `npm run sync-version` (or let `npm run build` do it — the build script runs `sync-version.sh` automatically)
+3. **Build**: Run `npm run build` to compile with the new version
+4. **Verify**: Launch the binary and confirm the TUI welcome message shows the correct version
+5. **Commit**: Commit the version bump (all `package.json` files touched by sync)
+6. **Tag**: Create a git tag matching the version: `git tag v<version>`
+7. **Push**: Push the commit and tag: `git push && git push --tags`
+
+**The version in `package.json` is the source of truth.** The TUI reads it at runtime via `config.ts`. If the version in `package.json` doesn't match the release, the TUI will show the wrong version to users.
+
+**Never create a git tag without first bumping `package.json` to match.**
+
 ## Testing
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Problem

The TUI welcome message shows `v1.0.0` but the current release is `1.2.0`. The `package.json` version was never bumped for the `1.1.0` or `1.2.0` releases, and the `v1.2.0` git tag is also missing.

## Changes

- **Bump version to 1.2.0** across all workspace packages (root, agent, ai, coding-agent, tui) via `sync-version.sh`
- **Add Release Protocol to AGENTS.md** — step-by-step checklist ensuring version bumps, builds, verification, commits, and tags happen in the right order for every release

## After merge

The `v1.2.0` git tag still needs to be created and pushed.

Closes #32
