### PR TITLE
Fix model resolution: third-party endpoints, fallback visibility, Telegram parity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8703,7 +8703,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8732,7 +8732,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8788,7 +8788,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8903,7 +8903,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8951,7 +8951,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8983,7 +8983,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -519,6 +519,20 @@ function isOAuthToken(apiKey: string): boolean {
 	return apiKey.includes("sk-ant-oat");
 }
 
+/**
+ * Check if a base URL points to a first-party Anthropic API endpoint.
+ * Third-party Anthropic-compatible endpoints (e.g. kimi-coding) should not
+ * receive Anthropic-specific beta headers or SDK flags.
+ */
+function isFirstPartyAnthropic(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return url.hostname === "api.anthropic.com" || url.hostname.endsWith(".api.anthropic.com");
+	} catch {
+		return false;
+	}
+}
+
 function createClient(
 	model: Model<"anthropic-messages">,
 	apiKey: string,
@@ -529,6 +543,7 @@ function createClient(
 	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
 	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
 	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id);
+	const firstParty = isFirstPartyAnthropic(model.baseUrl);
 
 	// Copilot: Bearer auth, selective betas (no fine-grained-tool-streaming)
 	if (model.provider === "github-copilot") {
@@ -545,11 +560,28 @@ function createClient(
 			defaultHeaders: mergeHeaders(
 				{
 					accept: "application/json",
-					"anthropic-dangerous-direct-browser-access": "true",
+					...(firstParty ? { "anthropic-dangerous-direct-browser-access": "true" } : {}),
 					...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
 				},
 				model.headers,
 				dynamicHeaders,
+				optionsHeaders,
+			),
+		});
+
+		return { client, isOAuthToken: false };
+	}
+
+	// Third-party Anthropic-compatible endpoints: minimal headers, no Anthropic-specific features
+	if (!firstParty) {
+		const client = new Anthropic({
+			apiKey,
+			baseURL: model.baseUrl,
+			defaultHeaders: mergeHeaders(
+				{
+					accept: "application/json",
+				},
+				model.headers,
 				optionsHeaders,
 			),
 		});
@@ -585,7 +617,7 @@ function createClient(
 		return { client, isOAuthToken: true };
 	}
 
-	// API key auth
+	// API key auth (first-party Anthropic)
 	const client = new Anthropic({
 		apiKey,
 		baseURL: model.baseUrl,

--- a/packages/ai/test/oauth.ts
+++ b/packages/ai/test/oauth.ts
@@ -75,7 +75,14 @@ export async function resolveApiKey(provider: string): Promise<string | undefine
 			}
 		}
 
-		const result = await getOAuthApiKey(provider as OAuthProvider, oauthCredentials);
+		let result: Awaited<ReturnType<typeof getOAuthApiKey>> | undefined;
+		try {
+			result = await getOAuthApiKey(provider as OAuthProvider, oauthCredentials);
+		} catch {
+			// Provider not registered as OAuth (e.g. "anthropic" with an OAuth entry
+			// in auth.json but no OAuth handler registered in the test environment)
+			return undefined;
+		}
 		if (!result) return undefined;
 
 		// Save refreshed credentials back to auth.json

--- a/packages/ai/test/third-party-anthropic.test.ts
+++ b/packages/ai/test/third-party-anthropic.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+	constructorOpts: undefined as Record<string, unknown> | undefined,
+	streamParams: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	const fakeStream = {
+		async *[Symbol.asyncIterator]() {
+			yield {
+				type: "message_start",
+				message: {
+					usage: { input_tokens: 10, output_tokens: 0 },
+				},
+			};
+			yield {
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 5 },
+			};
+		},
+		finalMessage: async () => ({
+			usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+		}),
+	};
+
+	class FakeAnthropic {
+		constructor(opts: Record<string, unknown>) {
+			mockState.constructorOpts = opts;
+		}
+		messages = {
+			stream: (params: Record<string, unknown>) => {
+				mockState.streamParams = params;
+				return fakeStream;
+			},
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+describe("Third-party Anthropic-compatible endpoints", () => {
+	const context = {
+		systemPrompt: "You are a helpful assistant.",
+		messages: [{ role: "user" as const, content: "Hello", timestamp: Date.now() }],
+	};
+
+	it("sends minimal headers for third-party endpoints (no beta headers, no dangerouslyAllowBrowser)", async () => {
+		const { getModel } = await import("../src/models.js");
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+
+		const model = getModel("kimi-coding", "k2p5");
+		expect(model).toBeDefined();
+		expect(model?.api).toBe("anthropic-messages");
+		expect(model?.baseUrl).not.toContain("anthropic.com");
+
+		const s = streamAnthropic(model!, context, { apiKey: "test-kimi-key" });
+		for await (const event of s) {
+			if (event.type === "error") break;
+		}
+
+		const opts = mockState.constructorOpts!;
+		expect(opts).toBeDefined();
+
+		// Should use the API key directly (not Bearer/OAuth)
+		expect(opts.apiKey).toBe("test-kimi-key");
+		expect(opts.authToken).toBeUndefined();
+
+		// Should NOT have dangerouslyAllowBrowser
+		expect(opts.dangerouslyAllowBrowser).toBeUndefined();
+
+		// Headers should be minimal — no Anthropic-specific beta headers
+		const headers = opts.defaultHeaders as Record<string, string>;
+		expect(headers.accept).toBe("application/json");
+		expect(headers["anthropic-beta"]).toBeUndefined();
+		expect(headers["anthropic-dangerous-direct-browser-access"]).toBeUndefined();
+	});
+
+	it("includes beta headers and dangerouslyAllowBrowser for first-party Anthropic endpoints", async () => {
+		const { getModel } = await import("../src/models.js");
+		const { streamAnthropic } = await import("../src/providers/anthropic.js");
+
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		expect(model).toBeDefined();
+
+		const s = streamAnthropic(model!, context, { apiKey: "sk-test-key" });
+		for await (const event of s) {
+			if (event.type === "error") break;
+		}
+
+		const opts = mockState.constructorOpts!;
+		expect(opts).toBeDefined();
+
+		// First-party should have dangerouslyAllowBrowser
+		expect(opts.dangerouslyAllowBrowser).toBe(true);
+
+		// Should have beta headers
+		const headers = opts.defaultHeaders as Record<string, string>;
+		expect(headers["anthropic-beta"]).toContain("fine-grained-tool-streaming");
+		expect(headers["anthropic-dangerous-direct-browser-access"]).toBe("true");
+	});
+});

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -108,6 +108,24 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 	return findModelInList(modelPattern, availableModels);
 }
 
+/**
+ * Resolve a model pattern against available models.
+ * Shared by TUI, CLI, and RPC/Telgram resolution paths.
+ *
+ * Handles: exact matches, provider/model references, fuzzy matching,
+ * and thinking level parsing (e.g. "sonnet:high").
+ *
+ * Returns the resolved model and optional thinking level/warning.
+ * Returns undefined model if no match found.
+ */
+export function resolveModelPattern(
+	pattern: string,
+	availableModels: Model<Api>[],
+	options?: { allowInvalidThinkingLevelFallback?: boolean },
+): ParsedModelResult {
+	return parseModelPattern(pattern, availableModels, options);
+}
+
 export interface ParsedModelResult {
 	model: Model<Api> | undefined;
 	/** Thinking level if explicitly specified in pattern, undefined otherwise */

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -110,7 +110,7 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 
 /**
  * Resolve a model pattern against available models.
- * Shared by TUI, CLI, and RPC/Telgram resolution paths.
+ * Shared by TUI, CLI, and RPC/Telegram resolution paths.
  *
  * Handles: exact matches, provider/model references, fuzzy matching,
  * and thinking level parsing (e.g. "sonnet:high").

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -108,24 +108,6 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 	return findModelInList(modelPattern, availableModels);
 }
 
-/**
- * Resolve a model pattern against available models.
- * Shared by TUI, CLI, and RPC/Telegram resolution paths.
- *
- * Handles: exact matches, provider/model references, fuzzy matching,
- * and thinking level parsing (e.g. "sonnet:high").
- *
- * Returns the resolved model and optional thinking level/warning.
- * Returns undefined model if no match found.
- */
-export function resolveModelPattern(
-	pattern: string,
-	availableModels: Model<Api>[],
-	options?: { allowInvalidThinkingLevelFallback?: boolean },
-): ParsedModelResult {
-	return parseModelPattern(pattern, availableModels, options);
-}
-
 export interface ParsedModelResult {
 	model: Model<Api> | undefined;
 	/** Thinking level if explicitly specified in pattern, undefined otherwise */

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -207,11 +207,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// If session has data, try to restore model from it
 	if (!model && hasExistingSession && existingSession.model) {
 		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
-		if (restoredModel && (await modelRegistry.getApiKey(restoredModel))) {
+		const hasApiKey = restoredModel ? !!(await modelRegistry.getApiKey(restoredModel)) : false;
+		if (restoredModel && hasApiKey) {
 			model = restoredModel;
 		}
 		if (!model) {
-			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+			const reason = !restoredModel ? "not found in registry" : "no API key available";
+			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId} (${reason})`;
+			console.warn(`[model-restore] ${modelFallbackMessage}`);
 		}
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -877,7 +877,7 @@ export async function main(args: string[]) {
 
 	if (mode === "rpc") {
 		printTimings();
-		await runRpcMode(session);
+		await runRpcMode(session, modelFallbackMessage);
 	} else if (isInteractive) {
 		if (scopedModels.length > 0 && (parsed.verbose || !settingsManager.getQuietStartup())) {
 			const modelList = scopedModels

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -253,6 +253,16 @@ export class RpcClient {
 	}
 
 	/**
+	 * Resolve a model pattern using the same logic as CLI/TUI.
+	 * Runs server-side so API keys never leave the process.
+	 * Returns null if no match found.
+	 */
+	async resolveModel(pattern: string): Promise<{ model: ModelInfo; warning?: string } | null> {
+		const response = await this.send({ type: "resolve_model", pattern });
+		return this.getData<{ model: ModelInfo; warning?: string } | null>(response);
+	}
+
+	/**
 	 * Hatch a new buddy companion. Runs inside the agent process
 	 * so API keys never leave the process boundary.
 	 */

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -19,6 +19,7 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
+import { resolveModelPattern } from "../../core/model-resolver.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { SessionManager } from "../../core/session-manager.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
@@ -46,7 +47,7 @@ export type {
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
  */
-export async function runRpcMode(session: AgentSession): Promise<never> {
+export async function runRpcMode(session: AgentSession, modelFallbackMessage?: string): Promise<never> {
 	takeOverStdout();
 
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
@@ -387,6 +388,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 					autoCompactionEnabled: session.autoCompactionEnabled,
 					messageCount: session.messages.length,
 					pendingMessageCount: session.pendingMessageCount,
+					modelFallbackMessage,
 				};
 				return success(id, "get_state", state);
 			}
@@ -403,6 +405,19 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				}
 				await session.setModel(model);
 				return success(id, "set_model", model);
+			}
+
+			case "resolve_model": {
+				session.modelRegistry.refresh();
+				const models = await session.modelRegistry.getAvailable();
+				const result = resolveModelPattern(command.pattern, models);
+				if (!result.model) {
+					return success(id, "resolve_model", null);
+				}
+				return success(id, "resolve_model", {
+					model: result.model,
+					warning: result.warning,
+				});
 			}
 
 			case "cycle_model": {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -19,7 +19,7 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../core/extensions/index.js";
-import { resolveModelPattern } from "../../core/model-resolver.js";
+import { parseModelPattern } from "../../core/model-resolver.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import { SessionManager } from "../../core/session-manager.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
@@ -410,7 +410,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			case "resolve_model": {
 				session.modelRegistry.refresh();
 				const models = await session.modelRegistry.getAvailable();
-				const result = resolveModelPattern(command.pattern, models);
+				const result = parseModelPattern(command.pattern, models);
 				if (!result.model) {
 					return success(id, "resolve_model", null);
 				}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -29,6 +29,7 @@ export type RpcCommand =
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
+	| { id?: string; type: "resolve_model"; pattern: string }
 	| { id?: string; type: "cycle_model" }
 	| { id?: string; type: "get_available_models" }
 
@@ -110,6 +111,9 @@ export interface RpcSessionState {
 	autoCompactionEnabled: boolean;
 	messageCount: number;
 	pendingMessageCount: number;
+	/** Non-empty when the model was changed from the user's saved preference
+	 *  (e.g. saved model unavailable after restart). */
+	modelFallbackMessage?: string;
 }
 
 // ============================================================================
@@ -135,6 +139,13 @@ export type RpcResponse =
 			command: "set_model";
 			success: true;
 			data: Model<any>;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "resolve_model";
+			success: true;
+			data: { model: Model<any>; warning?: string } | null;
 	  }
 	| {
 			id?: string;

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -42,6 +42,7 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_OAUTH_T
 		expect(state.model?.id).toBe("claude-sonnet-4-5");
 		expect(state.isStreaming).toBe(false);
 		expect(state.messageCount).toBe(0);
+		expect(state.modelFallbackMessage).toBeUndefined();
 	}, 30000);
 
 	test("should save messages to session file", async () => {

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -318,4 +318,18 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_OAUTH_T
 		expect(sessionInfoEntries.length).toBe(1);
 		expect(sessionInfoEntries[0].name).toBe("my-test-session");
 	}, 60000);
+
+	test("should resolve model patterns via resolve_model command", async () => {
+		await client.start();
+
+		// Exact model match
+		const result = await client.resolveModel("claude-sonnet-4-5");
+		expect(result).not.toBeNull();
+		expect(result!.model.provider).toBe("anthropic");
+		expect(result!.model.id).toBe("claude-sonnet-4-5");
+
+		// Non-existent model returns null
+		const noMatch = await client.resolveModel("nonexistent-model-xyz-12345");
+		expect(noMatch).toBeNull();
+	}, 30000);
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/telegram/src/agent-bridge.ts
+++ b/packages/telegram/src/agent-bridge.ts
@@ -303,6 +303,19 @@ export class AgentBridge {
 	}
 
 	/**
+	 * Resolve a model pattern using the same logic as CLI/TUI.
+	 */
+	async resolveModel(pattern: string): Promise<{ model: any; warning?: string } | null> {
+		if (!this.client) return null;
+		try {
+			return await this.client.resolveModel(pattern);
+		} catch (e) {
+			this.handleProcessError(e);
+			throw e;
+		}
+	}
+
+	/**
 	 * Set thinking level.
 	 */
 	async setThinkingLevel(level: string): Promise<void> {

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -88,6 +88,12 @@ export function createBot(config: Config): Bot {
 			return;
 		}
 
+		// Surface model fallback warning (e.g. saved model unavailable after restart)
+		if (userState.pendingModelFallbackWarning) {
+			await safeSend(ctx.api, ctx.chat!.id, `⚠️ _${userState.pendingModelFallbackWarning}_`);
+			userState.pendingModelFallbackWarning = undefined;
+		}
+
 		sendPrompt(ctx.api, userState, {
 			chatId: ctx.chat!.id,
 			replyToId: ctx.message.message_id,
@@ -109,6 +115,12 @@ export function createBot(config: Config): Bot {
 			log(`[FILE] Bridge setup failed: ${e}`);
 			await safeSend(ctx.api, ctx.chat!.id, `❌ Failed to start agent: ${e}`);
 			return;
+		}
+
+		// Surface model fallback warning (e.g. saved model unavailable after restart)
+		if (userState.pendingModelFallbackWarning) {
+			await safeSend(ctx.api, ctx.chat!.id, `⚠️ _${userState.pendingModelFallbackWarning}_`);
+			userState.pendingModelFallbackWarning = undefined;
 		}
 
 		await handleFile(ctx, ctx.api, boundGetUserState);

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -11,6 +11,14 @@ import { sendPrompt } from "./handlers/message.js";
 import type { UserState } from "./types.js";
 import { log, safeDelete, safeSend } from "./util/telegram.js";
 
+/** Flush any pending model fallback warning to the user (shown once after bridge restart) */
+async function flushPendingWarning(api: Bot["api"], chatId: number, userState: UserState): Promise<void> {
+	if (userState.pendingModelFallbackWarning) {
+		await safeSend(api, chatId, `⚠️ _${userState.pendingModelFallbackWarning}_`);
+		userState.pendingModelFallbackWarning = undefined;
+	}
+}
+
 /** Per-user state store */
 const userStates = new Map<number, UserState>();
 
@@ -88,11 +96,7 @@ export function createBot(config: Config): Bot {
 			return;
 		}
 
-		// Surface model fallback warning (e.g. saved model unavailable after restart)
-		if (userState.pendingModelFallbackWarning) {
-			await safeSend(ctx.api, ctx.chat!.id, `⚠️ _${userState.pendingModelFallbackWarning}_`);
-			userState.pendingModelFallbackWarning = undefined;
-		}
+		await flushPendingWarning(ctx.api, ctx.chat!.id, userState);
 
 		sendPrompt(ctx.api, userState, {
 			chatId: ctx.chat!.id,
@@ -117,11 +121,7 @@ export function createBot(config: Config): Bot {
 			return;
 		}
 
-		// Surface model fallback warning (e.g. saved model unavailable after restart)
-		if (userState.pendingModelFallbackWarning) {
-			await safeSend(ctx.api, ctx.chat!.id, `⚠️ _${userState.pendingModelFallbackWarning}_`);
-			userState.pendingModelFallbackWarning = undefined;
-		}
+		await flushPendingWarning(ctx.api, ctx.chat!.id, userState);
 
 		await handleFile(ctx, ctx.api, boundGetUserState);
 	});

--- a/packages/telegram/src/bridge-lifecycle.ts
+++ b/packages/telegram/src/bridge-lifecycle.ts
@@ -67,7 +67,9 @@ export async function ensureBridgeWithSession(config: Config, userState: UserSta
 		return bridge;
 	}
 
+	const hadBridge = !!userState.bridge?.isAlive;
 	const bridge = await ensureBridge(config, userState);
+	const freshBridge = !hadBridge;
 
 	// Track effective cwd (default from config on first bridge creation)
 	if (!userState.effectiveCwd) {
@@ -77,6 +79,18 @@ export async function ensureBridgeWithSession(config: Config, userState: UserSta
 	// No session yet — try to resume latest
 	if (!bridge.sessionId) {
 		await bridge.resumeLatest();
+	}
+
+	// Check for model fallback warning on fresh bridge (e.g. after crash)
+	if (freshBridge) {
+		try {
+			const state = await bridge.getState();
+			if (state?.modelFallbackMessage) {
+				userState.pendingModelFallbackWarning = state.modelFallbackMessage;
+			}
+		} catch {
+			// Non-critical — the warning is best-effort
+		}
 	}
 
 	return bridge;

--- a/packages/telegram/src/commands/agent.ts
+++ b/packages/telegram/src/commands/agent.ts
@@ -115,24 +115,13 @@ export async function cmdModel(ctx: Context, userState: UserState, args: string)
 			return;
 		}
 
-		// Try to match and switch
-		const pattern = args.trim().toLowerCase();
-		const models = await bridge.getAvailableModels();
+		// Resolve pattern using the same logic as CLI/TUI
+		const pattern = args.trim();
+		const result = await bridge.resolveModel(pattern);
 
-		// Score matches: exact id > exact provider/id > substring
-		const scored = models
-			.map((m: any) => {
-				const id = m.id.toLowerCase();
-				const full = `${m.provider}/${m.id}`.toLowerCase();
-				if (id === pattern || full === pattern) return { model: m, score: 0 };
-				if (id.includes(pattern) || full.includes(pattern)) return { model: m, score: 1 };
-				return { model: m, score: -1 };
-			})
-			.filter((s) => s.score >= 0)
-			.sort((a, b) => a.score - b.score);
-
-		if (scored.length === 0) {
-			// Group models by provider for readable display
+		if (!result) {
+			// No match — list available models grouped by provider
+			const models = await bridge.getAvailableModels();
 			const byProvider = new Map<string, string[]>();
 			for (const m of models as any[]) {
 				const list = byProvider.get(m.provider) || [];
@@ -150,10 +139,10 @@ export async function cmdModel(ctx: Context, userState: UserState, args: string)
 			return;
 		}
 
-		// If multiple matches, prefer exact over substring
-		const match = scored[0].model;
-		await bridge.setModel((match as any).provider, (match as any).id);
-		await safeSend(ctx.api, chatId, `🧠 Switched to \`${(match as any).provider}/${(match as any).id}\``);
+		const model = result.model as any;
+		await bridge.setModel(model.provider, model.id);
+		const warning = result.warning ? ` ⚠️ ${result.warning}` : "";
+		await safeSend(ctx.api, chatId, `🧠 Switched to \`${model.provider}/${model.id}\`${warning}`);
 	} catch (e) {
 		log(`[CMD] /model error: ${e}`);
 		await safeSend(ctx.api, chatId, `❌ ${e}`);

--- a/packages/telegram/src/types.ts
+++ b/packages/telegram/src/types.ts
@@ -35,6 +35,8 @@ export interface UserState {
 	outbox: Array<{ chatId: number; text: string; long?: boolean; retries?: number }>;
 	/** Buddy controller — any to avoid import of @dreb/coding-agent/buddy */
 	buddyController: any;
+	/** Pending model fallback warning to show the user (set once after bridge start) */
+	pendingModelFallbackWarning?: string;
 }
 
 /** Session info for persistence across bot restarts */

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #149

## Changes

- **Bug 1**: Skip Anthropic beta headers for third-party Anthropic-compatible endpoints (e.g. kimi-coding). The `fine-grained-tool-streaming` beta header caused pathological slow behavior on non-Anthropic endpoints.
- **Bug 2**: Make model fallback messages visible in RPC/TUI so silent model switches after crashes are reported to the user.
- **Bug 3**: Unify Telegram `/model` matching to use the same resolution logic as CLI/TUI via a new `resolve_model` RPC command.
- **Bug 4 (deferred)**: Endpoint probing deferred to a follow-up. The parity fix (Bug 3) is the real win.

## Test fixes
- Gracefully handle unknown OAuth providers in test helper instead of crashing.

Implementation plan posted as a comment below.