### PR TITLE
feat: add findModel() with fuzzy matching, update tests

### DIFF
--- a/packages/agent/test/e2e.test.ts
+++ b/packages/agent/test/e2e.test.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage, Model, ToolResultMessage, UserMessage } from "@dreb/ai";
-import { getModel } from "@dreb/ai";
+import { findModel, getModel } from "@dreb/ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../src/index.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
@@ -209,7 +209,7 @@ describe("Agent E2E Tests", () => {
 	});
 
 	describe.skipIf(!process.env.ANTHROPIC_API_KEY)("Anthropic Provider (claude-haiku-4-5)", () => {
-		const model = getModel("anthropic", "claude-haiku-4-5");
+		const model = findModel("anthropic", "haiku")!;
 
 		it("should handle basic text prompt", async () => {
 			await basicPrompt(model);

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -25,6 +25,52 @@ export function getModel<TProvider extends KnownProvider, TModelId extends keyof
 	return providerModels?.get(modelId as string) as Model<ModelApi<TProvider, TModelId>>;
 }
 
+/**
+ * Find a model by fuzzy matching against the provider's model IDs.
+ *
+ * Tries exact match first, then falls back to case-insensitive substring
+ * matching. Prefers alias models (non-dated IDs) over dated versions.
+ * Returns undefined if no match or multiple ambiguous matches.
+ *
+ * Useful in tests to avoid hardcoding exact model IDs that may be
+ * deprecated or renamed across model generations.
+ *
+ * @example
+ * findModel("anthropic", "sonnet")    // → claude-sonnet-4-5
+ * findModel("anthropic", "haiku")     // → claude-haiku-4-5
+ * findModel("openai", "gpt-5-mini")   // → exact match
+ */
+export function findModel(provider: string, pattern: string): Model<Api> | undefined {
+	const providerModels = modelRegistry.get(provider);
+	if (!providerModels) return undefined;
+
+	// Try exact match first
+	const exact = providerModels.get(pattern);
+	if (exact) return exact;
+
+	// Substring match (case-insensitive)
+	const normalizedPattern = pattern.toLowerCase();
+	const matches = Array.from(providerModels.values()).filter(
+		(m) => m.id.toLowerCase().includes(normalizedPattern) || m.name?.toLowerCase().includes(normalizedPattern),
+	);
+
+	if (matches.length === 0) return undefined;
+	if (matches.length === 1) return matches[0];
+
+	// Multiple matches — prefer aliases (non-dated IDs) over dated versions
+	const isAlias = (id: string) => !/\d{8}/.test(id);
+	const aliases = matches.filter((m) => isAlias(m.id));
+
+	if (aliases.length === 1) return aliases[0];
+	if (aliases.length > 1) {
+		// Among multiple aliases, prefer the latest (highest version sort)
+		return aliases.sort((a, b) => b.id.localeCompare(a.id))[0];
+	}
+
+	// All dated — prefer the latest
+	return matches.sort((a, b) => b.id.localeCompare(a.id))[0];
+}
+
 export function getProviders(): KnownProvider[] {
 	return Array.from(modelRegistry.keys()) as KnownProvider[];
 }

--- a/packages/ai/test/find-model.test.ts
+++ b/packages/ai/test/find-model.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { findModel, getModel } from "../src/models.js";
+
+describe("findModel", () => {
+	it("returns exact match when available", () => {
+		const model = findModel("anthropic", "claude-sonnet-4-5");
+		expect(model).toBeDefined();
+		expect(model!.id).toBe("claude-sonnet-4-5");
+	});
+
+	it("returns undefined for unknown provider", () => {
+		expect(findModel("nonexistent", "sonnet")).toBeUndefined();
+	});
+
+	it("returns undefined for no matching pattern", () => {
+		expect(findModel("anthropic", "zzz-no-match")).toBeUndefined();
+	});
+
+	it("finds model by substring (case-insensitive)", () => {
+		const model = findModel("anthropic", "haiku");
+		expect(model).toBeDefined();
+		expect(model!.id).toContain("haiku");
+	});
+
+	it("finds model by substring — sonnet", () => {
+		const model = findModel("anthropic", "sonnet");
+		expect(model).toBeDefined();
+		expect(model!.id).toContain("sonnet");
+	});
+
+	it("finds model by substring — opus", () => {
+		const model = findModel("anthropic", "opus");
+		expect(model).toBeDefined();
+		expect(model!.id).toContain("opus");
+	});
+
+	it("prefers alias over dated version", () => {
+		const model = findModel("anthropic", "sonnet");
+		expect(model).toBeDefined();
+		// Should not return a dated version like claude-sonnet-4-5-20250514
+		expect(model!.id).not.toMatch(/\d{8}/);
+	});
+
+	it("matches are consistent with getModel for exact IDs", () => {
+		const exact = getModel("anthropic", "claude-sonnet-4-5");
+		const fuzzy = findModel("anthropic", "claude-sonnet-4-5");
+		expect(fuzzy).toBe(exact);
+	});
+
+	it("works across providers", () => {
+		const openaiModel = findModel("openai", "gpt-5");
+		expect(openaiModel).toBeDefined();
+
+		const googleModel = findModel("google", "gemini");
+		expect(googleModel).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { type AssistantMessage, getModel } from "@dreb/ai";
+import { type AssistantMessage, findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -63,7 +63,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		mkdirSync(tempDir, { recursive: true });
 		vi.useFakeTimers();
 
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			initialState: {
 				model,
@@ -237,7 +237,9 @@ describe("AgentSession auto-compaction queue resume", () => {
 	it("should trigger threshold compaction for error messages using last successful usage", async () => {
 		const model = session.model!;
 
-		// A successful assistant message with high token usage (near context limit)
+		// A successful assistant message with high token usage (exceeds compaction threshold).
+		// Default reserveTokens is 16384, so we need totalTokens > contextWindow - 16384.
+		const nearLimitTokens = model.contextWindow - 10_000;
 		const successfulAssistant: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "large successful response" }],
@@ -245,11 +247,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 			provider: model.provider,
 			model: model.id,
 			usage: {
-				input: 180_000,
-				output: 10_000,
+				input: nearLimitTokens,
+				output: 0,
 				cacheRead: 0,
 				cacheWrite: 0,
-				totalTokens: 190_000,
+				totalTokens: nearLimitTokens,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "stop",

--- a/packages/coding-agent/test/agent-session-branching.test.ts
+++ b/packages/coding-agent/test/agent-session-branching.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -42,7 +42,7 @@ describe.skipIf(!API_KEY)("AgentSession forking", () => {
 	});
 
 	function createSession(noSession: boolean = false) {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => API_KEY,
 			initialState: {

--- a/packages/coding-agent/test/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession, type AgentSessionEvent } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -46,7 +46,7 @@ describe.skipIf(!API_KEY)("AgentSession compaction e2e", () => {
 	});
 
 	function createSession(inMemory = false) {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => API_KEY,
 			initialState: {

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@dreb/ai";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, findModel } from "@dreb/ai";
 import { Type } from "@sinclair/typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
@@ -69,7 +69,7 @@ describe("AgentSession concurrent prompt guard", () => {
 	});
 
 	function createSession() {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		let abortSignal: AbortSignal | undefined;
 
 		// Use a stream function that responds to abort
@@ -173,7 +173,7 @@ describe("AgentSession concurrent prompt guard", () => {
 
 	it("should allow prompt() after previous completes", async () => {
 		// Create session with a stream that completes immediately
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: {
@@ -217,7 +217,7 @@ describe("AgentSession concurrent prompt guard", () => {
 	});
 
 	it("should wait for queued agent events before emitting tool_call", async () => {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const tool = {
 			name: "dummy",
 			description: "Dummy tool",
@@ -353,7 +353,7 @@ describe("AgentSession concurrent prompt guard", () => {
 	});
 
 	it("should persist message_end events in order with slow extension handlers", async () => {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const tool = {
 			name: "dummy",
 			description: "Dummy tool",

--- a/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { DefaultResourceLoader } from "../src/core/resource-loader.js";
@@ -42,7 +42,7 @@ describe("AgentSession dynamic provider registration", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir,
-			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			model: findModel("anthropic", "sonnet")!,
 			settingsManager,
 			sessionManager,
 			authStorage,

--- a/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { Type } from "@sinclair/typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DefaultResourceLoader } from "../src/core/resource-loader.js";
@@ -57,7 +57,7 @@ describe("AgentSession dynamic tool registration", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir,
-			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			model: findModel("anthropic", "sonnet")!,
 			settingsManager,
 			sessionManager,
 			resourceLoader,
@@ -104,7 +104,7 @@ describe("AgentSession dynamic tool registration", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir,
-			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			model: findModel("anthropic", "sonnet")!,
 			settingsManager,
 			sessionManager,
 			resourceLoader,
@@ -164,7 +164,7 @@ describe("AgentSession dynamic tool registration", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir,
-			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			model: findModel("anthropic", "sonnet")!,
 			settingsManager,
 			sessionManager,
 			resourceLoader,

--- a/packages/coding-agent/test/agent-session-model-switch-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-model-switch-thinking.test.ts
@@ -1,5 +1,5 @@
 import { Agent, type ThinkingLevel } from "@dreb/agent-core";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -8,8 +8,9 @@ import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import { createTestResourceLoader } from "./utilities.js";
 
-const reasoningModel = getModel("anthropic", "claude-sonnet-4-5")!;
-const nonReasoningModel = getModel("anthropic", "claude-3-5-haiku-latest")!;
+const reasoningModel = findModel("anthropic", "sonnet")!;
+// This test specifically needs a non-reasoning model — claude-3-5-haiku has reasoning: false
+const nonReasoningModel = findModel("anthropic", "3-5-haiku")!;
 
 function createSession({
 	thinkingLevel = "high",

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent, type AgentEvent, type AgentTool } from "@dreb/agent-core";
-import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@dreb/ai";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, findModel } from "@dreb/ai";
 import { Type } from "@sinclair/typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
@@ -74,7 +74,7 @@ describe("AgentSession retry", () => {
 		const delayAssistantMessageEndMs = options?.delayAssistantMessageEndMs ?? 0;
 		let callCount = 0;
 
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: { model, systemPrompt: "Test", tools: [] },
@@ -195,7 +195,7 @@ describe("AgentSession retry", () => {
 		};
 		created.session.dispose();
 
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: { model, systemPrompt: "Test", tools: [] },
@@ -247,7 +247,7 @@ describe("AgentSession retry", () => {
 			},
 		};
 
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: { model, systemPrompt: "Test", tools: [] },

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -1,5 +1,5 @@
 import { Agent } from "@dreb/agent-core";
-import { type AssistantMessage, getModel, type Usage } from "@dreb/ai";
+import { type AssistantMessage, findModel, type Usage } from "@dreb/ai";
 import { describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -8,7 +8,7 @@ import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import { createTestResourceLoader } from "./utilities.js";
 
-const model = getModel("anthropic", "claude-sonnet-4-5")!;
+const model = findModel("anthropic", "sonnet")!;
 
 function createUsage(totalTokens: number): Usage {
 	return {

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -86,7 +86,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 	}
 
 	function createSession(extensions: Extension[]) {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		const agent = new Agent({
 			getApiKey: () => API_KEY,
 			initialState: {

--- a/packages/coding-agent/test/compaction-thinking-model.test.ts
+++ b/packages/coding-agent/test/compaction-thinking-model.test.ts
@@ -12,7 +12,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent, type ThinkingLevel } from "@dreb/agent-core";
-import { getModel, type Model } from "@dreb/ai";
+import { findModel, getModel, type Model } from "@dreb/ai";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
@@ -194,7 +194,7 @@ describe.skipIf(!HAS_ANTHROPIC_AUTH)("Compaction with thinking models (Anthropic
 	}
 
 	it("should compact successfully with claude-sonnet-4-5 and thinking level high", async () => {
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 		createSession(model, "high");
 
 		// Send a simple prompt

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@dreb/agent-core";
 import type { AssistantMessage, Usage } from "@dreb/ai";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -397,7 +397,7 @@ describe("Large session fixture", () => {
 describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("LLM summarization", () => {
 	it("should generate a compaction result for the large session", async () => {
 		const entries = loadLargeSessionEntries();
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 
 		const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS);
 		expect(preparation).toBeDefined();
@@ -418,7 +418,7 @@ describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("LLM summarization", () => {
 	it("should produce valid session after compaction", async () => {
 		const entries = loadLargeSessionEntries();
 		const loaded = buildSessionContext(entries);
-		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const model = findModel("anthropic", "sonnet")!;
 
 		const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS);
 		expect(preparation).toBeDefined();

--- a/packages/coding-agent/test/sdk-session-manager.test.ts
+++ b/packages/coding-agent/test/sdk-session-manager.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModel } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAgentSession } from "../src/core/sdk.js";
 import { SessionManager } from "../src/core/session-manager.js";
@@ -26,7 +26,7 @@ describe("createAgentSession session manager defaults", () => {
 	});
 
 	it("uses agentDir for the default persisted session path", async () => {
-		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const model = findModel("anthropic", "sonnet");
 		expect(model).toBeTruthy();
 
 		const { session } = await createAgentSession({
@@ -47,7 +47,7 @@ describe("createAgentSession session manager defaults", () => {
 	});
 
 	it("keeps an explicit sessionManager override", async () => {
-		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const model = findModel("anthropic", "sonnet");
 		expect(model).toBeTruthy();
 
 		const sessionManager = SessionManager.inMemory(cwd);

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -6,7 +6,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync }
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Agent } from "@dreb/agent-core";
-import { getModel, type OAuthCredentials, type OAuthProvider } from "@dreb/ai";
+import { findModel, type OAuthCredentials, type OAuthProvider } from "@dreb/ai";
 import { getOAuthApiKey } from "@dreb/ai/oauth";
 import { AgentSession } from "../src/core/agent-session.js";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -242,7 +242,7 @@ export function createTestSession(options: TestSessionOptions = {}): TestSession
 	const tempDir = join(tmpdir(), `dreb-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(tempDir, { recursive: true });
 
-	const model = getModel("anthropic", "claude-sonnet-4-5")!;
+	const model = findModel("anthropic", "sonnet")!;
 	const agent = new Agent({
 		getApiKey: () => API_KEY,
 		initialState: {


### PR DESCRIPTION
Closes #31

Adds `findModel(provider, pattern)` to `@dreb/ai` for substring model matching. Prefers alias models over dated versions, latest version among ties.

Updated 15 test files to use fuzzy patterns (`findModel('anthropic', 'sonnet')`) instead of exact model IDs. Also made auto-compaction threshold test use model-relative token counts.

**New tests:** `packages/ai/test/find-model.test.ts` (9 tests)