### PR TITLE
Cherry-pick 4 upstream fixes from pi-mono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8703,7 +8703,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "^2.0.0"
@@ -8732,7 +8732,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8788,7 +8788,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "^2.0.0",
@@ -8903,7 +8903,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8951,7 +8951,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"dependencies": {
 				"@dreb/coding-agent": "^2.0.0",
 				"grammy": "^1.35.0"
@@ -8983,7 +8983,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "^1.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2658,7 +2658,7 @@ export class AgentSession {
 
 		const err = message.errorMessage;
 		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors, fetch failed, terminated, retry delay exceeded
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i.test(
+		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|ended without|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i.test(
 			err,
 		);
 	}

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { createWriteStream, type WriteStream } from "node:fs";
+import { createWriteStream, type WriteStream, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
@@ -126,6 +126,16 @@ export async function executeBashWithOperations(
 
 		const fullOutput = outputChunks.join("");
 		const truncationResult = truncateTail(fullOutput);
+
+		// If truncation occurred (e.g. by line count) but no temp file was
+		// created (output was under the byte-streaming threshold), write the
+		// full output to a temp file so the truncation message can reference it.
+		if (truncationResult.truncated && !tempFilePath) {
+			const id = randomBytes(8).toString("hex");
+			tempFilePath = join(tmpdir(), `dreb-bash-${id}.log`);
+			writeFileSync(tempFilePath, fullOutput);
+		}
+
 		const cancelled = options?.signal?.aborted ?? false;
 
 		return {
@@ -144,6 +154,11 @@ export async function executeBashWithOperations(
 		if (options?.signal?.aborted) {
 			const fullOutput = outputChunks.join("");
 			const truncationResult = truncateTail(fullOutput);
+			if (truncationResult.truncated && !tempFilePath) {
+				const id = randomBytes(8).toString("hex");
+				tempFilePath = join(tmpdir(), `dreb-bash-${id}.log`);
+				writeFileSync(tempFilePath, fullOutput);
+			}
 			return {
 				output: truncationResult.truncated ? truncationResult.content : fullOutput,
 				exitCode: undefined,

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { createWriteStream, existsSync } from "node:fs";
+import { createWriteStream, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentTool } from "@dreb/agent-core";
@@ -343,6 +343,13 @@ export function createBashToolDefinition(
 						const fullOutput = renderTerminalOutput(fullBuffer.toString("utf-8"));
 						// Apply tail truncation for the final display payload.
 						const truncation = truncateTail(fullOutput);
+						// If truncation occurred (e.g. by line count) but no temp file was
+						// created (output was under the byte-streaming threshold), write the
+						// full output to a temp file so the truncation message can reference it.
+						if (truncation.truncated && !tempFilePath) {
+							tempFilePath = getTempFilePath();
+							writeFileSync(tempFilePath, fullOutput);
+						}
 						let outputText = truncation.content || "(no output)";
 						let details: BashToolDetails | undefined;
 						if (truncation.truncated) {

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -144,6 +144,61 @@ describe("AgentSession retry", () => {
 		expect(created.session.isRetrying).toBe(false);
 	});
 
+	it("retries on 'ended without' error", async () => {
+		let callCount = 0;
+		const model = findModel("anthropic", "sonnet")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				callCount++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (callCount === 1) {
+						const msg = createAssistantMessage("", {
+							stopReason: "error",
+							errorMessage: "request ended without sending any chunks",
+						});
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "error", reason: "error", error: msg });
+					} else {
+						const msg = createAssistantMessage("Success");
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "done", reason: "stop", message: msg });
+					}
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		const events: string[] = [];
+		session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		await session.prompt("Test");
+
+		expect(callCount).toBe(2);
+		expect(events).toEqual(["start:1", "end:success=true"]);
+		expect(session.isRetrying).toBe(false);
+	});
+
 	it("exhausts max retries and emits failure", async () => {
 		const created = createSession({ failCount: 99, maxRetries: 2 });
 		const events: string[] = [];

--- a/packages/coding-agent/test/bash-truncation.test.ts
+++ b/packages/coding-agent/test/bash-truncation.test.ts
@@ -67,6 +67,30 @@ describe("executeBash truncation temp file", () => {
 		expect(result.truncated).toBe(false);
 		expect(result.fullOutputPath).toBeUndefined();
 	});
+
+	it("creates a temp file when an aborted command has truncatable output", async () => {
+		const controller = new AbortController();
+
+		// Produce 3000+ lines (over the 2000-line truncation threshold) then sleep to keep alive
+		const resultPromise = executeBash("seq 3000; sleep 30", { signal: controller.signal });
+
+		// Give seq time to finish output, then abort during sleep
+		await new Promise<void>((resolve) => setTimeout(resolve, 300));
+		controller.abort();
+
+		const result = await resultPromise;
+		trackTempFile(result.fullOutputPath);
+
+		expect(result.cancelled).toBe(true);
+		expect(result.truncated).toBe(true);
+		expect(result.fullOutputPath).toBeDefined();
+		expect(result.fullOutputPath).not.toBe("undefined");
+		expect(existsSync(result.fullOutputPath!)).toBe(true);
+
+		const fullContent = readFileSync(result.fullOutputPath!, "utf-8");
+		const lineCount = fullContent.trimEnd().split("\n").length;
+		expect(lineCount).toBe(3000);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/test/bash-truncation.test.ts
+++ b/packages/coding-agent/test/bash-truncation.test.ts
@@ -51,8 +51,8 @@ describe("executeBash truncation temp file", () => {
 	});
 
 	it("creates a temp file when output exceeds byte limit", async () => {
-		// Generate >50KB of output
-		const result = await executeBash("head -c 60000 /dev/urandom | base64");
+		// Generate >50KB of deterministic output (60000 bytes > 50KB = 51200 bytes)
+		const result = await executeBash("head -c 60000 /dev/zero | tr '\\0' 'A'");
 		trackTempFile(result.fullOutputPath);
 
 		expect(result.truncated).toBe(true);

--- a/packages/coding-agent/test/bash-truncation.test.ts
+++ b/packages/coding-agent/test/bash-truncation.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { executeBash } from "../src/core/bash-executor.js";
+import { createBashTool } from "../src/core/tools/bash.js";
+
+function getTextOutput(result: { content?: Array<{ type: string; text?: string }> }): string {
+	return (
+		result.content
+			?.filter((block) => block.type === "text")
+			.map((block) => block.text ?? "")
+			.join("\n") ?? ""
+	);
+}
+
+/** Collect temp file paths created during tests so we can clean them up. */
+const tempFiles: string[] = [];
+
+function trackTempFile(path: string | undefined): void {
+	if (path) tempFiles.push(path);
+}
+
+afterEach(() => {
+	for (const f of tempFiles) {
+		try {
+			unlinkSync(f);
+		} catch {}
+	}
+	tempFiles.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// executeBash (bash-executor.ts)
+// ---------------------------------------------------------------------------
+describe("executeBash truncation temp file", () => {
+	it("creates a temp file when output exceeds line limit but not byte limit", async () => {
+		// seq 3000 produces 3000 lines (~14KB) — well under 50KB but over 2000 lines
+		const result = await executeBash("seq 3000");
+		trackTempFile(result.fullOutputPath);
+
+		expect(result.truncated).toBe(true);
+		expect(result.fullOutputPath).toBeDefined();
+		expect(result.fullOutputPath).not.toBe("undefined");
+		expect(existsSync(result.fullOutputPath!)).toBe(true);
+
+		const fullContent = readFileSync(result.fullOutputPath!, "utf-8");
+		// Should contain all 3000 numbers
+		expect(fullContent).toContain("1\n");
+		expect(fullContent).toContain("3000");
+		const lineCount = fullContent.trimEnd().split("\n").length;
+		expect(lineCount).toBe(3000);
+	});
+
+	it("creates a temp file when output exceeds byte limit", async () => {
+		// Generate >50KB of output
+		const result = await executeBash("head -c 60000 /dev/urandom | base64");
+		trackTempFile(result.fullOutputPath);
+
+		expect(result.truncated).toBe(true);
+		expect(result.fullOutputPath).toBeDefined();
+		expect(existsSync(result.fullOutputPath!)).toBe(true);
+	});
+
+	it("does not create a temp file when output is small", async () => {
+		const result = await executeBash("echo hello");
+		trackTempFile(result.fullOutputPath);
+
+		expect(result.truncated).toBe(false);
+		expect(result.fullOutputPath).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createBashTool (bash tool)
+// ---------------------------------------------------------------------------
+describe("bash tool truncation temp file", () => {
+	it("includes a valid temp file path (not undefined) in truncation message for line-truncated output", async () => {
+		const tool = createBashTool(process.cwd());
+		const result = await tool.execute("test-call", { command: "seq 3000" });
+		const output = getTextOutput(result);
+
+		// The truncation message should mention "Showing lines" and a real file path
+		expect(output).toContain("Showing lines");
+		expect(output).toContain("Full output:");
+		expect(output).not.toContain("Full output: undefined");
+
+		// Extract the temp file path from the message
+		const match = output.match(/Full output: (.+)\]/);
+		expect(match).toBeTruthy();
+		const tempPath = match![1];
+		trackTempFile(tempPath);
+
+		expect(existsSync(tempPath)).toBe(true);
+		const fullContent = readFileSync(tempPath, "utf-8");
+		expect(fullContent).toContain("3000");
+		const lineCount = fullContent.trimEnd().split("\n").length;
+		expect(lineCount).toBe(3000);
+	});
+
+	it("does not include temp file info for small output", async () => {
+		const tool = createBashTool(process.cwd());
+		const result = await tool.execute("test-call", { command: "echo hello" });
+		const output = getTextOutput(result);
+
+		expect(output).toContain("hello");
+		expect(output).not.toContain("Full output:");
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/telegram/src/handlers/events.ts
+++ b/packages/telegram/src/handlers/events.ts
@@ -124,7 +124,7 @@ export interface EventDisplayState {
  * Mirrors the core's _isRetryableError check as a defensive Layer 2.
  */
 const RETRYABLE_ERROR_PATTERN =
-	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i;
+	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|ended without|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i;
 
 function isRetryableError(errorMessage: string): boolean {
 	return RETRYABLE_ERROR_PATTERN.test(errorMessage);

--- a/packages/telegram/test/events.test.ts
+++ b/packages/telegram/test/events.test.ts
@@ -148,6 +148,21 @@ describe("agent_end", () => {
 		expect(state.toolCount).toBe(0);
 	});
 
+	it("does NOT set done for 'ended without' errors (stream termination)", async () => {
+		const send = vi.fn();
+		const state = makeState({ toolCount: 2, textBlocks: ["partial"] });
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "agent_end",
+			messages: [{ stopReason: "error", errorMessage: "request ended without sending any chunks" }],
+		});
+
+		expect(state.done).toBe(false);
+		expect(state.pendingRetry).toBe(true);
+		expect(state.textBlocks).toEqual([]);
+		expect(state.toolCount).toBe(0);
+	});
+
 	it("does NOT set done when background agents are still running", async () => {
 		const send = vi.fn();
 		const state = makeState();

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -121,7 +121,7 @@ export class Markdown implements Component {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
 			const tokenLines = this.renderToken(token, contentWidth, nextToken?.type);
-			renderedLines.push(...tokenLines);
+			for (const line of tokenLines) renderedLines.push(line);
 		}
 
 		// Wrap lines (NO padding, NO background yet)
@@ -130,7 +130,7 @@ export class Markdown implements Component {
 			if (isImageLine(line)) {
 				wrappedLines.push(line);
 			} else {
-				wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+				for (const wl of wrapTextWithAnsi(line, contentWidth)) wrappedLines.push(wl);
 			}
 		}
 
@@ -331,7 +331,7 @@ export class Markdown implements Component {
 
 			case "list": {
 				const listLines = this.renderList(token as any, 0, styleContext);
-				lines.push(...listLines);
+				for (const line of listLines) lines.push(line);
 				// Don't add spacing after lists if a space token follows
 				// (the space token will handle it)
 				break;
@@ -339,7 +339,7 @@ export class Markdown implements Component {
 
 			case "table": {
 				const tableLines = this.renderTable(token as any, width, nextTokenType, styleContext);
-				lines.push(...tableLines);
+				for (const line of tableLines) lines.push(line);
 				break;
 			}
 
@@ -575,7 +575,7 @@ export class Markdown implements Component {
 				// Nested list - render with one additional indent level
 				// These lines will have their own indent, so we just add them as-is
 				const nestedLines = this.renderList(token as any, parentDepth + 1, styleContext);
-				lines.push(...nestedLines);
+				for (const line of nestedLines) lines.push(line);
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens)
 				const text =

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -91,7 +91,7 @@ export class SettingsList implements Component {
 		const lines: string[] = [];
 
 		if (this.searchEnabled && this.searchInput) {
-			lines.push(...this.searchInput.render(width));
+			for (const line of this.searchInput.render(width)) lines.push(line);
 			lines.push("");
 		}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -201,11 +201,13 @@ export class Container implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			for (const line of child.render(width)) lines.push(line);
 		}
 		return lines;
 	}
 }
+
+const RENDER_THROTTLE_MS = 16; // ~60fps
 
 /**
  * TUI - Main class for managing terminal UI with differential rendering
@@ -220,7 +222,8 @@ export class TUI extends Container {
 
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
 	public onDebug?: () => void;
-	private renderRequested = false;
+	private renderTimer: ReturnType<typeof setTimeout> | null = null;
+	private lastRenderAt = 0;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private inputBuffer = ""; // Buffer for parsing terminal responses
@@ -430,6 +433,10 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		if (this.renderTimer !== null) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = null;
+		}
 		this.stopped = true;
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.previousLines.length > 0) {
@@ -457,12 +464,27 @@ export class TUI extends Container {
 			this.maxLinesRendered = 0;
 			this.previousViewportTop = 0;
 		}
-		if (this.renderRequested) return;
-		this.renderRequested = true;
-		process.nextTick(() => {
-			this.renderRequested = false;
-			this.doRender();
-		});
+		this.scheduleRender();
+	}
+
+	private scheduleRender(): void {
+		if (this.renderTimer !== null) return;
+		const elapsed = performance.now() - this.lastRenderAt;
+		if (elapsed >= RENDER_THROTTLE_MS) {
+			// Enough time has passed — render on next tick (preserves existing coalescing)
+			this.renderTimer = setTimeout(() => {
+				this.renderTimer = null;
+				this.lastRenderAt = performance.now();
+				this.doRender();
+			}, 0);
+		} else {
+			// Too soon — schedule for the remaining time
+			this.renderTimer = setTimeout(() => {
+				this.renderTimer = null;
+				this.lastRenderAt = performance.now();
+				this.doRender();
+			}, RENDER_THROTTLE_MS - elapsed);
+		}
 	}
 
 	private handleInput(data: string): void {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -590,7 +590,7 @@ export function wrapTextWithAnsi(text: string, width: number): string[] {
 	for (const inputLine of inputLines) {
 		// Prepend active ANSI codes from previous lines (except for first line)
 		const prefix = result.length > 0 ? tracker.getActiveCodes() : "";
-		result.push(...wrapSingleLine(prefix + inputLine, width));
+		for (const wl of wrapSingleLine(prefix + inputLine, width)) result.push(wl);
 		// Update tracker with codes from this line for next iteration
 		updateTrackerFromText(inputLine, tracker);
 	}
@@ -634,7 +634,7 @@ function wrapSingleLine(line: string, width: number): string[] {
 
 			// Break long token - breakLongWord handles its own resets
 			const broken = breakLongWord(token, width, tracker);
-			wrapped.push(...broken.slice(0, -1));
+			for (const bl of broken.slice(0, -1)) wrapped.push(bl);
 			currentLine = broken[broken.length - 1];
 			currentVisibleLength = visibleWidth(currentLine);
 			continue;

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -24,6 +24,10 @@ class LoggingVirtualTerminal extends VirtualTerminal {
 		return this.writes.join("");
 	}
 
+	getWriteCount(): number {
+		return this.writes.length;
+	}
+
 	clearWrites(): void {
 		this.writes = [];
 	}
@@ -744,6 +748,13 @@ describe("TUI render throttle", () => {
 		component.lines = ["Initial"];
 		tui.start();
 		await terminal.flush();
+
+		// Record how many writes a single render produces
+		terminal.clearWrites();
+		component.lines = ["Baseline"];
+		tui.requestRender();
+		await terminal.flush();
+		const writesPerRender = terminal.getWriteCount();
 		terminal.clearWrites();
 
 		// Fire many rapid requestRender calls
@@ -758,6 +769,14 @@ describe("TUI render throttle", () => {
 		// The final state should reflect the last update
 		const viewport = terminal.getViewport();
 		assert.ok(viewport[0]?.includes("Update 49"), `Final state should be last update, got: ${viewport[0]}`);
+
+		// Throttle should have coalesced 50 requests into far fewer actual renders
+		const totalWrites = terminal.getWriteCount();
+		const maxExpectedRenders = 5; // 50 requests within one tick → at most a few renders
+		assert.ok(
+			totalWrites <= writesPerRender * maxExpectedRenders,
+			`Expected at most ${maxExpectedRenders} renders (${writesPerRender * maxExpectedRenders} writes), got ${totalWrites} writes`,
+		);
 
 		tui.stop();
 	});

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -733,3 +733,53 @@ describe("TUI spinner lifecycle", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI render throttle", () => {
+	it("coalesces rapid render requests", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["Initial"];
+		tui.start();
+		await terminal.flush();
+		terminal.clearWrites();
+
+		// Fire many rapid requestRender calls
+		for (let i = 0; i < 50; i++) {
+			component.lines = [`Update ${i}`];
+			tui.requestRender();
+		}
+
+		// Wait for all timers to settle
+		await terminal.flush();
+
+		// The final state should reflect the last update
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("Update 49"), `Final state should be last update, got: ${viewport[0]}`);
+
+		tui.stop();
+	});
+
+	it("force render resets state even during throttle window", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["Line 0", "Line 1", "Line 2"];
+		tui.start();
+		await terminal.flush();
+
+		// Immediately force render — should still work correctly
+		component.lines = ["Force updated"];
+		tui.requestRender(true);
+		await terminal.flush();
+
+		const viewport = terminal.getViewport();
+		assert.ok(viewport[0]?.includes("Force updated"), `Force render applied: ${viewport[0]}`);
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -125,9 +125,12 @@ export class VirtualTerminal implements Terminal {
 
 	/**
 	 * Wait for all pending writes to complete. Viewport and scroll buffer will be updated.
+	 * Waits long enough for TUI render throttle timers (setTimeout) to fire first.
 	 */
 	async flush(): Promise<void> {
-		// Write an empty string to ensure all previous writes are flushed
+		// Wait for pending timers (TUI render throttle uses setTimeout)
+		await new Promise<void>((resolve) => setTimeout(resolve, 20));
+		// Then flush xterm's write queue
 		return new Promise<void>((resolve) => {
 			this.xterm.write("", () => resolve());
 		});


### PR DESCRIPTION
Closes #146

Cherry-pick 4 of the 5 upstream fixes identified in the issue. Fix 5 (JSON mode with piped stdin) does not apply to our fork.

**Fixes included:**
1. TUI: Replace spread-into-push with safe loops (9 sites) — prevents V8 stack overflow
2. TUI: Add 16ms render throttle — reduces CPU/flicker under streaming load
3. Bash: Create temp file on line truncation — fixes `Full output: undefined`
4. Stream retry: Add `ended without` to transient error regex

Implementation plan posted as a comment below.