### PR TITLE
fix: add tsgo --noEmit to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npx biome check --error-on-warnings .
+npx tsgo --noEmit
 bash test.sh


### PR DESCRIPTION
## Summary
The pre-commit hook ran biome + tests but not `tsgo --noEmit`, which CI runs. This allowed type errors in `examples/sdk/` to slip through locally (#38). Now the hook matches CI exactly.

## Test plan
- [x] Pre-commit hook now runs tsgo, biome, and tests in that order
- [x] Verified: committing with this hook runs all three checks