### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
Version bump for v1.3.0 release — persistent memory system.

## Changes
- Bump version in root package.json to 1.3.0
- sync-version propagates to all workspace packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)