### PR TITLE
Buddy speech bubble: side-by-side layout, dynamic width, line cap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8595,7 +8595,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8624,7 +8624,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8680,7 +8680,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8794,7 +8794,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8842,7 +8842,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8874,7 +8874,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8598,39 +8598,12 @@
 			"version": "2.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dreb/ai": "^1.0.0"
+				"@dreb/ai": "^2.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^24.3.0",
 				"typescript": "^5.7.3",
 				"vitest": "^3.2.4"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"packages/agent/node_modules/@dreb/ai": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/ai/-/ai-1.18.0.tgz",
-			"integrity": "sha512-8lTh5guKWg58ESeJZiMAjJuJqJyd/EnyK/OWH0AhdnIT0EWmOKnstcGAu/6HwRMZz0kUn8Jv9BD0O5TJ2y+9cg==",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.73.0",
-				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "1.14.1",
-				"@sinclair/typebox": "^0.34.41",
-				"ajv": "^8.17.1",
-				"ajv-formats": "^3.0.1",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"dreb-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -8642,18 +8615,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
-			}
-		},
-		"packages/agent/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"packages/agent/node_modules/undici-types": {
@@ -8722,10 +8683,10 @@
 			"version": "2.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dreb/agent-core": "^1.0.0",
-				"@dreb/ai": "^1.0.0",
-				"@dreb/semantic-search": "^1.0.0",
-				"@dreb/tui": "^1.0.0",
+				"@dreb/agent-core": "^2.0.0",
+				"@dreb/ai": "^2.0.0",
+				"@dreb/semantic-search": "^2.0.0",
+				"@dreb/tui": "^2.0.0",
 				"@huggingface/transformers": "^4.0.1",
 				"@mariozechner/jiti": "^2.6.2",
 				"@silvia-odwyer/photon-node": "^0.3.4",
@@ -8806,110 +8767,6 @@
 				"anthropic-ai-sdk": "bin/cli"
 			}
 		},
-		"packages/coding-agent/node_modules/@dreb/agent-core": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/agent-core/-/agent-core-1.18.0.tgz",
-			"integrity": "sha512-5IZN3mjUUq3EgxnRbGbw/383qla9X02FSGV3f8ISJRQQZy35CmZsOTpZXJXzNoF71+/X3mJtDyrYNf3RKsJrQg==",
-			"license": "MIT",
-			"dependencies": {
-				"@dreb/ai": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"packages/coding-agent/node_modules/@dreb/ai": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/ai/-/ai-1.18.0.tgz",
-			"integrity": "sha512-8lTh5guKWg58ESeJZiMAjJuJqJyd/EnyK/OWH0AhdnIT0EWmOKnstcGAu/6HwRMZz0kUn8Jv9BD0O5TJ2y+9cg==",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.73.0",
-				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "1.14.1",
-				"@sinclair/typebox": "^0.34.41",
-				"ajv": "^8.17.1",
-				"ajv-formats": "^3.0.1",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"dreb-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"packages/coding-agent/node_modules/@dreb/ai/node_modules/@anthropic-ai/sdk": {
-			"version": "0.73.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
-			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
-			"license": "MIT",
-			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
-			},
-			"bin": {
-				"anthropic-ai-sdk": "bin/cli"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
-		},
-		"packages/coding-agent/node_modules/@dreb/semantic-search": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/semantic-search/-/semantic-search-1.18.0.tgz",
-			"integrity": "sha512-at3rhbjHiwvEaxnfN4DUeMp7vPUbC9HNfXl2LwTfpNSKKU30arLxSAtQHCQha7JzjgGqK9UjIeFj9h7F/TdbiA==",
-			"license": "MIT",
-			"dependencies": {
-				"@huggingface/transformers": "^4.0.1",
-				"@modelcontextprotocol/sdk": "^1.29.0",
-				"ignore": "^7.0.5",
-				"tree-sitter-c": "^0.24.1",
-				"tree-sitter-cpp": "^0.23.4",
-				"tree-sitter-go": "^0.25.0",
-				"tree-sitter-java": "^0.23.5",
-				"tree-sitter-javascript": "^0.25.0",
-				"tree-sitter-python": "^0.25.0",
-				"tree-sitter-rust": "^0.24.0",
-				"tree-sitter-typescript": "^0.23.2",
-				"web-tree-sitter": "^0.26.8"
-			},
-			"bin": {
-				"semantic-search-mcp": "bin/server.js"
-			},
-			"engines": {
-				"node": ">=22.0.0"
-			}
-		},
-		"packages/coding-agent/node_modules/@dreb/tui": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/tui/-/tui-1.18.0.tgz",
-			"integrity": "sha512-hWFh9C+s8bLocrZRV9aVsdghqdvC3OCVksOIR0M22dd1XBxM9wGML8i8Navl96IkG0+Tm5jxEdDTGVeYu7MeMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mime-types": "^2.1.4",
-				"chalk": "^5.5.0",
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12",
-				"mime-types": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
-			}
-		},
 		"packages/coding-agent/node_modules/@types/node": {
 			"version": "24.12.0",
 			"dev": true,
@@ -8987,7 +8844,7 @@
 			"name": "@dreb/telegram",
 			"version": "2.1.0",
 			"dependencies": {
-				"@dreb/coding-agent": "^1.0.0",
+				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
 			},
 			"bin": {
@@ -9002,129 +8859,12 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"packages/telegram/node_modules/@dreb/agent-core": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/agent-core/-/agent-core-1.18.0.tgz",
-			"integrity": "sha512-5IZN3mjUUq3EgxnRbGbw/383qla9X02FSGV3f8ISJRQQZy35CmZsOTpZXJXzNoF71+/X3mJtDyrYNf3RKsJrQg==",
-			"license": "MIT",
-			"dependencies": {
-				"@dreb/ai": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"packages/telegram/node_modules/@dreb/ai": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/ai/-/ai-1.18.0.tgz",
-			"integrity": "sha512-8lTh5guKWg58ESeJZiMAjJuJqJyd/EnyK/OWH0AhdnIT0EWmOKnstcGAu/6HwRMZz0kUn8Jv9BD0O5TJ2y+9cg==",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.73.0",
-				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "1.14.1",
-				"@sinclair/typebox": "^0.34.41",
-				"ajv": "^8.17.1",
-				"ajv-formats": "^3.0.1",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"dreb-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"packages/telegram/node_modules/@dreb/coding-agent": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/coding-agent/-/coding-agent-1.18.0.tgz",
-			"integrity": "sha512-kvz61nHuJdy2l3DC2A0dhpgeqVnYZAp9vhUvuX8/SzLgkcIawABMhD6OTkWSWwHi4qsMDDxRsLt5TWSAdVoDhg==",
-			"license": "MIT",
-			"dependencies": {
-				"@dreb/agent-core": "^1.0.0",
-				"@dreb/ai": "^1.0.0",
-				"@dreb/tui": "^1.0.0",
-				"@huggingface/transformers": "^4.0.1",
-				"@mariozechner/jiti": "^2.6.2",
-				"@silvia-odwyer/photon-node": "^0.3.4",
-				"ajv": "^8.17.1",
-				"chalk": "^5.5.0",
-				"cli-highlight": "^2.1.11",
-				"diff": "^8.0.2",
-				"extract-zip": "^2.0.1",
-				"file-type": "^21.1.1",
-				"glob": "^13.0.1",
-				"hosted-git-info": "^9.0.2",
-				"ignore": "^7.0.5",
-				"marked": "^15.0.12",
-				"minimatch": "^10.2.3",
-				"proper-lockfile": "^4.1.2",
-				"strip-ansi": "^7.1.0",
-				"tree-sitter-c": "^0.24.1",
-				"tree-sitter-cpp": "^0.23.4",
-				"tree-sitter-go": "^0.25.0",
-				"tree-sitter-java": "^0.23.5",
-				"tree-sitter-javascript": "^0.25.0",
-				"tree-sitter-python": "^0.25.0",
-				"tree-sitter-rust": "^0.24.0",
-				"tree-sitter-typescript": "^0.23.2",
-				"undici": "^7.19.1",
-				"web-tree-sitter": "^0.26.8",
-				"yaml": "^2.8.2"
-			},
-			"bin": {
-				"dreb": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.6.0"
-			},
-			"optionalDependencies": {
-				"@mariozechner/clipboard": "^0.3.2"
-			}
-		},
-		"packages/telegram/node_modules/@dreb/tui": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/@dreb/tui/-/tui-1.18.0.tgz",
-			"integrity": "sha512-hWFh9C+s8bLocrZRV9aVsdghqdvC3OCVksOIR0M22dd1XBxM9wGML8i8Navl96IkG0+Tm5jxEdDTGVeYu7MeMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mime-types": "^2.1.4",
-				"chalk": "^5.5.0",
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12",
-				"mime-types": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
-			}
-		},
 		"packages/telegram/node_modules/@types/node": {
 			"version": "24.12.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
-			}
-		},
-		"packages/telegram/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"packages/telegram/node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,7 +20,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/ai": "^1.0.0"
+		"@dreb/ai": "^2.0.0"
 	},
 	"keywords": [
 		"ai",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -52,10 +52,10 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/agent-core": "^1.0.0",
-		"@dreb/ai": "^1.0.0",
-		"@dreb/semantic-search": "^1.0.0",
-		"@dreb/tui": "^1.0.0",
+		"@dreb/agent-core": "^2.0.0",
+		"@dreb/ai": "^2.0.0",
+		"@dreb/semantic-search": "^2.0.0",
+		"@dreb/tui": "^2.0.0",
 		"@huggingface/transformers": "^4.0.1",
 		"@mariozechner/jiti": "^2.6.2",
 		"@silvia-odwyer/photon-node": "^0.3.4",

--- a/packages/coding-agent/src/core/buddy/buddy-manager.ts
+++ b/packages/coding-agent/src/core/buddy/buddy-manager.ts
@@ -38,7 +38,7 @@ const OLLAMA_MODEL_BASE: Omit<Model<"openai-completions">, "id" | "name"> = {
 };
 
 /** Max words for buddy response before truncation */
-const MAX_RESPONSE_WORDS = 300;
+const MAX_RESPONSE_WORDS = 60;
 
 /** Prompt for soul generation (uses parent LLM, not Ollama) */
 const SOUL_GENERATION_PROMPT = `You are generating a companion character for a coding assistant terminal app. Based on the species, rarity, and stats below, generate a creative name, a one-sentence personality description, and a funny fictional backstory.

--- a/packages/coding-agent/src/modes/interactive/components/buddy-component.ts
+++ b/packages/coding-agent/src/modes/interactive/components/buddy-component.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Component, MarkdownTheme as MT, TUI } from "@dreb/tui";
-import { joinColumns, truncateToWidth, visibleWidth } from "@dreb/tui";
+import { joinColumns, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@dreb/tui";
 import { marked } from "marked";
 import { applyEyes, getSpeciesFrames, getSpeciesWidth } from "../../../core/buddy/buddy-species.js";
 import type { BuddyState } from "../../../core/buddy/buddy-types.js";
@@ -198,7 +198,7 @@ export class BuddyComponent implements Component {
 		// Build RIGHT block: speech bubble or thinking indicator
 		let rightLines: string[] = [];
 		if (this.speechText) {
-			const availableWidth = width - spriteWidth - SIDE_PANEL_GAP - 4; // 4 for bubble borders+padding
+			const availableWidth = width - spriteWidth - SIDE_PANEL_GAP - 5; // 5 for leading space + bubble borders + padding
 			const bubbleMaxWidth = Math.max(20, availableWidth);
 			rightLines = this.formatSpeechBubble(this.speechText, bubbleMaxWidth);
 		} else if (this.thinkingLabel !== null) {
@@ -335,21 +335,8 @@ export class BuddyComponent implements Component {
 		// Render inline markdown (bold, italic, code) to styled text with ANSI codes
 		const styledText = this.renderInlineMarkdown(text);
 
-		// Word-wrap using visible width (ANSI-aware)
-		const lines: string[] = [];
-		const words = styledText.split(" ");
-		let currentLine = "";
-
-		for (const word of words) {
-			const test = currentLine ? `${currentLine} ${word}` : word;
-			if (visibleWidth(test) > maxWidth) {
-				if (currentLine) lines.push(currentLine);
-				currentLine = word;
-			} else {
-				currentLine = test;
-			}
-		}
-		if (currentLine) lines.push(currentLine);
+		// Word-wrap using visible width (ANSI-aware, handles long words)
+		const lines = wrapTextWithAnsi(styledText, maxWidth);
 
 		// Enforce hard line cap
 		if (lines.length > SPEECH_MAX_CONTENT_LINES) {

--- a/packages/coding-agent/src/modes/interactive/components/buddy-component.ts
+++ b/packages/coding-agent/src/modes/interactive/components/buddy-component.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Component, MarkdownTheme as MT, TUI } from "@dreb/tui";
-import { truncateToWidth, visibleWidth } from "@dreb/tui";
+import { joinColumns, truncateToWidth, visibleWidth } from "@dreb/tui";
 import { marked } from "marked";
 import { applyEyes, getSpeciesFrames, getSpeciesWidth } from "../../../core/buddy/buddy-species.js";
 import type { BuddyState } from "../../../core/buddy/buddy-types.js";
@@ -22,6 +22,8 @@ const SPEECH_BUBBLE_DURATION_MS = 10000;
 const PET_DURATION_MS = 2500;
 const HEART_CHARS = ["❤️", "💕", "💖", "💗", "✨"];
 const NARROW_THRESHOLD = 100;
+const SPEECH_MAX_CONTENT_LINES = 3;
+const SIDE_PANEL_GAP = 2;
 
 export class BuddyComponent implements Component {
 	private ui: TUI;
@@ -165,18 +167,18 @@ export class BuddyComponent implements Component {
 		const frames = getSpeciesFrames(this.state.species);
 		const frame = frames[this.currentFrame % this.totalFrames];
 		const rendered = applyEyes(frame, this.state.eyeStyle);
+		const spriteWidth = getSpeciesWidth(this.state.species);
 
-		// Hat line (if present)
+		// Build LEFT block: hat + heart animation + sprite lines
+		const leftLines: string[] = [];
+
+		// Hat line
 		if (this.state.hat) {
-			const hatPad = Math.max(0, Math.floor((getSpeciesWidth(this.state.species) - 1) / 2) - 1);
-			lines.push(" ".repeat(hatPad) + this.state.hat);
+			const hatPad = Math.max(0, Math.floor((spriteWidth - 1) / 2) - 1);
+			leftLines.push(" ".repeat(hatPad) + this.state.hat);
 		}
 
-		// Sprite lines
-		const spriteWidth = getSpeciesWidth(this.state.species);
-		lines.push(...rendered);
-
-		// Heart animation line above sprite
+		// Heart animation line (above sprite, inserted at top)
 		if (this.isPetting && this.hearts.length > 0) {
 			const heartLine = " ".repeat(spriteWidth);
 			const chars = heartLine.split("");
@@ -187,36 +189,45 @@ export class BuddyComponent implements Component {
 					chars.splice(x, hChar.length, ...hChar.split(""));
 				}
 			}
-			// Insert heart line before sprite
-			lines.splice(this.state.hat ? 1 : 0, 0, chars.join(""));
+			leftLines.push(chars.join(""));
 		}
 
-		// Name + rarity line
+		// Sprite lines
+		leftLines.push(...rendered);
+
+		// Build RIGHT block: speech bubble or thinking indicator
+		let rightLines: string[] = [];
+		if (this.speechText) {
+			const availableWidth = width - spriteWidth - SIDE_PANEL_GAP - 4; // 4 for bubble borders+padding
+			const bubbleMaxWidth = Math.max(20, availableWidth);
+			rightLines = this.formatSpeechBubble(this.speechText, bubbleMaxWidth);
+		} else if (this.thinkingLabel !== null) {
+			const dots = ".".repeat((this.thinkingDots % BuddyComponent.THINKING_DOT_COUNT) + 1);
+			const label = this.thinkingLabel || "thinking";
+			rightLines = [` ${theme.fg("muted", `💭 ${label}${dots}`)}`];
+		}
+
+		// Merge left and right side-by-side
+		if (rightLines.length > 0) {
+			const merged = joinColumns(leftLines, rightLines, SIDE_PANEL_GAP, width);
+			lines.push(...merged);
+		} else {
+			lines.push(...leftLines);
+		}
+
+		// Name + rarity line (full width, below the sprite+panel area)
 		const shinyMark = this.state.shiny ? " ✨" : "";
 		const rarityColor = this.rarityColor(this.state.rarity);
 		const nameLine = ` ${theme.bold(this.state.name)}${shinyMark} ${theme.fg(rarityColor, `[${this.state.rarity}]`)} ${theme.fg("muted", this.state.species)}`;
 		lines.push(nameLine);
 
-		// Stats line
+		// Stats line (full width)
 		const statParts = (Object.values(Stat) as Stat[]).map((s) => {
 			const val = this.state.stats[s];
 			const bar = this.statBar(val);
 			return `${theme.fg("muted", s[0])}:${bar}`;
 		});
 		lines.push(` ${statParts.join(" ")}`);
-
-		// Thinking indicator
-		if (this.thinkingLabel !== null) {
-			const dots = ".".repeat((this.thinkingDots % BuddyComponent.THINKING_DOT_COUNT) + 1);
-			const label = this.thinkingLabel || "thinking";
-			lines.push(` ${theme.fg("muted", `💭 ${label}${dots}`)}`);
-		}
-
-		// Speech bubble (beside or below sprite)
-		if (this.speechText) {
-			const bubbleLines = this.formatSpeechBubble(this.speechText, Math.min(width - 4, 60));
-			lines.push(...bubbleLines);
-		}
 
 		return lines;
 	}
@@ -339,6 +350,17 @@ export class BuddyComponent implements Component {
 			}
 		}
 		if (currentLine) lines.push(currentLine);
+
+		// Enforce hard line cap
+		if (lines.length > SPEECH_MAX_CONTENT_LINES) {
+			const kept = lines.slice(0, SPEECH_MAX_CONTENT_LINES - 1);
+			const lastLine = lines[SPEECH_MAX_CONTENT_LINES - 1];
+			// Truncate the last kept line with ellipsis
+			const truncated = truncateToWidth(lastLine, maxWidth - 1, "…");
+			kept.push(truncated);
+			lines.length = 0;
+			lines.push(...kept);
+		}
 
 		// Wrap in bubble border using visible width for measurement
 		const maxLineWidth = Math.max(...lines.map((l) => visibleWidth(l)));

--- a/packages/coding-agent/test/buddy-component.test.ts
+++ b/packages/coding-agent/test/buddy-component.test.ts
@@ -2,6 +2,7 @@
  * Unit tests for BuddyComponent — rendering, speech bubbles, petting, state updates.
  */
 
+import { visibleWidth } from "@dreb/tui";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BuddyState } from "../src/core/buddy/buddy-types.js";
 import { Rarity, Stat } from "../src/core/buddy/buddy-types.js";
@@ -138,10 +139,59 @@ describe("BuddyComponent", () => {
 			const lines = comp.render(120);
 			comp.dispose();
 
-			// Full render has sprite + name + stats + bubble lines; bubble should have multiple content lines
 			// Find the bubble lines (those with │ borders)
 			const bubbleContentLines = lines.filter((l) => l.includes("│") && !l.includes("╭") && !l.includes("╰"));
 			expect(bubbleContentLines.length).toBeGreaterThan(1);
+		});
+
+		it("renders speech bubble beside sprite on same rows", () => {
+			const state = createTestState();
+			const comp = new BuddyComponent(mockUI, state);
+			comp.showSpeech("Hello beside!");
+			const lines = comp.render(120);
+			comp.dispose();
+
+			// At least one line should have both sprite content (●● from Duck eyeStyle) and bubble border (│)
+			const sideBySideLines = lines.filter(
+				(l) => l.includes("│") && (l.includes("●●") || l.includes("╭") || l.includes("╰")),
+			);
+			expect(sideBySideLines.length).toBeGreaterThan(0);
+		});
+
+		it("caps speech bubble to max 3 content lines", () => {
+			const state = createTestState();
+			const comp = new BuddyComponent(mockUI, state);
+			// Generate text that would produce many wrapped lines
+			const words = Array.from({ length: 30 }, (_, i) => `word${i}`);
+			const longText = words.join(" ");
+			comp.showSpeech(longText);
+			const lines = comp.render(120);
+			comp.dispose();
+
+			// Count bubble content lines (│ but not ╭ or ╰)
+			const contentLines = lines.filter((l) => l.includes("│") && !l.includes("╭") && !l.includes("╰"));
+			// Should have at most 3 content lines (the cap)
+			expect(contentLines.length).toBeLessThanOrEqual(3);
+			// Total bubble lines: top border + content + bottom border = at most 5
+			const bubbleLines = lines.filter((l) => l.includes("╭") || l.includes("╰") || l.includes("│"));
+			expect(bubbleLines.length).toBeLessThanOrEqual(5);
+		});
+
+		it("scales bubble width to fill available terminal space", () => {
+			const state = createTestState();
+			const comp = new BuddyComponent(mockUI, state);
+			const longText =
+				"This is a reasonably long speech text that should cause the bubble to expand wider than the old sixty character maximum.";
+			comp.showSpeech(longText);
+			const lines = comp.render(120);
+			comp.dispose();
+
+			// Find lines with bubble borders and check they are wider than 60 chars
+			const borderLines = lines.filter((l) => l.includes("╭") || l.includes("╰"));
+			for (const line of borderLines) {
+				// Visible width should be > 60 (the old hard-coded max)
+				expect(visibleWidth(line)).toBeGreaterThan(60);
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/buddy-manager.test.ts
+++ b/packages/coding-agent/test/buddy-manager.test.ts
@@ -753,38 +753,38 @@ describe("BuddyManager.respondToNameCall()", () => {
 
 describe("truncateResponse", () => {
 	it("passes through short responses unchanged", () => {
-		expect(truncateResponse("Hello world!", 300)).toBe("Hello world!");
+		expect(truncateResponse("Hello world!", 60)).toBe("Hello world!");
 	});
 
 	it("passes through responses at exactly the limit", () => {
-		const words = Array.from({ length: 300 }, (_, i) => `word${i}`);
+		const words = Array.from({ length: 60 }, (_, i) => `word${i}`);
 		const text = words.join(" ");
-		expect(truncateResponse(text, 300)).toBe(text);
+		expect(truncateResponse(text, 60)).toBe(text);
 	});
 
 	it("truncates responses over the word limit", () => {
-		const words = Array.from({ length: 400 }, (_, i) => `word${i}`);
+		const words = Array.from({ length: 100 }, (_, i) => `word${i}`);
 		const text = words.join(" ");
-		const result = truncateResponse(text, 300);
+		const result = truncateResponse(text, 60);
 		expect(result).toContain("...[truncated]");
-		expect(result.split(/\s+/).length).toBeLessThanOrEqual(302); // 300 words + "...[truncated]"
+		expect(result.split(/\s+/).length).toBeLessThanOrEqual(62); // 60 words + "...[truncated]"
 	});
 
 	it("preserves content before truncation point", () => {
-		const words = Array.from({ length: 400 }, (_, i) => `word${i}`);
+		const words = Array.from({ length: 100 }, (_, i) => `word${i}`);
 		const text = words.join(" ");
-		const result = truncateResponse(text, 300);
+		const result = truncateResponse(text, 60);
 		expect(result.startsWith("word0 word1 word2")).toBe(true);
-		expect(result).toContain("word299");
-		expect(result).not.toContain("word300");
+		expect(result).toContain("word59");
+		expect(result).not.toContain("word60");
 	});
 
 	it("handles empty string", () => {
-		expect(truncateResponse("", 300)).toBe("");
+		expect(truncateResponse("", 60)).toBe("");
 	});
 
 	it("handles single word", () => {
-		expect(truncateResponse("hello", 300)).toBe("hello");
+		expect(truncateResponse("hello", 60)).toBe("hello");
 	});
 });
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -30,7 +30,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/coding-agent": "^1.0.0",
+		"@dreb/coding-agent": "^2.0.0",
 		"grammy": "^1.35.0"
 	},
 	"devDependencies": {

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -101,4 +101,4 @@ export {
 	TUI,
 } from "./tui.js";
 // Utilities
-export { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";
+export { joinColumns, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.js";

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -763,6 +763,48 @@ function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): s
 }
 
 /**
+ * Merge two blocks of lines side-by-side into a single block.
+ * ANSI-safe: uses visibleWidth() for measurement and pads/truncates accordingly.
+ *
+ * @param left - Left block lines (may contain ANSI codes)
+ * @param right - Right block lines (may contain ANSI codes)
+ * @param gap - Number of spaces between left and right columns
+ * @param totalWidth - Maximum total width per line
+ * @returns Merged lines array
+ */
+export function joinColumns(left: string[], right: string[], gap: number, totalWidth: number): string[] {
+	const maxRows = Math.max(left.length, right.length);
+	if (maxRows === 0) return [];
+
+	// Find the max visible width across all left lines
+	let leftColWidth = 0;
+	for (const line of left) {
+		const w = visibleWidth(line);
+		if (w > leftColWidth) leftColWidth = w;
+	}
+
+	const rightColWidth = Math.max(0, totalWidth - leftColWidth - gap);
+	const gapStr = " ".repeat(gap);
+	const result: string[] = [];
+
+	for (let row = 0; row < maxRows; row++) {
+		const leftLine = row < left.length ? left[row]! : "";
+		const rightLine = row < right.length ? right[row]! : "";
+
+		// Pad left line to leftColWidth (ANSI-safe)
+		const leftVisible = visibleWidth(leftLine);
+		const leftPadded = leftLine + " ".repeat(Math.max(0, leftColWidth - leftVisible));
+
+		// Truncate right line if it exceeds rightColWidth
+		const rightTruncated = rightColWidth > 0 ? truncateToWidth(rightLine, rightColWidth) : "";
+
+		result.push(leftPadded + gapStr + rightTruncated);
+	}
+
+	return result;
+}
+
+/**
  * Apply background color to a line, padding to full width.
  *
  * @param line - Line of text (may contain ANSI codes)

--- a/packages/tui/test/join-columns.test.ts
+++ b/packages/tui/test/join-columns.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { joinColumns, visibleWidth } from "../src/utils.js";
+
+describe("joinColumns", () => {
+	it("merges two equal-height blocks side-by-side", () => {
+		const left = ["hello", "world"];
+		const right = ["foo", "bar"];
+		const result = joinColumns(left, right, 1, 20);
+
+		assert.strictEqual(result.length, 2);
+		assert.strictEqual(result[0], "hello foo");
+		assert.strictEqual(result[1], "world bar");
+	});
+
+	it("pads right rows when left is taller", () => {
+		const left = ["aaa", "bbb", "ccc"];
+		const right = ["x", "y"];
+		const result = joinColumns(left, right, 2, 20);
+
+		assert.strictEqual(result.length, 3);
+		assert.strictEqual(result[0], "aaa  x");
+		assert.strictEqual(result[1], "bbb  y");
+		assert.strictEqual(result[2], "ccc  ");
+	});
+
+	it("pads left rows when right is taller", () => {
+		const left = ["aa"];
+		const right = ["xx", "yy", "zz"];
+		const result = joinColumns(left, right, 2, 20);
+
+		assert.strictEqual(result.length, 3);
+		assert.strictEqual(result[0], "aa  xx");
+		assert.strictEqual(result[1], "    yy");
+		assert.strictEqual(result[2], "    zz");
+	});
+
+	it("truncates right side when total exceeds totalWidth", () => {
+		const left = ["hello"];
+		const right = ["abcdefghijklmnopqrstuvwxyz"];
+		const result = joinColumns(left, right, 2, 13);
+
+		assert.strictEqual(result.length, 1);
+		const line = result[0]!;
+		// left "hello" = 5, gap = 2, right truncated to 13-5-2 = 6 chars
+		assert.strictEqual(visibleWidth(line), 13);
+		assert.ok(line.startsWith("hello  "));
+	});
+
+	it("handles ANSI codes without breaking width calculation", () => {
+		const left = ["\x1b[31mhi\x1b[0m", "\x1b[32mbye\x1b[0m"];
+		const right = ["\x1b[34mfoo\x1b[0m", "\x1b[35mbar\x1b[0m"];
+		const result = joinColumns(left, right, 1, 20);
+
+		assert.strictEqual(result.length, 2);
+		// left col width = max(2, 3) = 3, so "hi" gets 1 padding space
+		// left col width = max(2, 3) = 3; "hi" (width 2) padded by 1 space, then gap=1
+		assert.strictEqual(result[0]!, "\x1b[31mhi\x1b[0m  \x1b[34mfoo\x1b[0m");
+		assert.strictEqual(result[1]!, "\x1b[32mbye\x1b[0m \x1b[35mbar\x1b[0m");
+	});
+
+	it("returns empty array when both blocks are empty", () => {
+		const result = joinColumns([], [], 1, 20);
+		assert.strictEqual(result.length, 0);
+	});
+
+	it("handles empty left block", () => {
+		const right = ["abc", "def"];
+		const result = joinColumns([], right, 2, 20);
+
+		assert.strictEqual(result.length, 2);
+		// left col width = 0, gap = 2, so lines start with 2 spaces then right content
+		assert.strictEqual(result[0], "  abc");
+		assert.strictEqual(result[1], "  def");
+	});
+
+	it("handles empty right block", () => {
+		const left = ["abc", "def"];
+		const result = joinColumns(left, [], 2, 20);
+
+		assert.strictEqual(result.length, 2);
+		assert.strictEqual(result[0], "abc  ");
+		assert.strictEqual(result[1], "def  ");
+	});
+
+	it("works with gap of 0", () => {
+		const left = ["ab", "cd"];
+		const right = ["xy", "zw"];
+		const result = joinColumns(left, right, 0, 20);
+
+		assert.strictEqual(result.length, 2);
+		assert.strictEqual(result[0], "abxy");
+		assert.strictEqual(result[1], "cdzw");
+	});
+
+	it("pads left column to max visible width across all left lines", () => {
+		const left = ["a", "bbb", "cc"];
+		const right = ["x", "y", "z"];
+		const result = joinColumns(left, right, 1, 20);
+
+		assert.strictEqual(result.length, 3);
+		// left col width = 3 (from "bbb"), so "a" gets 2 padding, "cc" gets 1 padding
+		assert.strictEqual(result[0], "a   x");
+		assert.strictEqual(result[1], "bbb y");
+		assert.strictEqual(result[2], "cc  z");
+	});
+});


### PR DESCRIPTION
Closes #116

Redesigns the buddy speech bubble layout:

- **Side-by-side rendering**: Speech bubble now renders beside the sprite (same rows) instead of below, dramatically reducing vertical footprint
- **Dynamic bubble width**: Scales to fill available terminal width instead of hardcoded 60 chars
- **Hard 3-line content cap**: Speech bubble capped to 3 content lines max with ellipsis truncation
- **Reduced word limit**: MAX_RESPONSE_WORDS from 300 → 60
- **Clean recovery**: Side-by-side layout avoids the stale layout artifact issue from vertical stacking
- **New TUI utility**: `joinColumns()` for ANSI-safe side-by-side string array merging

Implementation plan posted as a comment below.