### PR TITLE
fix: add getMemoryIndexes to SDK example mock

### DIFF
--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -50,6 +50,12 @@ const resourceLoader: ResourceLoader = {
 	getPrompts: () => ({ prompts: [], diagnostics: [] }),
 	getThemes: () => ({ themes: [], diagnostics: [] }),
 	getAgentsFiles: () => ({ agentsFiles: [] }),
+	getMemoryIndexes: () => ({
+		global: [],
+		project: [],
+		globalMemoryDir: "",
+		projectMemoryDir: "",
+	}),
 	getSystemPrompt: () => `You are a minimal assistant.
 Available: read, bash. Be concise.`,
 	getAppendSystemPrompt: () => [],


### PR DESCRIPTION
## Summary
The `12-full-control.ts` SDK example creates an inline `ResourceLoader` mock that was missing the new `getMemoryIndexes` method added in #36, breaking CI type checking.

## Test plan
- [x] `npx tsgo --noEmit` passes
- [x] Full test suite passes