### PR TITLE
Fix TUI ghost whitespace on shrink and scroll position destruction on growth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8595,7 +8595,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8624,7 +8624,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8680,7 +8680,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8794,7 +8794,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8842,7 +8842,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8874,7 +8874,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -107,7 +107,7 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `terminal.showImages` | boolean | `true` | Show images in terminal (if supported) |
-| `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
+
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -24,7 +24,6 @@ export interface RetrySettings {
 
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
-	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 }
 
 export interface ImageSettings {
@@ -845,23 +844,6 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.showImages = show;
 		this.markModified("terminal", "showImages");
-		this.save();
-	}
-
-	getClearOnShrink(): boolean {
-		// Settings takes precedence, then env var, then default false
-		if (this.settings.terminal?.clearOnShrink !== undefined) {
-			return this.settings.terminal.clearOnShrink;
-		}
-		return process.env.DREB_CLEAR_ON_SHRINK === "1";
-	}
-
-	setClearOnShrink(enabled: boolean): void {
-		if (!this.globalSettings.terminal) {
-			this.globalSettings.terminal = {};
-		}
-		this.globalSettings.terminal.clearOnShrink = enabled;
-		this.markModified("terminal", "clearOnShrink");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -49,7 +49,6 @@ export interface SettingsConfig {
 	editorPaddingX: number;
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
-	clearOnShrink: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -72,7 +71,6 @@ export interface SettingsCallbacks {
 	onEditorPaddingXChange: (padding: number) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
-	onClearOnShrinkChange: (enabled: boolean) => void;
 	onCancel: () => void;
 }
 
@@ -344,16 +342,6 @@ export class SettingsSelectorComponent extends Container {
 			values: ["3", "5", "7", "10", "15", "20"],
 		});
 
-		// Clear on shrink toggle (insert after autocomplete-max-visible)
-		const autocompleteIndex = items.findIndex((item) => item.id === "autocomplete-max-visible");
-		items.splice(autocompleteIndex + 1, 0, {
-			id: "clear-on-shrink",
-			label: "Clear on shrink",
-			description: "Clear empty rows when content shrinks (may cause flicker)",
-			currentValue: config.clearOnShrink ? "true" : "false",
-			values: ["true", "false"],
-		});
-
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -412,9 +400,6 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "autocomplete-max-visible":
 						callbacks.onAutocompleteMaxVisibleChange(parseInt(newValue, 10));
-						break;
-					case "clear-on-shrink":
-						callbacks.onClearOnShrinkChange(newValue === "true");
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -283,7 +283,6 @@ export class InteractiveMode {
 			},
 		});
 		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
-		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
@@ -3381,7 +3380,6 @@ export class InteractiveMode {
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
-					clearOnShrink: this.settingsManager.getClearOnShrink(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3476,10 +3474,6 @@ export class InteractiveMode {
 						if (this.editor !== this.defaultEditor && this.editor.setAutocompleteMaxVisible !== undefined) {
 							this.editor.setAutocompleteMaxVisible(maxVisible);
 						}
-					},
-					onClearOnShrinkChange: (enabled) => {
-						this.settingsManager.setClearOnShrink(enabled);
-						this.ui.setClearOnShrink(enabled);
 					},
 					onCancel: () => {
 						done();
@@ -4104,7 +4098,6 @@ export class InteractiveMode {
 				this.editor.setAutocompleteMaxVisible?.(autocompleteMaxVisible);
 			}
 			this.ui.setShowHardwareCursor(this.settingsManager.getShowHardwareCursor());
-			this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 			this.setupAutocomplete(this.fdPath);
 			const runner = this.session.extensionRunner;
 			if (runner) {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -22,7 +22,7 @@ export class Loader extends Text {
 	}
 
 	render(width: number): string[] {
-		return ["", ...super.render(width)];
+		return super.render(width);
 	}
 
 	start() {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -226,7 +226,6 @@ export class TUI extends Container {
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
 	private showHardwareCursor = process.env.DREB_HARDWARE_CURSOR === "1";
-	private clearOnShrink = process.env.DREB_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
@@ -265,19 +264,6 @@ export class TUI extends Container {
 			this.terminal.hideCursor();
 		}
 		this.requestRender();
-	}
-
-	getClearOnShrink(): boolean {
-		return this.clearOnShrink;
-	}
-
-	/**
-	 * Set whether to trigger full re-render when content shrinks.
-	 * When true (default), empty rows are cleared when content shrinks.
-	 * When false, empty rows remain (reduces redraws on slower terminals).
-	 */
-	setClearOnShrink(enabled: boolean): void {
-		this.clearOnShrink = enabled;
 	}
 
 	setFocus(component: Component | null): void {
@@ -900,10 +886,13 @@ export class TUI extends Container {
 		newLines = this.applyLineResets(newLines);
 
 		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		const fullRender = (clear: boolean, clearScrollback = false): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+			if (clear) {
+				buffer += "\x1b[2J\x1b[H"; // Clear screen, home
+				if (clearScrollback) buffer += "\x1b[3J"; // Clear scrollback (only for width changes)
+			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				buffer += newLines[i];
@@ -944,7 +933,7 @@ export class TUI extends Container {
 		// Width changes always need a full re-render because wrapping changes.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
-			fullRender(true);
+			fullRender(true, true);
 			return;
 		}
 
@@ -953,16 +942,7 @@ export class TUI extends Container {
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
 		if (heightChanged && !isTermuxSession()) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
-			fullRender(true);
-			return;
-		}
-
-		// Content shrunk below the working area and no overlays - re-render to clear empty rows
-		// (overlays need the padding, so only do this when no overlays are active)
-		// Configurable via setClearOnShrink() or DREB_CLEAR_ON_SHRINK=0 env var
-		if (this.clearOnShrink && newLines.length < this.maxLinesRendered && this.overlayStack.length === 0) {
-			logRedraw(`clearOnShrink (maxLinesRendered=${this.maxLinesRendered})`);
-			fullRender(true);
+			fullRender(true, false);
 			return;
 		}
 
@@ -1006,18 +986,22 @@ export class TUI extends Container {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true);
+					fullRender(true, false);
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
 				if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
 				else if (lineDiff < 0) buffer += `\x1b[${-lineDiff}A`;
 				buffer += "\r";
+				// When content is completely empty, clear the row at targetRow too
+				if (newLines.length === 0) {
+					buffer += "\x1b[2K";
+				}
 				// Clear extra lines without scrolling
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					fullRender(true, false);
 					return;
 				}
 				if (extraLines > 0) {
@@ -1035,6 +1019,12 @@ export class TUI extends Container {
 				this.cursorRow = targetRow;
 				this.hardwareCursorRow = targetRow;
 			}
+			// Track actual content height — shrink when no overlays to prevent ghost whitespace
+			if (this.overlayStack.length === 0) {
+				this.maxLinesRendered = newLines.length;
+			} else {
+				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+			}
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousLines = newLines;
 			this.previousWidth = width;
@@ -1043,12 +1033,31 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// If changes are above the viewport, decide whether to clamp or full redraw
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			if (newLines.length >= prevViewportTop + height) {
+				// Content still fills viewport — clamp off-screen changes
+				if (lastChanged < prevViewportTop) {
+					// All changes are above viewport — update state without rendering
+					if (this.overlayStack.length === 0) {
+						this.maxLinesRendered = newLines.length;
+					} else {
+						this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+					}
+					this.previousViewportTop = prevViewportTop;
+					this.positionHardwareCursor(cursorPos, newLines.length);
+					this.previousLines = newLines;
+					this.previousWidth = width;
+					this.previousHeight = height;
+					return;
+				}
+				firstChanged = prevViewportTop;
+			} else {
+				// Viewport needs to shift — full redraw without scrollback clear
+				logRedraw(`firstChanged < viewportTop with viewport shift (${firstChanged} < ${prevViewportTop})`);
+				fullRender(true, false);
+				return;
+			}
 		}
 
 		// Render from first changed line to end
@@ -1176,8 +1185,12 @@ export class TUI extends Container {
 		// hardwareCursorRow tracks actual terminal cursor position (for movement)
 		this.cursorRow = Math.max(0, newLines.length - 1);
 		this.hardwareCursorRow = finalCursorRow;
-		// Track terminal's working area (grows but doesn't shrink unless cleared)
-		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+		// Track terminal's working area — shrink when no overlays to prevent ghost whitespace
+		if (this.overlayStack.length === 0) {
+			this.maxLinesRendered = newLines.length;
+		} else {
+			this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
+		}
 		this.previousViewportTop = Math.max(prevViewportTop, finalCursorRow - height + 1);
 
 		// Position hardware cursor for IME

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -144,10 +144,9 @@ describe("TUI resize handling", () => {
 });
 
 describe("TUI content shrinkage", () => {
-	it("clears empty rows when content shrinks significantly", async () => {
-		const terminal = new VirtualTerminal(40, 10);
+	it("clears empty rows when content shrinks via differential renderer", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
-		tui.setClearOnShrink(true); // Explicitly enable (may be disabled via env var)
 		const component = new TestComponent();
 		tui.addChild(component);
 
@@ -157,19 +156,22 @@ describe("TUI content shrinkage", () => {
 		await terminal.flush();
 
 		const initialRedraws = tui.fullRedraws;
+		terminal.clearWrites();
 
 		// Shrink to fewer lines
 		component.lines = ["Line 0", "Line 1"];
 		tui.requestRender();
 		await terminal.flush();
 
-		// Should have triggered a full redraw to clear empty rows
-		assert.ok(tui.fullRedraws > initialRedraws, "Content shrinkage should trigger full redraw");
+		// Should NOT trigger a full redraw — differential renderer handles it
+		assert.strictEqual(tui.fullRedraws, initialRedraws, "Shrink should use differential rendering, not full redraw");
+		// Should NOT clear scrollback
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Shrink should not clear scrollback");
 
 		const viewport = terminal.getViewport();
 		assert.ok(viewport[0]?.includes("Line 0"), "First line preserved");
 		assert.ok(viewport[1]?.includes("Line 1"), "Second line preserved");
-		// Lines below should be empty (cleared)
+		// Lines below should be empty (cleared by targeted erasure)
 		assert.strictEqual(viewport[2]?.trim(), "", "Line 2 should be cleared");
 		assert.strictEqual(viewport[3]?.trim(), "", "Line 3 should be cleared");
 
@@ -179,7 +181,6 @@ describe("TUI content shrinkage", () => {
 	it("handles shrink to single line", async () => {
 		const terminal = new VirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
-		tui.setClearOnShrink(true); // Explicitly enable (may be disabled via env var)
 		const component = new TestComponent();
 		tui.addChild(component);
 
@@ -202,7 +203,6 @@ describe("TUI content shrinkage", () => {
 	it("handles shrink to empty", async () => {
 		const terminal = new VirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
-		tui.setClearOnShrink(true); // Explicitly enable (may be disabled via env var)
 		const component = new TestComponent();
 		tui.addChild(component);
 
@@ -503,6 +503,232 @@ describe("TUI differential rendering", () => {
 			"Editor 1",
 			"Editor 2",
 		]);
+
+		tui.stop();
+	});
+});
+
+describe("TUI scrollback preservation", () => {
+	it("does not clear scrollback when content shrinks", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["Line 0", "Line 1", "Line 2", "Line 3", "Line 4", "Line 5"];
+		tui.start();
+		await terminal.flush();
+		terminal.clearWrites();
+
+		// Shrink content
+		component.lines = ["Line 0", "Line 1"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Shrink should not clear scrollback");
+		tui.stop();
+	});
+
+	it("clears scrollback on width change", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["Line 0", "Line 1", "Line 2"];
+		tui.start();
+		await terminal.flush();
+		terminal.clearWrites();
+
+		// Width change should clear scrollback (wrapping invalidates it)
+		terminal.resize(60, 10);
+		await terminal.flush();
+
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "Width change should clear scrollback");
+		tui.stop();
+	});
+
+	it("does not clear scrollback on height change", async () => {
+		await withEnv({ TERMUX_VERSION: undefined }, async () => {
+			const terminal = new LoggingVirtualTerminal(40, 10);
+			const tui = new TUI(terminal);
+			const component = new TestComponent();
+			tui.addChild(component);
+
+			component.lines = ["Line 0", "Line 1", "Line 2"];
+			tui.start();
+			await terminal.flush();
+			terminal.clearWrites();
+
+			// Height change should clear screen but NOT scrollback
+			terminal.resize(40, 15);
+			await terminal.flush();
+
+			assert.ok(terminal.getWrites().includes("\x1b[2J"), "Height change should clear screen");
+			assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
+			tui.stop();
+		});
+	});
+
+	it("off-screen changes do not trigger scrollback clear", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// Content longer than terminal height
+		component.lines = Array.from({ length: 15 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.flush();
+
+		const initialRedraws = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// Change a line above the viewport (viewport shows lines 10-14)
+		component.lines = Array.from({ length: 15 }, (_, i) => (i === 2 ? "CHANGED" : `Line ${i}`));
+		tui.requestRender();
+		await terminal.flush();
+
+		// Should not trigger a full redraw or clear scrollback
+		assert.strictEqual(tui.fullRedraws, initialRedraws, "Off-screen change should not trigger full redraw");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Off-screen change should not clear scrollback");
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "Off-screen change should not clear screen");
+
+		// Visible content should remain correct
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[4]?.includes("Line 14"), "Bottom of viewport preserved");
+
+		tui.stop();
+	});
+});
+
+describe("TUI maxLinesRendered tracking", () => {
+	it("shrinks maxLinesRendered when no overlays are active", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// Render long content
+		component.lines = Array.from({ length: 8 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.flush();
+
+		// Shrink content
+		component.lines = ["Line 0", "Line 1", "Line 2"];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Now grow slightly — should NOT trigger full redraw (maxLinesRendered tracked actual)
+		const redraws = tui.fullRedraws;
+		component.lines = ["Line 0", "Line 1", "Line 2", "Line 3"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.strictEqual(tui.fullRedraws, redraws, "Growth after shrink should use differential rendering");
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[3]?.includes("Line 3"), "New line rendered correctly");
+
+		tui.stop();
+	});
+
+	it("keeps maxLinesRendered stable with overlays active", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// Render content
+		component.lines = Array.from({ length: 8 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.flush();
+
+		// Show overlay
+		const overlayComponent = new TestComponent();
+		overlayComponent.lines = ["Overlay content"];
+		const handle = tui.showOverlay(overlayComponent, { width: 20, anchor: "center" });
+		await terminal.flush();
+
+		// Shrink content while overlay is active
+		component.lines = ["Line 0", "Line 1", "Line 2"];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Overlay positioning should remain stable (maxLinesRendered should not shrink)
+		const viewport = terminal.getViewport();
+		// The overlay should still be visible and positioned correctly
+		const overlayVisible = viewport.some((line) => line.includes("Overlay content"));
+		assert.ok(overlayVisible, "Overlay should remain visible after content shrink");
+
+		handle.hide();
+		tui.stop();
+	});
+});
+
+describe("TUI spinner lifecycle", () => {
+	it("spinner add and remove leaves no ghost lines", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const chat = new TestComponent();
+		const spinner = new TestComponent();
+		tui.addChild(chat);
+		tui.addChild(spinner);
+
+		// Chat content with spinner
+		chat.lines = ["Message 1", "Message 2"];
+		spinner.lines = ["⠋ Loading..."];
+		tui.start();
+		await terminal.flush();
+
+		let viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("Message 1"), "Chat line 1");
+		assert.ok(viewport[1]?.includes("Message 2"), "Chat line 2");
+		assert.ok(viewport[2]?.includes("Loading"), "Spinner visible");
+
+		// Remove spinner (simulates spinner stop)
+		spinner.lines = [];
+		tui.requestRender();
+		await terminal.flush();
+
+		viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("Message 1"), "Chat line 1 preserved");
+		assert.ok(viewport[1]?.includes("Message 2"), "Chat line 2 preserved");
+		assert.strictEqual(viewport[2]?.trim(), "", "Spinner line should be cleared");
+
+		tui.stop();
+	});
+
+	it("all-deleted case uses targeted erasure not full redraw", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// Render 5 lines (all fit in viewport)
+		component.lines = ["Line 0", "Line 1", "Line 2", "Line 3", "Line 4"];
+		tui.start();
+		await terminal.flush();
+
+		const initialRedraws = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// Shrink to 3 lines — lines 3,4 are "all deleted"
+		component.lines = ["Line 0", "Line 1", "Line 2"];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Should use targeted erasure, not full redraw
+		assert.strictEqual(tui.fullRedraws, initialRedraws, "Should not trigger full redraw");
+		// Should use line-by-line erasure (\x1b[2K)
+		assert.ok(terminal.getWrites().includes("\x1b[2K"), "Should use targeted line erasure");
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "Should not clear entire screen");
+
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("Line 0"), "Line 0 preserved");
+		assert.ok(viewport[1]?.includes("Line 1"), "Line 1 preserved");
+		assert.ok(viewport[2]?.includes("Line 2"), "Line 2 preserved");
+		assert.strictEqual(viewport[3]?.trim(), "", "Line 3 cleared");
+		assert.strictEqual(viewport[4]?.trim(), "", "Line 4 cleared");
 
 		tui.stop();
 	});


### PR DESCRIPTION
Closes #139

Fixes two related TUI rendering defects:
1. Ghost whitespace when content shrinks (e.g. spinner removal)
2. Scroll position destroyed when content changes above viewport

Implementation plan posted as a comment below.