### PR TITLE
docs: add task-type heuristics for subagent model routing

### DIFF
--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -882,6 +882,11 @@ export function createSubagentToolDefinition(
 			"Subagents have their own context window — provide enough context in the task prompt",
 			"Each background agent notifies independently when done — completion messages include a list of any still-running agents. If you need their results before proceeding, stop generating — do not output anything, do not launch filler work. Your turn ends, and when a background agent completes, its result arrives as a new message that resumes your turn automatically.",
 			"Agent definitions may specify a `model` field using Anthropic-family names as strength-tier hints: 'opus' = strongest, 'sonnet' = mid-tier, 'haiku' = fast/cheap. These resolve via substring matching against the current provider's model list. If your provider doesn't carry matching models (e.g., on z.ai, OpenAI, etc.), you MUST pass a `model` override with your provider's equivalent: strongest tier (e.g., glm-5-1), mid tier (e.g., glm-5-turbo), or fast tier. Per-invocation `model` overrides always take precedence over agent definition models. For parallel/chain, set per-task.",
+			"**Model routing by task type** — default to cheap/fast models and only escalate when needed. Haiku-tier (~10-20x cheaper than opus-tier) handles most subagent work well:" +
+				"\n  - **Haiku-tier** (fast/cheap): file discovery, grep, listing, navigation, code reading, summarization, exploration, mechanical transforms" +
+				"\n  - **Sonnet-tier** (mid): code generation, implementation, refactoring, test writing, documentation" +
+				"\n  - **Opus-tier** (strong): code review, architecture decisions, complex multi-step reasoning, evaluation, novel design" +
+				"\n  Most subagent tasks are exploration or mechanical work — use haiku-tier by default. Only escalate to sonnet/opus when the task requires judgment or creativity.",
 		],
 		parameters: subagentSchema,
 


### PR DESCRIPTION
Closes #48

Adds concrete model routing guidance to the subagent tool's prompt guidelines with a task taxonomy:

- **Haiku-tier** (fast/cheap): file discovery, grep, exploration, mechanical transforms  
- **Sonnet-tier** (mid): code generation, implementation, test writing, docs
- **Opus-tier** (strong): code review, architecture, evaluation, novel design

Emphasizes defaulting to cheap models (~10-20x cheaper) and only escalating when the task requires judgment or creativity.

This is a prompt-only change \u2014 no behavior changes, no dynamic model injection. The existing provider-aware tier language and fuzzy matching already handle cross-provider resolution.