### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"node": ">=20.0.0"
 	},
 
-	"version": "1.7.4",
+	"version": "1.8.0",
 
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-
-	"version": "1.7.4",
-
+	"version": "1.8.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@dreb/ai",
-
-	"version": "1.7.4",
-
+	"version": "1.8.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-
-	"version": "1.7.4",
-
+	"version": "1.8.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,8 +1,6 @@
 {
 	"name": "@dreb/tui",
-
-	"version": "1.7.4",
-
+	"version": "1.8.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Version bump for v1.8.0 release (subagent guardrails feature).