### PR TITLE
Remove default keybindings for model switching shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8703,7 +8703,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8732,7 +8732,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8788,7 +8788,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8903,7 +8903,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8951,7 +8951,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8983,7 +8983,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -83,7 +83,7 @@ npm link -w packages/coding-agent
 
 ## Providers & Models
 
-For each built-in provider, dreb maintains a list of tool-capable models, updated with every release. Authenticate via subscription (`/login`) or API key, then select any model from that provider via `/model` (or Ctrl+L).
+For each built-in provider, dreb maintains a list of tool-capable models, updated with every release. Authenticate via subscription (`/login`) or API key, then select any model from that provider via `/model`.
 
 **Subscriptions:**
 - OpenAI ChatGPT Plus/Pro (Codex)
@@ -151,7 +151,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 |---------|-------------|
 | `/login`, `/logout` | OAuth authentication |
 | `/model` | Switch models |
-| `/scoped-models` | Enable/disable models for Ctrl+P cycling |
+| `/scoped-models` | Enable/disable models for cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
@@ -180,8 +180,7 @@ See `/hotkeys` for the full list. Customize via `~/.dreb/agent/keybindings.json`
 | Ctrl+C twice | Quit |
 | Escape | Cancel/abort |
 | Escape twice | Open `/tree` |
-| Ctrl+L | Open model selector |
-| Ctrl+P / Shift+Ctrl+P | Cycle scoped models forward/backward |
+
 | Shift+Tab | Cycle thinking level |
 | Ctrl+O | Collapse/expand tool output |
 | Ctrl+T | Collapse/expand thinking blocks |
@@ -543,7 +542,7 @@ cat README.md | dreb -p "Summarize this text"
 | `--model <pattern>` | Model pattern or ID (supports `provider/id` and optional `:<thinking>`) |
 | `--api-key <key>` | API key (overrides env vars) |
 | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
-| `--models <patterns>` | Comma-separated patterns for Ctrl+P cycling |
+| `--models <patterns>` | Comma-separated patterns for model cycling |
 | `--list-models [search]` | List available models |
 
 ### Session Options

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -275,7 +275,7 @@ user sends another prompt ◄─────────────────
   ├─► session_before_tree (can cancel or customize)
   └─► session_tree
 
-/model or Ctrl+P (model selection/cycling)
+/model (model selection/cycling)
   └─► model_select
 
 exit (Ctrl+C, Ctrl+D)
@@ -536,7 +536,7 @@ This is mainly useful for debugging provider serialization and cache behavior.
 
 #### model_select
 
-Fired when the model changes via `/model` command, model cycling (`Ctrl+P`), or session restore.
+Fired when the model changes via `/model` command, model cycling, or session restore.
 
 ```typescript
 dreb.on("model_select", async (event, ctx) => {

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -109,9 +109,9 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 
 | Keybinding id | Default | Description |
 |--------|---------|-------------|
-| `app.model.select` | `ctrl+l` | Open model selector |
-| `app.model.cycleForward` | `ctrl+p` | Cycle to next model |
-| `app.model.cycleBackward` | `shift+ctrl+p` | Cycle to previous model |
+| `app.model.select` | *(none)* | Open model selector |
+| `app.model.cycleForward` | *(none)* | Cycle to next model |
+| `app.model.cycleBackward` | *(none)* | Cycle to previous model |
 | `app.thinking.cycle` | `shift+tab` | Cycle thinking level |
 | `app.thinking.toggle` | `ctrl+t` | Collapse or expand thinking blocks |
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -304,7 +304,7 @@ const { session } = await createAgentSession({
   model: opus,
   thinkingLevel: "medium", // off, minimal, low, medium, high, xhigh
   
-  // Models for cycling (Ctrl+P in interactive mode)
+  // Models for cycling (bindable via keybindings.json)
   scopedModels: [
     { model: opus, thinkingLevel: "high" },
     { model: haiku, thinkingLevel: "off" },

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -144,7 +144,7 @@ When multiple sources specify a session directory, `--session-dir` CLI flag take
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `enabledModels` | string[] | - | Model patterns for Ctrl+P cycling (same format as `--models` CLI flag) |
+| `enabledModels` | string[] | - | Model patterns for cycling (same format as `--models` CLI flag) |
 
 ```json
 {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -57,14 +57,14 @@ export const KEYBINDINGS = {
 		description: "Cycle thinking level",
 	},
 	"app.model.cycleForward": {
-		defaultKeys: "ctrl+p",
+		defaultKeys: [],
 		description: "Cycle to next model",
 	},
 	"app.model.cycleBackward": {
-		defaultKeys: "shift+ctrl+p",
+		defaultKeys: [],
 		description: "Cycle to previous model",
 	},
-	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
+	"app.model.select": { defaultKeys: [], description: "Open model selector" },
 	"app.tools.expand": { defaultKeys: "ctrl+o", description: "Toggle tool output" },
 	"app.thinking.toggle": {
 		defaultKeys: "ctrl+t",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -482,8 +482,15 @@ export class InteractiveMode {
 				hint("app.suspend", "to suspend"),
 				keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
 				hint("app.thinking.cycle", "to cycle thinking level"),
-				rawKeyHint(`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`, "to cycle models"),
-				hint("app.model.select", "to select model"),
+				...(keyText("app.model.cycleForward") || keyText("app.model.cycleBackward")
+					? [
+							rawKeyHint(
+								`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`,
+								"to cycle models",
+							),
+						]
+					: []),
+				...(keyText("app.model.select") ? [hint("app.model.select", "to select model")] : []),
 				hint("app.tools.expand", "to expand tools"),
 				hint("app.thinking.toggle", "to expand thinking"),
 				hint("app.editor.external", "for external editor"),
@@ -4381,9 +4388,7 @@ export class InteractiveMode {
 | \`${exit}\` | Exit (when editor is empty) |
 | \`${suspend}\` | Suspend to background |
 | \`${cycleThinkingLevel}\` | Cycle thinking level |
-| \`${cycleModelForward}\` / \`${cycleModelBackward}\` | Cycle models |
-| \`${selectModel}\` | Open model selector |
-| \`${expandTools}\` | Toggle tool output expansion |
+${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cycleModelBackward}\` | Cycle models |\n` : ""}${selectModel ? `| \`${selectModel}\` | Open model selector |\n` : ""}| \`${expandTools}\` | Toggle tool output expansion |
 | \`${toggleThinking}\` | Toggle thinking block visibility |
 | \`${externalEditor}\` | Edit message in external editor |
 | \`${followUp}\` | Queue follow-up message |

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #144

Remove default key bindings for `app.model.cycleForward`, `app.model.cycleBackward`, and `app.model.select` to prevent accidental model switches. The actions remain available for users to bind manually via `keybindings.json`.

Implementation plan posted as a comment below.