### PR TITLE
Process bash output through terminal rendering to reduce context bloat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5142,6 +5142,12 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/from-node-stream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/from-node-stream/-/from-node-stream-0.1.2.tgz",
+			"integrity": "sha512-JtJYm9xYSO1xxrhEmU7WOE4NjaLVgVjQ2J0ZymhN/ouTXjsHlmuUHs3YKV9vHaiF5Nlt7KPVHkrblYMLEP+P/A==",
+			"license": "MIT"
+		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -7589,6 +7595,108 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/terminal-render": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/terminal-render/-/terminal-render-1.5.1.tgz",
+			"integrity": "sha512-ieR4aMVHCJBNR0geVmp8Iq3w+UIrEnsnvJyu0b0MuTFYN7uKe4FPdrCOhB/mfB6Cz9BnUlW+MZs4V+k3o1d+bw==",
+			"license": "MIT",
+			"dependencies": {
+				"from-node-stream": "^0.1.0",
+				"yargs": "^18.0.0"
+			}
+		},
+		"node_modules/terminal-render/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/terminal-render/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/terminal-render/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/terminal-render/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/terminal-render/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/terminal-render/node_modules/yargs": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^7.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/terminal-render/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -8703,6 +8811,7 @@
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
 				"strip-ansi": "^7.1.0",
+				"terminal-render": "^1.5.1",
 				"tree-sitter-c": "^0.24.1",
 				"tree-sitter-cpp": "^0.23.4",
 				"tree-sitter-go": "^0.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8703,7 +8703,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8732,7 +8732,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8788,7 +8788,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8903,7 +8903,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8951,7 +8951,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8983,7 +8983,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -72,6 +72,7 @@
 		"minimatch": "^10.2.3",
 		"proper-lockfile": "^4.1.2",
 		"strip-ansi": "^7.1.0",
+		"terminal-render": "^1.5.1",
 		"tree-sitter-c": "^0.24.1",
 		"tree-sitter-cpp": "^0.23.4",
 		"tree-sitter-go": "^0.25.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -315,14 +315,7 @@ export function createBashToolDefinition(
 					// Stream partial output using the rolling tail buffer.
 					if (onUpdate) {
 						const fullBuffer = Buffer.concat(chunks);
-						let fullText: string;
-						try {
-							fullText = renderTerminalOutput(fullBuffer.toString("utf-8"));
-						} catch (err) {
-							const detail = err instanceof Error ? err.message : String(err);
-							console.error(`[dreb] terminal-render fallback in streaming handler: ${detail}, using raw output`);
-							fullText = fullBuffer.toString("utf-8");
-						}
+						const fullText = renderTerminalOutput(fullBuffer.toString("utf-8"));
 						const truncation = truncateTail(fullText);
 						onUpdate({
 							content: [{ type: "text", text: truncation.content || "" }],
@@ -378,14 +371,7 @@ export function createBashToolDefinition(
 						// Close temp file stream and include buffered output in the error message.
 						if (tempFileStream) tempFileStream.end();
 						const fullBuffer = Buffer.concat(chunks);
-						let output: string;
-						try {
-							output = renderTerminalOutput(fullBuffer.toString("utf-8"));
-						} catch (renderErr) {
-							const detail = renderErr instanceof Error ? renderErr.message : String(renderErr);
-							console.error(`[dreb] terminal-render fallback in error handler: ${detail}, using raw output`);
-							output = fullBuffer.toString("utf-8");
-						}
+						let output = renderTerminalOutput(fullBuffer.toString("utf-8"));
 						if (err.message === "aborted") {
 							if (output) output += "\n\n";
 							output += "Command aborted";

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -315,7 +315,14 @@ export function createBashToolDefinition(
 					// Stream partial output using the rolling tail buffer.
 					if (onUpdate) {
 						const fullBuffer = Buffer.concat(chunks);
-						const fullText = renderTerminalOutput(fullBuffer.toString("utf-8"));
+						let fullText: string;
+						try {
+							fullText = renderTerminalOutput(fullBuffer.toString("utf-8"));
+						} catch (err) {
+							const detail = err instanceof Error ? err.message : String(err);
+							console.error(`[dreb] terminal-render fallback in streaming handler: ${detail}, using raw output`);
+							fullText = fullBuffer.toString("utf-8");
+						}
 						const truncation = truncateTail(fullText);
 						onUpdate({
 							content: [{ type: "text", text: truncation.content || "" }],
@@ -371,7 +378,14 @@ export function createBashToolDefinition(
 						// Close temp file stream and include buffered output in the error message.
 						if (tempFileStream) tempFileStream.end();
 						const fullBuffer = Buffer.concat(chunks);
-						let output = fullBuffer.toString("utf-8");
+						let output: string;
+						try {
+							output = renderTerminalOutput(fullBuffer.toString("utf-8"));
+						} catch (renderErr) {
+							const detail = renderErr instanceof Error ? renderErr.message : String(renderErr);
+							console.error(`[dreb] terminal-render fallback in error handler: ${detail}, using raw output`);
+							output = fullBuffer.toString("utf-8");
+						}
 						if (err.message === "aborted") {
 							if (output) output += "\n\n";
 							output += "Command aborted";

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -13,6 +13,7 @@ import { waitForChildProcess } from "../../utils/child-process.js";
 import { getShellConfig, getShellEnv, killProcessTree } from "../../utils/shell.js";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import { getTextOutput, invalidArgText, str } from "./render-utils.js";
+import { renderTerminalOutput } from "./terminal-render.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateTail } from "./truncate.js";
 
@@ -314,7 +315,7 @@ export function createBashToolDefinition(
 					// Stream partial output using the rolling tail buffer.
 					if (onUpdate) {
 						const fullBuffer = Buffer.concat(chunks);
-						const fullText = fullBuffer.toString("utf-8");
+						const fullText = renderTerminalOutput(fullBuffer.toString("utf-8"));
 						const truncation = truncateTail(fullText);
 						onUpdate({
 							content: [{ type: "text", text: truncation.content || "" }],
@@ -337,7 +338,9 @@ export function createBashToolDefinition(
 						if (tempFileStream) tempFileStream.end();
 						// Combine the rolling buffer chunks.
 						const fullBuffer = Buffer.concat(chunks);
-						const fullOutput = fullBuffer.toString("utf-8");
+						// Render terminal output to collapse progress bars, handle \r overwrites,
+						// and process ANSI cursor movement — producing what a terminal would display.
+						const fullOutput = renderTerminalOutput(fullBuffer.toString("utf-8"));
 						// Apply tail truncation for the final display payload.
 						const truncation = truncateTail(fullOutput);
 						let outputText = truncation.content || "(no output)";

--- a/packages/coding-agent/src/core/tools/terminal-render.ts
+++ b/packages/coding-agent/src/core/tools/terminal-render.ts
@@ -20,7 +20,7 @@ const MAX_CURSOR_POSITION = 5000;
 export function sanitizeCursorPositioning(input: string): string {
 	// Match CSI sequences: ESC[ followed by params and a final byte
 	// Covers H, f (CUP), A/B/C/D (movement), d (VPA), G/` (HPA)
-	return input.replace(/\x1b\[([0-9;]*)([HABCDGHfd`])/g, (_match, params: string, cmd: string) => {
+	return input.replace(/\x1b\[([0-9;]*)([ABCDEGHfdr`])/g, (_match, params: string, cmd: string) => {
 		const capped = params
 			.split(";")
 			.map((p: string) => {

--- a/packages/coding-agent/src/core/tools/terminal-render.ts
+++ b/packages/coding-agent/src/core/tools/terminal-render.ts
@@ -14,22 +14,109 @@ const MAX_CURSOR_POSITION = 5000;
  * millions of empty lines. This function caps row/column values in:
  * - CUP (cursor position): ESC[<row>;<col>H  or ESC[<row>;<col>f
  * - CUU/CUD/CUF/CUB (cursor movement): ESC[<n>A/B/C/D
+ * - CNL (cursor next line): ESC[<n>E
  * - VPA (vertical position absolute): ESC[<row>d
  * - HPA (horizontal position absolute): ESC[<col>G or ESC[<col>`
+ *
+ * In addition to per-sequence caps, this tracks cumulative cursor position
+ * to prevent accumulation attacks where many sequences each at the per-sequence
+ * cap combine to push the cursor to millions of rows/columns, triggering OOM
+ * via array allocation in the terminal renderer.
  */
 export function sanitizeCursorPositioning(input: string): string {
-	// Match CSI sequences: ESC[ followed by params and a final byte
-	// Covers H, f (CUP), A/B/C/D (movement), d (VPA), G/` (HPA)
-	return input.replace(/\x1b\[([0-9;]*)([ABCDEGHfdr`])/g, (_match, params: string, cmd: string) => {
-		const capped = params
-			.split(";")
+	// Track cumulative cursor position across sequences. An attacker can send
+	// thousands of ESC[5000B sequences, each passing the per-sequence cap but
+	// accumulating to ~55M rows. By tracking position, we clamp movement that
+	// would exceed the limit.
+	let cursorRow = 0;
+	let cursorCol = 0;
+
+	const parsePart = (p: string | undefined): number | null => {
+		if (p === undefined) return null;
+		const n = Number.parseInt(p, 10);
+		return Number.isNaN(n) ? null : n;
+	};
+
+	// Cap all numeric params individually and rebuild the param string
+	const capParams = (rawParts: string[]) =>
+		rawParts
 			.map((p: string) => {
 				const n = Number.parseInt(p, 10);
 				if (Number.isNaN(n)) return p;
 				return String(Math.min(n, MAX_CURSOR_POSITION));
 			})
 			.join(";");
-		return `\x1b[${capped}${cmd}`;
+
+	// Match CSI sequences: ESC[ followed by params and a final byte
+	// Covers H, f (CUP), A/B/C/D (movement), E (CNL), d (VPA), G/` (HPA), r (scroll region)
+	return input.replace(/\x1b\[([0-9;]*)([ABCDEGHfdr`])/g, (_match, params: string, cmd: string) => {
+		const rawParts = params.split(";");
+
+		switch (cmd) {
+			case "B": // Cursor down by n (default 1)
+			case "E": {
+				// Cursor next line by n (default 1)
+				const n = parsePart(rawParts[0]) ?? 1;
+				const capped = Math.min(n, MAX_CURSOR_POSITION);
+				const allowed = Math.max(0, MAX_CURSOR_POSITION - cursorRow);
+				const clamped = Math.min(capped, allowed);
+				cursorRow += clamped;
+				if (cmd === "E") cursorCol = 0;
+				return `\x1b[${clamped}${cmd}`;
+			}
+			case "A": {
+				// Cursor up by n (default 1)
+				const n = parsePart(rawParts[0]) ?? 1;
+				const capped = Math.min(n, MAX_CURSOR_POSITION);
+				cursorRow = Math.max(0, cursorRow - capped);
+				return `\x1b[${capped}A`;
+			}
+			case "C": {
+				// Cursor forward by n (default 1)
+				const n = parsePart(rawParts[0]) ?? 1;
+				const capped = Math.min(n, MAX_CURSOR_POSITION);
+				const allowed = Math.max(0, MAX_CURSOR_POSITION - cursorCol);
+				const clamped = Math.min(capped, allowed);
+				cursorCol += clamped;
+				return `\x1b[${clamped}C`;
+			}
+			case "D": {
+				// Cursor back by n (default 1)
+				const n = parsePart(rawParts[0]) ?? 1;
+				const capped = Math.min(n, MAX_CURSOR_POSITION);
+				cursorCol = Math.max(0, cursorCol - capped);
+				return `\x1b[${capped}D`;
+			}
+			case "H":
+			case "f": {
+				// Absolute cursor position: ESC[row;colH
+				const row = parsePart(rawParts[0]);
+				const col = parsePart(rawParts[1]);
+				cursorRow = row != null ? Math.min(row, MAX_CURSOR_POSITION) : 1;
+				cursorCol = col != null ? Math.min(col, MAX_CURSOR_POSITION) : 1;
+				return `\x1b[${capParams(rawParts)}${cmd}`;
+			}
+			case "d": {
+				// VPA - vertical position absolute
+				const row = parsePart(rawParts[0]);
+				cursorRow = row != null ? Math.min(row, MAX_CURSOR_POSITION) : 1;
+				return `\x1b[${capParams(rawParts)}d`;
+			}
+			case "G":
+			case "`": {
+				// HPA - horizontal position absolute
+				const col = parsePart(rawParts[0]);
+				cursorCol = col != null ? Math.min(col, MAX_CURSOR_POSITION) : 1;
+				return `\x1b[${capParams(rawParts)}${cmd}`;
+			}
+			case "r": {
+				// Set scroll region - cap params, no position tracking
+				return `\x1b[${capParams(rawParts)}r`;
+			}
+			default: {
+				return `\x1b[${capParams(rawParts)}${cmd}`;
+			}
+		}
 	});
 }
 

--- a/packages/coding-agent/src/core/tools/terminal-render.ts
+++ b/packages/coding-agent/src/core/tools/terminal-render.ts
@@ -1,0 +1,22 @@
+import { TerminalTextRender } from "terminal-render";
+
+/**
+ * Process raw terminal output through a terminal renderer, producing the clean
+ * text a human would actually see on screen.
+ *
+ * This handles:
+ * - Carriage returns (`\r`) — progress bars overwrite the current line
+ * - ANSI cursor movement — up, down, forward, backward, absolute positioning
+ * - Backspace (`\b`) — moves cursor back one position
+ * - Line clearing / screen clearing escape sequences
+ * - Tab stops
+ *
+ * The result is the final rendered state of the terminal — identical to what
+ * a human would see in a real terminal after the output completes.
+ */
+export function renderTerminalOutput(raw: string): string {
+	if (!raw) return raw;
+	const renderer = new TerminalTextRender();
+	renderer.write(raw);
+	return renderer.render();
+}

--- a/packages/coding-agent/src/core/tools/terminal-render.ts
+++ b/packages/coding-agent/src/core/tools/terminal-render.ts
@@ -1,6 +1,39 @@
 import { TerminalTextRender } from "terminal-render";
 
 /**
+ * Maximum row or column value allowed in ANSI cursor positioning sequences.
+ * Anything larger gets capped to this value to prevent memory exhaustion from
+ * malicious sequences like `ESC[9999999;1H`.
+ */
+const MAX_CURSOR_POSITION = 5000;
+
+/**
+ * Sanitize ANSI cursor positioning sequences to prevent memory exhaustion.
+ *
+ * Sequences like `ESC[9999999;1H` can cause TerminalTextRender to allocate
+ * millions of empty lines. This function caps row/column values in:
+ * - CUP (cursor position): ESC[<row>;<col>H  or ESC[<row>;<col>f
+ * - CUU/CUD/CUF/CUB (cursor movement): ESC[<n>A/B/C/D
+ * - VPA (vertical position absolute): ESC[<row>d
+ * - HPA (horizontal position absolute): ESC[<col>G or ESC[<col>`
+ */
+export function sanitizeCursorPositioning(input: string): string {
+	// Match CSI sequences: ESC[ followed by params and a final byte
+	// Covers H, f (CUP), A/B/C/D (movement), d (VPA), G/` (HPA)
+	return input.replace(/\x1b\[([0-9;]*)([HABCDGHfd`])/g, (_match, params: string, cmd: string) => {
+		const capped = params
+			.split(";")
+			.map((p: string) => {
+				const n = Number.parseInt(p, 10);
+				if (Number.isNaN(n)) return p;
+				return String(Math.min(n, MAX_CURSOR_POSITION));
+			})
+			.join(";");
+		return `\x1b[${capped}${cmd}`;
+	});
+}
+
+/**
  * Process raw terminal output through a terminal renderer, producing the clean
  * text a human would actually see on screen.
  *
@@ -13,10 +46,21 @@ import { TerminalTextRender } from "terminal-render";
  *
  * The result is the final rendered state of the terminal — identical to what
  * a human would see in a real terminal after the output completes.
+ *
+ * Safety:
+ * - Cursor positioning values are capped to prevent memory exhaustion
+ * - Errors fall back to returning the raw input
  */
 export function renderTerminalOutput(raw: string): string {
 	if (!raw) return raw;
-	const renderer = new TerminalTextRender();
-	renderer.write(raw);
-	return renderer.render();
+	try {
+		const sanitized = sanitizeCursorPositioning(raw);
+		const renderer = new TerminalTextRender();
+		renderer.write(sanitized);
+		return renderer.render();
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		console.error(`[dreb] terminal-render fallback: TerminalTextRender failed (${detail}), returning raw output`);
+		return raw;
+	}
 }

--- a/packages/coding-agent/test/terminal-render.test.ts
+++ b/packages/coding-agent/test/terminal-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderTerminalOutput } from "../src/core/tools/terminal-render.js";
+import { renderTerminalOutput, sanitizeCursorPositioning } from "../src/core/tools/terminal-render.js";
 
 describe("renderTerminalOutput", () => {
 	it("should collapse \\r-based progress bar to final state", () => {
@@ -110,5 +110,93 @@ describe("renderTerminalOutput", () => {
 		const result = renderTerminalOutput(input);
 		expect(result).toContain("new text");
 		expect(result).not.toContain("old text");
+	});
+
+	it("should cap extreme cursor positioning to prevent memory exhaustion", () => {
+		// ESC[9999999;1H would try to create ~10M lines without sanitization
+		const input = "hello\x1b[9999999;1Hworld";
+		const start = performance.now();
+		const result = renderTerminalOutput(input);
+		const elapsed = performance.now() - start;
+		// Should complete quickly (not allocate millions of lines)
+		expect(elapsed).toBeLessThan(2000);
+		expect(result).toContain("world");
+	});
+
+	it("should return raw input when TerminalTextRender throws", () => {
+		// We can't easily make TerminalTextRender throw, but we can verify the
+		// function doesn't throw for edge cases that might break the renderer
+		const weirdInput = "\x1b[999999999999;999999999999H";
+		expect(() => renderTerminalOutput(weirdInput)).not.toThrow();
+	});
+});
+
+describe("sanitizeCursorPositioning", () => {
+	it("should cap large row values in CUP sequences", () => {
+		const input = "\x1b[9999999;1H";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[5000;1H");
+	});
+
+	it("should cap large column values in CUP sequences", () => {
+		const input = "\x1b[1;9999999H";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[1;5000H");
+	});
+
+	it("should cap both row and column values", () => {
+		const input = "\x1b[9999999;9999999H";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[5000;5000H");
+	});
+
+	it("should not modify values within the cap", () => {
+		const input = "\x1b[25;80H";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[25;80H");
+	});
+
+	it("should cap cursor movement sequences (CUU/CUD/CUF/CUB)", () => {
+		expect(sanitizeCursorPositioning("\x1b[9999999A")).toBe("\x1b[5000A");
+		expect(sanitizeCursorPositioning("\x1b[9999999B")).toBe("\x1b[5000B");
+		expect(sanitizeCursorPositioning("\x1b[9999999C")).toBe("\x1b[5000C");
+		expect(sanitizeCursorPositioning("\x1b[9999999D")).toBe("\x1b[5000D");
+	});
+
+	it("should cap VPA and HPA sequences", () => {
+		expect(sanitizeCursorPositioning("\x1b[9999999d")).toBe("\x1b[5000d");
+		expect(sanitizeCursorPositioning("\x1b[9999999G")).toBe("\x1b[5000G");
+	});
+
+	it("should handle the lowercase f variant of CUP", () => {
+		const input = "\x1b[9999999;1f";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[5000;1f");
+	});
+
+	it("should leave non-cursor sequences untouched", () => {
+		// Color code
+		const input = "\x1b[31mhello\x1b[0m";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe(input);
+	});
+
+	it("should handle input with no ANSI sequences", () => {
+		const input = "plain text";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe(input);
+	});
+
+	it("should preserve empty params (defaults)", () => {
+		// ESC[H means cursor to home (1,1) — empty params
+		const input = "\x1b[H";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[H");
+	});
+
+	it("should handle multiple sequences in one string", () => {
+		const input = "text\x1b[9999999;1Hmore\x1b[9999999A";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("text\x1b[5000;1Hmore\x1b[5000A");
 	});
 });

--- a/packages/coding-agent/test/terminal-render.test.ts
+++ b/packages/coding-agent/test/terminal-render.test.ts
@@ -226,4 +226,80 @@ describe("sanitizeCursorPositioning", () => {
 		const result = sanitizeCursorPositioning(input);
 		expect(result).toBe("\x1b[1;5000r");
 	});
+
+	it("should clamp accumulated cursor-down sequences to MAX_CURSOR_POSITION", () => {
+		// Three sequences of 2000 each = 6000 total, but should be clamped to 5000
+		const input = "\x1b[2000B\x1b[2000B\x1b[2000B";
+		const result = sanitizeCursorPositioning(input);
+		// First: 2000 allowed (cursor at 2000)
+		// Second: 2000 allowed (cursor at 4000)
+		// Third: only 1000 allowed (cursor would exceed 5000)
+		expect(result).toBe("\x1b[2000B\x1b[2000B\x1b[1000B");
+	});
+
+	it("should clamp accumulated cursor-forward sequences to MAX_CURSOR_POSITION", () => {
+		const input = "\x1b[3000C\x1b[3000C";
+		const result = sanitizeCursorPositioning(input);
+		// First: 3000 allowed (cursor at 3000)
+		// Second: only 2000 allowed (5000 - 3000)
+		expect(result).toBe("\x1b[3000C\x1b[2000C");
+	});
+
+	it("should allow cursor re-use after moving up", () => {
+		// Move down 3000, then up 2000, then down — should have 4000 available
+		const input = "\x1b[3000B\x1b[2000A\x1b[4000B";
+		const result = sanitizeCursorPositioning(input);
+		// After first: cursorRow=3000
+		// After second: cursorRow=1000
+		// Third: allowed=5000-1000=4000, clamped=min(4000,4000)=4000
+		expect(result).toBe("\x1b[3000B\x1b[2000A\x1b[4000B");
+	});
+
+	it("should track absolute positioning for accumulation limits", () => {
+		// Absolute position to row 4000, then cursor down
+		const input = "\x1b[4000;1H\x1b[2000B";
+		const result = sanitizeCursorPositioning(input);
+		// After H: cursorRow=4000
+		// Cursor down 2000: allowed=5000-4000=1000, clamped=1000
+		expect(result).toBe("\x1b[4000;1H\x1b[1000B");
+	});
+
+	it("should prevent cursor accumulation from many repeated sequences", () => {
+		// Attack vector: 11000 sequences of ESC[5000B each pass per-sequence cap
+		// but would accumulate to row ~55M without cumulative tracking
+		const malicious = "\x1b[5000B".repeat(11000);
+		const result = sanitizeCursorPositioning(malicious);
+		// First sequence moves to 5000, all remaining are clamped to 0
+		expect(result.startsWith("\x1b[5000B")).toBe(true);
+		expect(result).toContain("\x1b[0B");
+		// Total should be 11000 sequences (none stripped, just clamped)
+		expect(result.split("\x1b[").length - 1).toBe(11000);
+	});
+});
+
+describe("renderTerminalOutput — cursor accumulation security", () => {
+	it("should survive repeated cursor-down attack without OOM or timeout", () => {
+		// ~11000 sequences of ESC[5000B in ~100KB of input
+		// Without the fix, this triggers ensureLine(55M) → ~1.3GB allocation → OOM
+		const malicious = "\x1b[5000B".repeat(11000);
+		const input = `start${malicious}end`;
+		const start = performance.now();
+		const result = renderTerminalOutput(input);
+		const elapsed = performance.now() - start;
+		// Must complete quickly — OOM or multi-second hang means the fix failed
+		expect(elapsed).toBeLessThan(2000);
+		expect(result).toContain("start");
+		expect(result).toContain("end");
+	});
+
+	it("should survive repeated cursor-forward attack without OOM or timeout", () => {
+		const malicious = "\x1b[5000C".repeat(11000);
+		const input = `start${malicious}end`;
+		const start = performance.now();
+		const result = renderTerminalOutput(input);
+		const elapsed = performance.now() - start;
+		expect(elapsed).toBeLessThan(2000);
+		expect(result).toContain("start");
+		expect(result).toContain("end");
+	});
 });

--- a/packages/coding-agent/test/terminal-render.test.ts
+++ b/packages/coding-agent/test/terminal-render.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { renderTerminalOutput } from "../src/core/tools/terminal-render.js";
+
+describe("renderTerminalOutput", () => {
+	it("should collapse \\r-based progress bar to final state", () => {
+		const input = "Progress: 0%\rProgress: 50%\rProgress: 100%";
+		const result = renderTerminalOutput(input);
+		expect(result).toBe("Progress: 100%");
+	});
+
+	it("should handle \\r overwrites with newlines between sections", () => {
+		const input = "Starting download...\nProgress: 0%\rProgress: 50%\rProgress: 100%\nDone!";
+		const result = renderTerminalOutput(input);
+		expect(result).toBe("Starting download...\nProgress: 100%\nDone!");
+	});
+
+	it("should handle multiple progress bars on separate lines", () => {
+		const input = ["File 1: 0%\rFile 1: 100%", "File 2: 0%\rFile 2: 100%"].join("\n");
+		const result = renderTerminalOutput(input);
+		expect(result).toContain("File 1: 100%");
+		expect(result).toContain("File 2: 100%");
+		// The intermediate "0%" states should be overwritten — only "100%" remains
+		expect(result).not.toContain("File 1: 0%");
+		expect(result).not.toContain("File 2: 0%");
+	});
+
+	it("should handle backspace", () => {
+		// "abc" then backspace twice, then "d" → overwrites 'b' with 'd'
+		const input = "abc\b\bd";
+		const result = renderTerminalOutput(input);
+		expect(result).toBe("adc");
+	});
+
+	it("should handle ANSI cursor-up and overwrite", () => {
+		// Write two lines, cursor up one, overwrite
+		const input = "Line 1\nLine 2\x1b[AOverwritten";
+		const result = renderTerminalOutput(input);
+		expect(result).toContain("Overwritten");
+		expect(result).toContain("Line 2");
+	});
+
+	it("should handle ANSI erase-line sequence", () => {
+		const input = "Old content\x1b[2KNew content";
+		const result = renderTerminalOutput(input);
+		expect(result).toContain("New content");
+		expect(result).not.toContain("Old content");
+	});
+
+	it("should pass through normal text unchanged", () => {
+		const input = "Hello, world!\nThis is a test.\nLine 3.";
+		const result = renderTerminalOutput(input);
+		expect(result).toBe(input);
+	});
+
+	it("should handle empty input", () => {
+		expect(renderTerminalOutput("")).toBe("");
+	});
+
+	it("should strip ANSI color codes while preserving text", () => {
+		// Red "error" then reset
+		const input = "\x1b[31merror\x1b[0m: something failed";
+		const result = renderTerminalOutput(input);
+		expect(result).toBe("error: something failed");
+	});
+
+	it("should handle \\r\\n line endings (Windows-style) correctly", () => {
+		const input = "Line 1\r\nLine 2\r\nLine 3";
+		const result = renderTerminalOutput(input);
+		expect(result).toContain("Line 1");
+		expect(result).toContain("Line 2");
+		expect(result).toContain("Line 3");
+	});
+
+	it("should handle a realistic npm install progress pattern", () => {
+		// npm-style progress: repeated \r overwrites on the same line
+		const lines = [];
+		for (let i = 0; i <= 100; i += 10) {
+			lines.push(`\rDownloading packages... ${i}%`);
+		}
+		const input = lines.join("");
+		const result = renderTerminalOutput(input);
+		expect(result).toBe("Downloading packages... 100%");
+		// Intermediate states should be overwritten
+		expect(result).not.toContain("Downloading packages... 0%");
+		expect(result).not.toContain("Downloading packages... 50%");
+	});
+
+	it("should handle large output efficiently", () => {
+		// 2000 lines of normal text should process quickly
+		const lines = Array.from({ length: 2000 }, (_, i) => `Line ${i + 1}: some content here`);
+		const input = lines.join("\n");
+		const start = performance.now();
+		const result = renderTerminalOutput(input);
+		const elapsed = performance.now() - start;
+		expect(result).toBe(input);
+		expect(elapsed).toBeLessThan(1000); // Should complete well under 1 second
+	});
+
+	it("should handle tab characters", () => {
+		const input = "col1\tcol2\tcol3";
+		const result = renderTerminalOutput(input);
+		// Tabs are expanded to tab stops (8-char boundaries)
+		expect(result).toContain("col1");
+		expect(result).toContain("col2");
+		expect(result).toContain("col3");
+	});
+
+	it("should handle clear-screen sequence", () => {
+		const input = "old text\x1b[2Jnew text";
+		const result = renderTerminalOutput(input);
+		expect(result).toContain("new text");
+		expect(result).not.toContain("old text");
+	});
+});

--- a/packages/coding-agent/test/terminal-render.test.ts
+++ b/packages/coding-agent/test/terminal-render.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderTerminalOutput, sanitizeCursorPositioning } from "../src/core/tools/terminal-render.js";
 
 describe("renderTerminalOutput", () => {
@@ -123,11 +123,26 @@ describe("renderTerminalOutput", () => {
 		expect(result).toContain("world");
 	});
 
-	it("should return raw input when TerminalTextRender throws", () => {
-		// We can't easily make TerminalTextRender throw, but we can verify the
-		// function doesn't throw for edge cases that might break the renderer
-		const weirdInput = "\x1b[999999999999;999999999999H";
-		expect(() => renderTerminalOutput(weirdInput)).not.toThrow();
+	it("should return raw input when TerminalTextRender throws", async () => {
+		// Use vi.doMock (not hoisted) + dynamic import to avoid breaking other tests
+		vi.doMock("terminal-render", () => ({
+			TerminalTextRender: vi.fn().mockImplementation(() => ({
+				write: vi.fn(),
+				render: vi.fn(() => {
+					throw new Error("Mock render failure");
+				}),
+			})),
+		}));
+
+		vi.resetModules();
+		const { renderTerminalOutput: mockedRender } = await import("../src/core/tools/terminal-render.js");
+
+		const input = "test input with \x1b[31mcolor\x1b[0m";
+		const result = mockedRender(input);
+		expect(result).toBe(input); // Should return raw input on error
+
+		vi.doUnmock("terminal-render");
+		vi.resetModules();
 	});
 });
 
@@ -198,5 +213,17 @@ describe("sanitizeCursorPositioning", () => {
 		const input = "text\x1b[9999999;1Hmore\x1b[9999999A";
 		const result = sanitizeCursorPositioning(input);
 		expect(result).toBe("text\x1b[5000;1Hmore\x1b[5000A");
+	});
+
+	it("should cap large row values in CNL sequences", () => {
+		const input = "\x1b[9999999E";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[5000E");
+	});
+
+	it("should cap scroll region bottom values", () => {
+		const input = "\x1b[1;9999999r";
+		const result = sanitizeCursorPositioning(input);
+		expect(result).toBe("\x1b[1;5000r");
 	});
 });

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -345,6 +345,26 @@ describe("Coding Agent Tools", () => {
 			expect(result.exitCode).toBe(0);
 			expect(result.output).toBe("red\n");
 		});
+
+		it("should collapse \\r-based progress output to final state", async () => {
+			// Simulate a progress bar: \r overwrites on the same line, then a final newline
+			const result = await bashTool.execute("test-terminal-render", {
+				command: "printf 'Progress: 0%%\\rProgress: 50%%\\rProgress: 100%%\\n'",
+			});
+			const output = getTextOutput(result).trim();
+			expect(output).toBe("Progress: 100%");
+			// Intermediate states should be overwritten by \r
+			expect(output).not.toContain("Progress: 0%");
+			expect(output).not.toContain("Progress: 50%");
+		});
+
+		it("should render ANSI color codes out of tool result", async () => {
+			const result = await bashTool.execute("test-terminal-render-ansi", {
+				command: "printf '\\033[31merror\\033[0m: failed\\n'",
+			});
+			const output = getTextOutput(result).trim();
+			expect(output).toBe("error: failed");
+		});
 	});
 
 	describe("grep tool", () => {

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -358,6 +358,27 @@ describe("Coding Agent Tools", () => {
 			expect(output).not.toContain("Progress: 50%");
 		});
 
+		it("should render terminal output in streaming updates", async () => {
+			const updates: any[] = [];
+			const onUpdate = (update: any) => updates.push(update);
+
+			await bashTool.execute(
+				"test-streaming-render",
+				{
+					command: "printf 'Progress: 0%%\\rProgress: 100%%\\n'",
+				},
+				undefined,
+				onUpdate,
+			);
+
+			// Should have received at least one update with rendered content
+			expect(updates.length).toBeGreaterThan(0);
+			const finalUpdate = updates[updates.length - 1];
+			const text = getTextOutput(finalUpdate).trim();
+			expect(text).toBe("Progress: 100%");
+			expect(text).not.toContain("Progress: 0%");
+		});
+
 		it("should render ANSI color codes out of tool result", async () => {
 			const result = await bashTool.execute("test-terminal-render-ansi", {
 				command: "printf '\\033[31merror\\033[0m: failed\\n'",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #114

Use the `terminal-render` library to process raw bash tool output through proper terminal emulation before it enters the LLM context. This collapses progress bars, handles `\r` overwrites, and renders ANSI cursor movement — producing the clean text a human would actually see on screen.

Implementation plan posted as a comment below.