### PR TITLE
Add /session-analysis command for behavioral quality metrics

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -42,6 +42,7 @@ export interface Args {
 	listModels?: string | true;
 	offline?: boolean;
 	verbose?: boolean;
+	agentType?: string;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -97,6 +98,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.fork = args[++i];
 		} else if (arg === "--session-dir" && i + 1 < args.length) {
 			result.sessionDir = args[++i];
+		} else if (arg === "--agent-type" && i + 1 < args.length) {
+			result.agentType = args[++i];
 		} else if (arg === "--models" && i + 1 < args.length) {
 			result.models = args[++i].split(",").map((s) => s.trim());
 		} else if (arg === "--no-tools") {
@@ -211,6 +214,7 @@ ${chalk.bold("Options:")}
   --session <path>               Use specific session file
   --fork <path>                  Fork specific session file or partial UUID into a new session
   --session-dir <dir>            Directory for session storage and lookup
+  --agent-type <name>            Agent type identifier for session metadata
   --no-session                   Don't save session (ephemeral)
   --models <patterns>            Comma-separated model patterns for Ctrl+P cycling
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -13,12 +13,12 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
-import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import type { Agent, AgentEvent, AgentMessage, AgentState, AgentTool, ThinkingLevel } from "@dreb/agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@dreb/ai";
 import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@dreb/ai";
-import { getDocsPath } from "../config.js";
+import { getDocsPath, getSubagentSessionsDir } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { sleep } from "../utils/sleep.js";
 import { type BashResult, executeBash as executeBashCommand, executeBashWithOperations } from "./bash-executor.js";
@@ -66,8 +66,24 @@ import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
+import {
+	analyzeSession,
+	computeDateComparison,
+	computeGroups,
+	computeProjectTrend,
+	computeTimeline,
+	type FullSessionAnalysis,
+	type SessionAnalysis,
+} from "./session-analyzer.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
-import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.js";
+import {
+	CURRENT_SESSION_VERSION,
+	getDefaultSessionDir,
+	getLatestCompactionEntry,
+	loadEntriesFromFile,
+	type SessionHeader,
+	type SessionMessageEntry,
+} from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 import type { SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
@@ -187,6 +203,8 @@ export interface ModelCycleResult {
 	/** Whether cycling through scoped models (--models flag) or all available */
 	isScoped: boolean;
 }
+
+export type { FullSessionAnalysis } from "./session-analyzer.js";
 
 /** Session statistics for /session command */
 export interface SessionStats {
@@ -3426,6 +3444,100 @@ export class AgentSession {
 			contextWindow,
 			percent,
 		};
+	}
+
+	/**
+	 * Get session analysis with behavioral quality metrics and project trends.
+	 */
+	async getSessionAnalysis(options?: { splitDate?: Date }): Promise<FullSessionAnalysis> {
+		// 1. Analyze current session from in-memory messages
+		const currentMessages = this.state.messages as Message[];
+		const current = analyzeSession(currentMessages, {
+			sessionId: this.sessionId,
+			sessionFile: this.sessionFile,
+			isSubagent: false,
+		});
+
+		// 2. Collect historical sessions for trend
+		const allSessions: SessionAnalysis[] = [current];
+		const cwd = this._cwd;
+
+		if (cwd) {
+			// Scan regular sessions
+			const sessionDir = getDefaultSessionDir(cwd);
+			this._scanSessionDir(sessionDir, false, allSessions);
+
+			// Scan subagent sessions (all dirs — filter by cwd from header)
+			const subagentBaseDir = getSubagentSessionsDir();
+			if (existsSync(subagentBaseDir)) {
+				for (const dirName of readdirSync(subagentBaseDir)) {
+					const subDir = join(subagentBaseDir, dirName);
+					try {
+						this._scanSessionDir(subDir, true, allSessions, cwd);
+					} catch {
+						// Skip inaccessible dirs
+					}
+				}
+			}
+		}
+
+		// 3. Compute trend and additional analysis
+		const trend = computeProjectTrend(allSessions);
+		const timeline = computeTimeline(allSessions);
+		const groups = computeGroups(allSessions, timeline);
+		const comparison = options?.splitDate ? computeDateComparison(allSessions, options.splitDate) : null;
+
+		return { current, timeline, groups, comparison, trend };
+	}
+
+	/**
+	 * Scan a directory for session JSONL files and analyze each one.
+	 * If filterCwd is provided, only include sessions whose header.cwd matches.
+	 */
+	private _scanSessionDir(dir: string, isSubagent: boolean, results: SessionAnalysis[], filterCwd?: string): void {
+		if (!existsSync(dir)) return;
+
+		let files: string[];
+		try {
+			files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+		} catch {
+			return;
+		}
+
+		for (const file of files) {
+			const filePath = join(dir, file);
+
+			// Skip the current session file (already analyzed from memory)
+			if (filePath === this.sessionFile) continue;
+
+			try {
+				const entries = loadEntriesFromFile(filePath);
+				if (entries.length === 0) continue;
+
+				const header = entries[0];
+				if (header.type !== "session") continue;
+
+				// Filter by cwd if specified (for subagent sessions)
+				if (filterCwd && (header as SessionHeader).cwd !== filterCwd) continue;
+
+				// Extract messages from entries
+				const messages = entries
+					.filter((e): e is SessionMessageEntry => e.type === "message" && "message" in e)
+					.map((e) => e.message as Message);
+
+				if (messages.length === 0) continue;
+
+				const analysis = analyzeSession(messages, {
+					sessionId: (header as SessionHeader).id || file,
+					sessionFile: filePath,
+					isSubagent,
+					agentType: (header as SessionHeader).agentType,
+				});
+				results.push(analysis);
+			} catch {
+				// Skip corrupt/unreadable files
+			}
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -13,7 +13,8 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import type { Agent, AgentEvent, AgentMessage, AgentState, AgentTool, ThinkingLevel } from "@dreb/agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@dreb/ai";
@@ -70,7 +71,6 @@ import {
 	analyzeSession,
 	computeDateComparison,
 	computeGroups,
-	computeProjectTrend,
 	computeTimeline,
 	type FullSessionAnalysis,
 	type SessionAnalysis,
@@ -78,9 +78,9 @@ import {
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
 import {
 	CURRENT_SESSION_VERSION,
+	type FileEntry,
 	getDefaultSessionDir,
 	getLatestCompactionEntry,
-	loadEntriesFromFile,
 	type SessionHeader,
 	type SessionMessageEntry,
 } from "./session-manager.js";
@@ -3446,6 +3446,12 @@ export class AgentSession {
 		};
 	}
 
+	/** Maximum size of a single JSONL file to process (20 MB). */
+	private static readonly SESSION_FILE_SIZE_CAP = 20 * 1024 * 1024;
+
+	/** Maximum number of JSONL files to process across all directories. */
+	private static readonly SESSION_FILE_COUNT_CAP = 500;
+
 	/**
 	 * Get session analysis with behavioral quality metrics and project trends.
 	 */
@@ -3463,55 +3469,85 @@ export class AgentSession {
 		const cwd = this._cwd;
 
 		if (cwd) {
+			const fileCounter = { count: 0 };
+
 			// Scan regular sessions
 			const sessionDir = getDefaultSessionDir(cwd);
-			this._scanSessionDir(sessionDir, false, allSessions);
+			await this._scanSessionDir(sessionDir, false, allSessions, fileCounter);
 
 			// Scan subagent sessions (all dirs — filter by cwd from header)
 			const subagentBaseDir = getSubagentSessionsDir();
-			if (existsSync(subagentBaseDir)) {
-				for (const dirName of readdirSync(subagentBaseDir)) {
-					const subDir = join(subagentBaseDir, dirName);
-					try {
-						this._scanSessionDir(subDir, true, allSessions, cwd);
-					} catch {
-						// Skip inaccessible dirs
-					}
-				}
+			try {
+				const dirNames = await readdir(subagentBaseDir);
+				await Promise.all(
+					dirNames.map((dirName) => {
+						const subDir = join(subagentBaseDir, dirName);
+						return this._scanSessionDir(subDir, true, allSessions, fileCounter, cwd);
+					}),
+				);
+			} catch {
+				// subagentBaseDir doesn't exist or is inaccessible — skip
 			}
 		}
 
-		// 3. Compute trend and additional analysis
-		const trend = computeProjectTrend(allSessions);
+		// 3. Compute additional analysis (trend removed — not consumed by renderers)
 		const timeline = computeTimeline(allSessions);
 		const groups = computeGroups(allSessions, timeline);
 		const comparison = options?.splitDate ? computeDateComparison(allSessions, options.splitDate) : null;
 
-		return { current, timeline, groups, comparison, trend };
+		return { current, timeline, groups, comparison, trend: null };
 	}
 
 	/**
 	 * Scan a directory for session JSONL files and analyze each one.
 	 * If filterCwd is provided, only include sessions whose header.cwd matches.
 	 */
-	private _scanSessionDir(dir: string, isSubagent: boolean, results: SessionAnalysis[], filterCwd?: string): void {
-		if (!existsSync(dir)) return;
-
-		let files: string[];
+	private async _scanSessionDir(
+		dir: string,
+		isSubagent: boolean,
+		results: SessionAnalysis[],
+		fileCounter: { count: number },
+		filterCwd?: string,
+	): Promise<void> {
+		let dirEntries: string[];
 		try {
-			files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+			dirEntries = await readdir(dir);
 		} catch {
-			return;
+			return; // Directory doesn't exist or is inaccessible
 		}
 
+		const files = dirEntries.filter((f) => f.endsWith(".jsonl"));
+
 		for (const file of files) {
+			if (fileCounter.count >= AgentSession.SESSION_FILE_COUNT_CAP) return;
+
 			const filePath = join(dir, file);
 
 			// Skip the current session file (already analyzed from memory)
 			if (filePath === this.sessionFile) continue;
 
 			try {
-				const entries = loadEntriesFromFile(filePath);
+				// Check file size before reading
+				const fileStat = await stat(filePath);
+				if (fileStat.size > AgentSession.SESSION_FILE_SIZE_CAP) {
+					console.log(`[session-analysis] skipping large file (${fileStat.size} bytes): ${filePath}`);
+					continue;
+				}
+
+				fileCounter.count++;
+
+				// Read and parse JSONL content
+				const content = await readFile(filePath, "utf8");
+				const entries: FileEntry[] = [];
+				for (const line of content.trim().split("\n")) {
+					if (!line.trim()) continue;
+					try {
+						entries.push(JSON.parse(line) as FileEntry);
+					} catch {
+						// Skip malformed lines
+					}
+				}
+
 				if (entries.length === 0) continue;
 
 				const header = entries[0];

--- a/packages/coding-agent/src/core/session-analysis-html.ts
+++ b/packages/coding-agent/src/core/session-analysis-html.ts
@@ -1,0 +1,441 @@
+import type {
+	AnalysisTimeline,
+	DateComparison,
+	FullSessionAnalysis,
+	GroupSummary,
+	SessionAnalysis,
+} from "./session-analyzer.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function fmtNum(v: number | null, suffix = ""): string {
+	if (v === null) return "n/a";
+	return `${v.toFixed(1)}${suffix}`;
+}
+
+function changeArrow(current: number | null, previous: number | null): string {
+	if (current === null || previous === null) return "—";
+	if (previous === 0) return current === 0 ? "→" : "↑ new";
+	const change = ((current - previous) / Math.abs(previous)) * 100;
+	if (Math.abs(change) < 1) return "→";
+	const arrow = change > 0 ? "↑" : "↓";
+	return `${arrow} ${change > 0 ? "+" : ""}${change.toFixed(0)}%`;
+}
+
+// ── Colors (Tokyo Night-ish palette) ────────────────────────────────────
+
+const COLORS = {
+	bg: "#1a1a1a",
+	surface: "#242424",
+	border: "#3b3b3b",
+	text: "#c0caf5",
+	dim: "#787c99",
+	accent: "#7aa2f7",
+	green: "#9ece6a",
+	yellow: "#e0af68",
+	red: "#f7768e",
+	purple: "#bb9af7",
+	cyan: "#7dcfff",
+	orange: "#ff9e64",
+};
+
+const BAR_COLORS = [COLORS.accent, COLORS.green, COLORS.yellow, COLORS.purple, COLORS.cyan, COLORS.orange, COLORS.red];
+
+// ── Section builders ────────────────────────────────────────────────────
+
+function renderCurrentSession(current: SessionAnalysis): string {
+	const rows: [string, string][] = [];
+	if (current.model)
+		rows.push(["Model", esc(current.provider ? `${current.provider}/${current.model}` : current.model)]);
+	rows.push(["Tool Calls", String(current.totalToolCalls)]);
+	rows.push(["Tokens", current.totalTokens.toLocaleString()]);
+	if (current.totalCost > 0) rows.push(["Cost", `$${current.totalCost.toFixed(4)}`]);
+	rows.push(["Read:Edit Ratio", fmtNum(current.readEditRatio)]);
+	rows.push(["Write vs Edit", fmtNum(current.writeVsEditPercent, "%")]);
+	rows.push(["Error Rate", fmtNum(current.errorRate, "%")]);
+	rows.push(["Self-Correction", fmtNum(current.selfCorrectionPer1K, " per 1K calls")]);
+
+	const tableRows = rows
+		.map(([label, value]) => `<tr><td class="label">${esc(label)}</td><td>${value}</td></tr>`)
+		.join("\n");
+
+	return `
+<section>
+  <h2>Current Session</h2>
+  <table class="kv-table">
+    ${tableRows}
+  </table>
+</section>`;
+}
+
+function renderToolDistribution(dist: Record<string, number>): string {
+	const entries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+	if (entries.length === 0) return "";
+	const maxCount = entries[0][1];
+
+	const bars = entries
+		.map(([name, count], i) => {
+			const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
+			const color = BAR_COLORS[i % BAR_COLORS.length];
+			return `<div class="bar-row">
+  <span class="bar-label">${esc(name)}</span>
+  <div class="bar-track"><div class="bar-fill" style="width:${pct.toFixed(1)}%;background:${color}"></div></div>
+  <span class="bar-count">${count}</span>
+</div>`;
+		})
+		.join("\n");
+
+	return `
+<section>
+  <h2>Tool Distribution</h2>
+  <div class="bar-chart">
+    ${bars}
+  </div>
+</section>`;
+}
+
+function renderTrends(timeline: AnalysisTimeline): string {
+	const periods = timeline.periods;
+	const firstLabel = periods[0].label;
+	const lastLabel = periods[periods.length - 1].label;
+
+	interface MetricRow {
+		name: string;
+		values: (number | null)[];
+		suffix: string;
+		color: string;
+	}
+
+	const metrics: MetricRow[] = [
+		{ name: "Read:Edit", values: periods.map((p) => p.metrics.avgReadEditRatio), suffix: "", color: COLORS.accent },
+		{ name: "Error Rate", values: periods.map((p) => p.metrics.avgErrorRate), suffix: "%", color: COLORS.red },
+		{
+			name: "Self-Correction",
+			values: periods.map((p) => p.metrics.avgSelfCorrectionPer1K),
+			suffix: "/1K",
+			color: COLORS.yellow,
+		},
+		{
+			name: "Cost/week",
+			values: periods.map((p) => (p.metrics.totalCost > 0 ? p.metrics.totalCost : null)),
+			suffix: "",
+			color: COLORS.green,
+		},
+	];
+
+	const renderMetricChart = (metric: MetricRow): string => {
+		const nonNull = metric.values.filter((v): v is number => v !== null);
+		if (nonNull.length === 0) return "";
+
+		const max = Math.max(...nonNull);
+		const min = Math.min(...nonNull);
+		const range = max - min;
+
+		const columns = metric.values
+			.map((v, i) => {
+				const heightPct = v === null ? 0 : range === 0 ? 50 : ((v - min) / range) * 80 + 10;
+				const valueLabel =
+					v === null ? "" : metric.name === "Cost/week" ? `$${v.toFixed(2)}` : `${v.toFixed(1)}${metric.suffix}`;
+				const opacity = v === null ? "0.15" : "1";
+				return `<div class="chart-col">
+  <div class="chart-bar-wrapper">
+    <div class="chart-bar" style="height:${heightPct.toFixed(0)}%;background:${metric.color};opacity:${opacity}" title="${esc(valueLabel)}"></div>
+  </div>
+  ${i === 0 ? "" : ""}
+</div>`;
+			})
+			.join("\n");
+
+		return `
+<div class="metric-chart">
+  <h3>${esc(metric.name)}</h3>
+  <div class="chart-container">
+    ${columns}
+  </div>
+  <div class="chart-labels">
+    ${periods.map((p) => `<span>${esc(p.label)}</span>`).join("\n    ")}
+  </div>
+</div>`;
+	};
+
+	const charts = metrics
+		.map(renderMetricChart)
+		.filter((s) => s.length > 0)
+		.join("\n");
+
+	return `
+<section>
+  <h2>Trends <span class="dim">(${timeline.totalSessions} sessions, ${periods.length} weeks: ${esc(firstLabel)} – ${esc(lastLabel)})</span></h2>
+  <div class="trends-grid">
+    ${charts}
+  </div>
+</section>`;
+}
+
+function renderGroupTable(title: string, groups: GroupSummary[]): string {
+	if (groups.length === 0) return "";
+
+	const rows = groups
+		.map(
+			(g) => `<tr>
+  <td>${esc(g.groupKey)}</td>
+  <td class="num">${g.sessionCount}</td>
+  <td class="num">${fmtNum(g.avgReadEditRatio)}</td>
+  <td class="num">${fmtNum(g.avgErrorRate, "%")}</td>
+</tr>`,
+		)
+		.join("\n");
+
+	return `
+<section>
+  <h2>${esc(title)}</h2>
+  <table class="data-table">
+    <thead>
+      <tr><th>Name</th><th>Sessions</th><th>Avg Read:Edit</th><th>Avg Error Rate</th></tr>
+    </thead>
+    <tbody>
+      ${rows}
+    </tbody>
+  </table>
+</section>`;
+}
+
+function renderComparison(comparison: DateComparison): string {
+	const dateStr = comparison.splitDate.toISOString().slice(0, 10);
+	const { before: b, after: a } = comparison;
+
+	interface CompRow {
+		label: string;
+		beforeVal: string;
+		afterVal: string;
+		change: string;
+	}
+
+	const rows: CompRow[] = [
+		{
+			label: "Read:Edit",
+			beforeVal: fmtNum(b.avgReadEditRatio),
+			afterVal: fmtNum(a.avgReadEditRatio),
+			change: changeArrow(a.avgReadEditRatio, b.avgReadEditRatio),
+		},
+		{
+			label: "Write vs Edit",
+			beforeVal: fmtNum(b.avgWriteVsEditPercent, "%"),
+			afterVal: fmtNum(a.avgWriteVsEditPercent, "%"),
+			change: changeArrow(a.avgWriteVsEditPercent, b.avgWriteVsEditPercent),
+		},
+		{
+			label: "Error Rate",
+			beforeVal: fmtNum(b.avgErrorRate, "%"),
+			afterVal: fmtNum(a.avgErrorRate, "%"),
+			change: changeArrow(a.avgErrorRate, b.avgErrorRate),
+		},
+		{
+			label: "Self-Correction",
+			beforeVal: fmtNum(b.avgSelfCorrectionPer1K, "/1K"),
+			afterVal: fmtNum(a.avgSelfCorrectionPer1K, "/1K"),
+			change: changeArrow(a.avgSelfCorrectionPer1K, b.avgSelfCorrectionPer1K),
+		},
+		{
+			label: "Cost",
+			beforeVal: `$${b.totalCost.toFixed(4)}`,
+			afterVal: `$${a.totalCost.toFixed(4)}`,
+			change: changeArrow(a.totalCost, b.totalCost),
+		},
+		{
+			label: "Tokens/call",
+			beforeVal: fmtNum(b.avgTokensPerToolCall),
+			afterVal: fmtNum(a.avgTokensPerToolCall),
+			change: changeArrow(a.avgTokensPerToolCall, b.avgTokensPerToolCall),
+		},
+	];
+
+	const tableRows = rows
+		.map(
+			(r) => `<tr>
+  <td class="label">${esc(r.label)}</td>
+  <td class="num">${r.beforeVal}</td>
+  <td class="num">${r.afterVal}</td>
+  <td class="change">${esc(r.change)}</td>
+</tr>`,
+		)
+		.join("\n");
+
+	return `
+<section>
+  <h2>Comparison: split at ${esc(dateStr)}</h2>
+  <table class="data-table">
+    <thead>
+      <tr><th>Metric</th><th>Before (${b.sessionCount})</th><th>After (${a.sessionCount})</th><th>Change</th></tr>
+    </thead>
+    <tbody>
+      ${tableRows}
+    </tbody>
+  </table>
+</section>`;
+}
+
+// ── Main export ─────────────────────────────────────────────────────────
+
+export function generateAnalysisHtml(analysis: FullSessionAnalysis): string {
+	const { current, timeline, groups, comparison } = analysis;
+
+	const sections: string[] = [];
+	sections.push(renderCurrentSession(current));
+	sections.push(renderToolDistribution(current.toolDistribution));
+
+	if (timeline) {
+		sections.push(renderTrends(timeline));
+	}
+
+	if (groups?.byModel && groups.byModel.length > 0) {
+		sections.push(renderGroupTable("By Model", groups.byModel));
+	}
+
+	if (groups?.byType && groups.byType.length > 0) {
+		sections.push(renderGroupTable("By Agent Type", groups.byType));
+	}
+
+	if (comparison) {
+		sections.push(renderComparison(comparison));
+	}
+
+	const body = sections.filter((s) => s.length > 0).join("\n");
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>dreb Session Analysis</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", "Consolas", monospace;
+    background: ${COLORS.bg};
+    color: ${COLORS.text};
+    padding: 2rem;
+    max-width: 960px;
+    margin: 0 auto;
+    line-height: 1.6;
+  }
+
+  h1 {
+    color: ${COLORS.accent};
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid ${COLORS.border};
+    padding-bottom: 0.5rem;
+  }
+
+  h2 {
+    color: ${COLORS.text};
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  h2 .dim { color: ${COLORS.dim}; font-size: 0.85rem; font-weight: normal; }
+
+  h3 {
+    color: ${COLORS.dim};
+    font-size: 0.85rem;
+    font-weight: normal;
+    margin-bottom: 0.5rem;
+  }
+
+  section {
+    background: ${COLORS.surface};
+    border: 1px solid ${COLORS.border};
+    border-radius: 6px;
+    padding: 1.25rem;
+    margin-bottom: 1.25rem;
+  }
+
+  /* Key-value table (current session) */
+  .kv-table { width: 100%; }
+  .kv-table td { padding: 0.2rem 0; }
+  .kv-table .label { color: ${COLORS.dim}; width: 180px; }
+
+  /* Data tables */
+  .data-table { width: 100%; border-collapse: collapse; }
+  .data-table th {
+    text-align: left;
+    color: ${COLORS.dim};
+    font-weight: normal;
+    font-size: 0.85rem;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid ${COLORS.border};
+  }
+  .data-table td {
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid ${COLORS.border}22;
+  }
+  .data-table .num { text-align: right; }
+  .data-table .label { color: ${COLORS.dim}; }
+  .data-table .change { text-align: right; }
+
+  /* Horizontal bar chart */
+  .bar-chart { display: flex; flex-direction: column; gap: 0.35rem; }
+  .bar-row { display: flex; align-items: center; gap: 0.5rem; }
+  .bar-label { width: 120px; text-align: right; color: ${COLORS.dim}; font-size: 0.85rem; flex-shrink: 0; }
+  .bar-track { flex: 1; height: 18px; background: ${COLORS.bg}; border-radius: 3px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 3px; transition: width 0.3s; min-width: 2px; }
+  .bar-count { width: 40px; text-align: right; font-size: 0.85rem; color: ${COLORS.dim}; flex-shrink: 0; }
+
+  /* Trend charts */
+  .trends-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+  @media (max-width: 700px) { .trends-grid { grid-template-columns: 1fr; } }
+
+  .metric-chart {
+    background: ${COLORS.bg};
+    border: 1px solid ${COLORS.border};
+    border-radius: 4px;
+    padding: 0.75rem;
+  }
+
+  .chart-container {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 100px;
+  }
+
+  .chart-col { flex: 1; display: flex; flex-direction: column; align-items: stretch; height: 100%; }
+  .chart-bar-wrapper { flex: 1; display: flex; align-items: flex-end; }
+  .chart-bar { width: 100%; border-radius: 2px 2px 0 0; min-height: 2px; }
+
+  .chart-labels {
+    display: flex;
+    gap: 3px;
+    margin-top: 0.35rem;
+  }
+  .chart-labels span {
+    flex: 1;
+    text-align: center;
+    font-size: 0.65rem;
+    color: ${COLORS.dim};
+  }
+
+  .footer {
+    color: ${COLORS.dim};
+    font-size: 0.8rem;
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid ${COLORS.border};
+  }
+</style>
+</head>
+<body>
+<h1>dreb Session Analysis</h1>
+${body}
+<div class="footer">
+  Metrics are noisy proxies — interpret relative to your project's own baseline, not as absolute values.
+</div>
+</body>
+</html>`;
+}

--- a/packages/coding-agent/src/core/session-analyzer.ts
+++ b/packages/coding-agent/src/core/session-analyzer.ts
@@ -1,0 +1,837 @@
+import type { AssistantMessage, Message, TextContent, ToolCall, ToolResultMessage } from "@dreb/ai";
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export interface ToolCallRecord {
+	name: string;
+	isError: boolean;
+	timestamp: number;
+}
+
+export interface TurnSummary {
+	index: number;
+	timestamp: number;
+	toolCalls: number;
+	tools: string[];
+}
+
+export interface AnalysisInput {
+	toolCalls: ToolCallRecord[];
+	assistantTexts: string[];
+	turns: TurnSummary[];
+	totalTurns: number;
+	totalCost: number;
+	totalTokens: number;
+}
+
+export interface SessionAnalysis {
+	sessionId: string;
+	sessionFile?: string;
+	timestamp: Date;
+	model?: string;
+	provider?: string;
+	isSubagent: boolean;
+	agentType?: string;
+	readEditRatio: number | null;
+	writeVsEditPercent: number | null;
+	errorRate: number | null;
+	selfCorrectionPer1K: number | null;
+	toolDistribution: Record<string, number>;
+	totalToolCalls: number;
+	totalCost: number;
+	totalTokens: number;
+	timeline: TurnSummary[];
+}
+
+export interface PeriodMetrics {
+	label: string;
+	sessionCount: number;
+	avgReadEditRatio: number | null;
+	avgWriteVsEditPercent: number | null;
+	avgErrorRate: number | null;
+	avgSelfCorrectionPer1K: number | null;
+	toolDistribution: Record<string, number>;
+	totalToolCalls: number;
+	totalCost: number;
+	totalTokens: number;
+	avgCostPerToolCall: number | null;
+	avgTokensPerToolCall: number | null;
+}
+
+export interface ProjectTrend {
+	currentPeriod: PeriodMetrics;
+	previousPeriod: PeriodMetrics;
+	totalSessions: number;
+}
+
+// ── New multi-period types ──────────────────────────────────────────────
+
+export interface TimePeriod {
+	label: string;
+	start: Date;
+	end: Date;
+	metrics: PeriodMetrics;
+}
+
+export interface AnalysisTimeline {
+	periods: TimePeriod[];
+	totalSessions: number;
+}
+
+export interface GroupSummary {
+	groupKey: string;
+	sessionCount: number;
+	totalToolCalls: number;
+	avgReadEditRatio: number | null;
+	avgErrorRate: number | null;
+	sparklineReadEdit: (number | null)[];
+	sparklineErrorRate: (number | null)[];
+}
+
+export interface DateComparison {
+	splitDate: Date;
+	before: PeriodMetrics;
+	after: PeriodMetrics;
+}
+
+export interface FullSessionAnalysis {
+	current: SessionAnalysis;
+	timeline: AnalysisTimeline | null;
+	groups: {
+		byModel: GroupSummary[];
+		byType: GroupSummary[];
+	} | null;
+	comparison: DateComparison | null;
+	trend: { currentPeriod: PeriodMetrics; previousPeriod: PeriodMetrics; totalSessions: number } | null;
+}
+
+// ── Read / Edit tool sets ───────────────────────────────────────────────
+
+const READ_TOOLS = new Set(["read", "grep", "search", "find", "ls", "web_search", "web_fetch"]);
+const EDIT_TOOLS = new Set(["edit", "write"]);
+
+// ── Self-correction patterns ────────────────────────────────────────────
+
+const SELF_CORRECTION_PATTERNS: RegExp[] = [
+	/\bactually,?\s/i,
+	/\bwait,/i,
+	/\bno wait\b/i,
+	/\bI was wrong\b/i,
+	/\blet me reconsider\b/i,
+	/\bI made a mistake\b/i,
+	/\bI need to correct\b/i,
+];
+
+// ── extractAnalysisInput ────────────────────────────────────────────────
+
+export function extractAnalysisInput(messages: Message[]): AnalysisInput {
+	const toolCalls: ToolCallRecord[] = [];
+	const assistantTexts: string[] = [];
+	const turns: TurnSummary[] = [];
+	let totalCost = 0;
+	let totalTokens = 0;
+
+	const pendingToolCalls = new Map<string, { name: string; timestamp: number }>();
+
+	let currentTurn: { timestamp: number; toolCallNames: string[]; toolCallIds: string[] } | null = null;
+	let turnIndex = 0;
+
+	for (const msg of messages) {
+		if (msg.role === "assistant") {
+			if (currentTurn) {
+				turns.push({
+					index: currentTurn === null ? 0 : turnIndex,
+					timestamp: currentTurn.timestamp,
+					toolCalls: currentTurn.toolCallNames.length,
+					tools: currentTurn.toolCallNames,
+				});
+				turnIndex++;
+			}
+
+			const assistantMsg = msg as AssistantMessage;
+			if (assistantMsg.usage) {
+				totalCost += assistantMsg.usage.cost?.total ?? 0;
+				totalTokens += assistantMsg.usage.totalTokens ?? 0;
+			}
+			const turnToolNames: string[] = [];
+			const turnToolIds: string[] = [];
+
+			for (const block of assistantMsg.content) {
+				if (block.type === "text") {
+					assistantTexts.push((block as TextContent).text);
+				} else if (block.type === "toolCall") {
+					const tc = block as ToolCall;
+					pendingToolCalls.set(tc.id, { name: tc.name, timestamp: assistantMsg.timestamp });
+					turnToolNames.push(tc.name);
+					turnToolIds.push(tc.id);
+				}
+			}
+
+			currentTurn = {
+				timestamp: assistantMsg.timestamp,
+				toolCallNames: turnToolNames,
+				toolCallIds: turnToolIds,
+			};
+		} else if (msg.role === "toolResult") {
+			const tr = msg as ToolResultMessage;
+			const pending = pendingToolCalls.get(tr.toolCallId);
+			toolCalls.push({
+				name: pending?.name ?? tr.toolName,
+				isError: tr.isError,
+				timestamp: tr.timestamp,
+			});
+		}
+	}
+
+	if (currentTurn) {
+		turns.push({
+			index: turnIndex,
+			timestamp: currentTurn.timestamp,
+			toolCalls: currentTurn.toolCallNames.length,
+			tools: currentTurn.toolCallNames,
+		});
+	}
+
+	return {
+		toolCalls,
+		assistantTexts,
+		turns,
+		totalTurns: turns.length,
+		totalCost,
+		totalTokens,
+	};
+}
+
+// ── Metric functions ────────────────────────────────────────────────────
+
+export function computeReadEditRatio(input: AnalysisInput): number | null {
+	let readCount = 0;
+	let editCount = 0;
+	for (const tc of input.toolCalls) {
+		if (READ_TOOLS.has(tc.name)) readCount++;
+		if (EDIT_TOOLS.has(tc.name)) editCount++;
+	}
+	if (editCount === 0) return null;
+	return readCount / editCount;
+}
+
+export function computeWriteVsEditPercent(input: AnalysisInput): number | null {
+	let writeCount = 0;
+	let editCount = 0;
+	for (const tc of input.toolCalls) {
+		if (tc.name === "write") writeCount++;
+		if (tc.name === "edit") editCount++;
+	}
+	const total = writeCount + editCount;
+	if (total === 0) return null;
+	return (writeCount / total) * 100;
+}
+
+export function computeErrorRate(input: AnalysisInput): number | null {
+	const total = input.toolCalls.length;
+	if (total === 0) return null;
+	const errors = input.toolCalls.filter((tc) => tc.isError).length;
+	return (errors / total) * 100;
+}
+
+export function computeSelfCorrectionFrequency(input: AnalysisInput): number | null {
+	const totalToolCalls = input.toolCalls.length;
+	if (totalToolCalls === 0) return null;
+
+	let matchCount = 0;
+	for (const text of input.assistantTexts) {
+		for (const pattern of SELF_CORRECTION_PATTERNS) {
+			const matches = text.match(new RegExp(pattern, "gi"));
+			if (matches) matchCount += matches.length;
+		}
+	}
+
+	return (matchCount / totalToolCalls) * 1000;
+}
+
+export function computeToolDistribution(input: AnalysisInput): Record<string, number> {
+	const dist: Record<string, number> = {};
+	for (const tc of input.toolCalls) {
+		dist[tc.name] = (dist[tc.name] ?? 0) + 1;
+	}
+	return dist;
+}
+
+// ── analyzeSession ──────────────────────────────────────────────────────
+
+export function analyzeSession(
+	messages: Message[],
+	metadata: { sessionId: string; sessionFile?: string; isSubagent: boolean; agentType?: string },
+): SessionAnalysis {
+	const input = extractAnalysisInput(messages);
+
+	const firstAssistant = messages.find((m) => m.role === "assistant") as AssistantMessage | undefined;
+	const firstMessage = messages[0];
+	const timestamp = firstMessage ? new Date(firstMessage.timestamp) : new Date();
+
+	return {
+		sessionId: metadata.sessionId,
+		sessionFile: metadata.sessionFile,
+		timestamp,
+		model: firstAssistant?.model,
+		provider: firstAssistant?.provider,
+		isSubagent: metadata.isSubagent,
+		agentType: metadata.agentType,
+		readEditRatio: computeReadEditRatio(input),
+		writeVsEditPercent: computeWriteVsEditPercent(input),
+		errorRate: computeErrorRate(input),
+		selfCorrectionPer1K: computeSelfCorrectionFrequency(input),
+		toolDistribution: computeToolDistribution(input),
+		totalToolCalls: input.toolCalls.length,
+		totalCost: input.totalCost,
+		totalTokens: input.totalTokens,
+		timeline: input.turns,
+	};
+}
+
+// ── Period/trend helpers ────────────────────────────────────────────────
+
+function averageNonNull(values: (number | null)[]): number | null {
+	const valid = values.filter((v): v is number => v !== null);
+	if (valid.length === 0) return null;
+	return valid.reduce((a, b) => a + b, 0) / valid.length;
+}
+
+function mergeToolDistributions(sessions: SessionAnalysis[]): Record<string, number> {
+	const merged: Record<string, number> = {};
+	for (const s of sessions) {
+		for (const [name, count] of Object.entries(s.toolDistribution)) {
+			merged[name] = (merged[name] ?? 0) + count;
+		}
+	}
+	return merged;
+}
+
+function buildPeriodMetrics(label: string, sessions: SessionAnalysis[]): PeriodMetrics {
+	const totalToolCalls = sessions.reduce((sum, s) => sum + s.totalToolCalls, 0);
+	const totalCost = sessions.reduce((sum, s) => sum + s.totalCost, 0);
+	const totalTokens = sessions.reduce((sum, s) => sum + s.totalTokens, 0);
+	return {
+		label,
+		sessionCount: sessions.length,
+		avgReadEditRatio: averageNonNull(sessions.map((s) => s.readEditRatio)),
+		avgWriteVsEditPercent: averageNonNull(sessions.map((s) => s.writeVsEditPercent)),
+		avgErrorRate: averageNonNull(sessions.map((s) => s.errorRate)),
+		avgSelfCorrectionPer1K: averageNonNull(sessions.map((s) => s.selfCorrectionPer1K)),
+		toolDistribution: mergeToolDistributions(sessions),
+		totalToolCalls,
+		totalCost,
+		totalTokens,
+		avgCostPerToolCall: totalToolCalls > 0 ? totalCost / totalToolCalls : null,
+		avgTokensPerToolCall: totalToolCalls > 0 ? totalTokens / totalToolCalls : null,
+	};
+}
+
+export function computeProjectTrend(sessions: SessionAnalysis[]): ProjectTrend | null {
+	if (sessions.length < 2) return null;
+
+	const now = Date.now();
+	const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
+
+	const thisWeek = sessions.filter((s) => {
+		const age = now - s.timestamp.getTime();
+		return age >= 0 && age < oneWeekMs;
+	});
+
+	const previousWeek = sessions.filter((s) => {
+		const age = now - s.timestamp.getTime();
+		return age >= oneWeekMs && age < 2 * oneWeekMs;
+	});
+
+	if (thisWeek.length === 0 && previousWeek.length === 0) return null;
+
+	return {
+		currentPeriod: buildPeriodMetrics("This week", thisWeek),
+		previousPeriod: buildPeriodMetrics("Previous week", previousWeek),
+		totalSessions: sessions.length,
+	};
+}
+
+// ── Sparkline ───────────────────────────────────────────────────────────
+
+const SPARK_CHARS = "▁▂▃▄▅▆▇█";
+
+export function sparkline(values: (number | null)[]): string {
+	const nonNull = values.filter((v): v is number => v !== null);
+	if (nonNull.length === 0) return "";
+
+	const min = Math.min(...nonNull);
+	const max = Math.max(...nonNull);
+
+	return values
+		.map((v) => {
+			if (v === null) return " ";
+			if (max === min) return SPARK_CHARS[4]; // ▄
+			const idx = Math.round(((v - min) / (max - min)) * 7);
+			return SPARK_CHARS[idx];
+		})
+		.join("");
+}
+
+// ── computeTimeline ─────────────────────────────────────────────────────
+
+function getMondayOfWeek(date: Date): Date {
+	const d = new Date(date);
+	const day = d.getDay(); // 0=Sun, 1=Mon, ...
+	const diff = day === 0 ? -6 : 1 - day;
+	d.setDate(d.getDate() + diff);
+	d.setHours(0, 0, 0, 0);
+	return d;
+}
+
+function formatShortDate(date: Date): string {
+	const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+	return `${months[date.getMonth()]} ${date.getDate()}`;
+}
+
+export function computeTimeline(sessions: SessionAnalysis[], numWeeks = 8): AnalysisTimeline | null {
+	if (sessions.length < 2) return null;
+
+	const now = new Date();
+	const currentMonday = getMondayOfWeek(now);
+	const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
+
+	const periods: TimePeriod[] = [];
+	for (let i = numWeeks - 1; i >= 0; i--) {
+		const start = new Date(currentMonday.getTime() - i * oneWeekMs);
+		const end = new Date(start.getTime() + oneWeekMs);
+		const label = formatShortDate(start);
+
+		const bucket = sessions.filter((s) => {
+			const t = s.timestamp.getTime();
+			return t >= start.getTime() && t < end.getTime();
+		});
+
+		periods.push({
+			label,
+			start,
+			end,
+			metrics: buildPeriodMetrics(label, bucket),
+		});
+	}
+
+	return {
+		periods,
+		totalSessions: sessions.length,
+	};
+}
+
+// ── computeGroups ───────────────────────────────────────────────────────
+
+function buildGroupSummary(
+	groupKey: string,
+	sessions: SessionAnalysis[],
+	timeline: AnalysisTimeline | null,
+): GroupSummary {
+	const sessionCount = sessions.length;
+	const totalToolCalls = sessions.reduce((sum, s) => sum + s.totalToolCalls, 0);
+	const avgReadEditRatio = averageNonNull(sessions.map((s) => s.readEditRatio));
+	const avgErrorRate = averageNonNull(sessions.map((s) => s.errorRate));
+
+	const sparklineReadEdit: (number | null)[] = [];
+	const sparklineErrorRate: (number | null)[] = [];
+
+	if (timeline) {
+		for (const period of timeline.periods) {
+			const inPeriod = sessions.filter((s) => {
+				const t = s.timestamp.getTime();
+				return t >= period.start.getTime() && t < period.end.getTime();
+			});
+			sparklineReadEdit.push(inPeriod.length > 0 ? averageNonNull(inPeriod.map((s) => s.readEditRatio)) : null);
+			sparklineErrorRate.push(inPeriod.length > 0 ? averageNonNull(inPeriod.map((s) => s.errorRate)) : null);
+		}
+	}
+
+	return {
+		groupKey,
+		sessionCount,
+		totalToolCalls,
+		avgReadEditRatio,
+		avgErrorRate,
+		sparklineReadEdit,
+		sparklineErrorRate,
+	};
+}
+
+export function computeGroups(
+	sessions: SessionAnalysis[],
+	timeline: AnalysisTimeline | null,
+): { byModel: GroupSummary[]; byType: GroupSummary[] } | null {
+	if (sessions.length < 2) return null;
+
+	// By model
+	const modelMap = new Map<string, SessionAnalysis[]>();
+	for (const s of sessions) {
+		const key = s.model ?? "unknown";
+		const arr = modelMap.get(key);
+		if (arr) arr.push(s);
+		else modelMap.set(key, [s]);
+	}
+
+	const byModel = Array.from(modelMap.entries())
+		.map(([key, group]) => buildGroupSummary(key, group, timeline))
+		.sort((a, b) => b.sessionCount - a.sessionCount)
+		.slice(0, 5);
+
+	// By type
+	const typeMap = new Map<string, SessionAnalysis[]>();
+	for (const s of sessions) {
+		const key = s.isSubagent ? (s.agentType ?? "unknown subagent") : "parent";
+		const arr = typeMap.get(key);
+		if (arr) arr.push(s);
+		else typeMap.set(key, [s]);
+	}
+
+	const byType = Array.from(typeMap.entries())
+		.map(([key, group]) => buildGroupSummary(key, group, timeline))
+		.sort((a, b) => b.sessionCount - a.sessionCount);
+
+	return { byModel, byType };
+}
+
+// ── computeDateComparison ───────────────────────────────────────────────
+
+export function computeDateComparison(sessions: SessionAnalysis[], splitDate: Date): DateComparison {
+	const before = sessions.filter((s) => s.timestamp.getTime() < splitDate.getTime());
+	const after = sessions.filter((s) => s.timestamp.getTime() >= splitDate.getTime());
+
+	return {
+		splitDate,
+		before: buildPeriodMetrics(`Before ${formatShortDate(splitDate)}`, before),
+		after: buildPeriodMetrics(`After ${formatShortDate(splitDate)}`, after),
+	};
+}
+
+// ── Format helpers ──────────────────────────────────────────────────────
+
+function bar(count: number, max: number, maxWidth = 30): string {
+	if (max === 0) return "";
+	const width = Math.round((count / max) * maxWidth);
+	return "█".repeat(width);
+}
+
+function fmtNum(v: number | null, suffix = ""): string {
+	if (v === null) return "n/a";
+	return `${v.toFixed(1)}${suffix}`;
+}
+
+function changeStr(current: number | null, previous: number | null): string {
+	if (current === null || previous === null) return "—";
+	if (previous === 0) {
+		if (current === 0) return "→";
+		return "↑ new";
+	}
+	const change = ((current - previous) / Math.abs(previous)) * 100;
+	if (Math.abs(change) < 1) return "→";
+	const arrow = change > 0 ? "↑" : "↓";
+	return `${arrow} ${change > 0 ? "+" : ""}${change.toFixed(0)}%`;
+}
+
+/** Build per-tool sparkline data from a timeline */
+function buildToolSparklines(timeline: AnalysisTimeline, topN = 5): { toolName: string; spark: string }[] {
+	// Aggregate total tool calls across all periods
+	const totalByTool = new Map<string, number>();
+	for (const period of timeline.periods) {
+		for (const [name, count] of Object.entries(period.metrics.toolDistribution)) {
+			totalByTool.set(name, (totalByTool.get(name) ?? 0) + count);
+		}
+	}
+
+	const topTools = Array.from(totalByTool.entries())
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, topN)
+		.map(([name]) => name);
+
+	return topTools.map((toolName) => {
+		const values = timeline.periods.map((p) => {
+			const count = p.metrics.toolDistribution[toolName];
+			return count !== undefined && count > 0 ? count : null;
+		});
+		return { toolName, spark: sparkline(values) };
+	});
+}
+
+// ── formatAnalysisForTui ────────────────────────────────────────────────
+
+export function formatAnalysisForTui(analysis: FullSessionAnalysis): string {
+	const { current, timeline, groups, comparison } = analysis;
+	const lines: string[] = [];
+
+	// ── Current Session ──
+	lines.push("── Current Session ──");
+	lines.push("");
+	if (current.model) lines.push(`  Model:              ${current.model}`);
+	if (current.provider) lines.push(`  Provider:           ${current.provider}`);
+	lines.push(`  Subagent:           ${current.isSubagent ? "yes" : "no"}`);
+	if (current.agentType) lines.push(`  Agent type:         ${current.agentType}`);
+	lines.push(`  Total tool calls:   ${current.totalToolCalls}`);
+	lines.push(`  Tokens:             ${current.totalTokens.toLocaleString()}`);
+	lines.push(`  Cost:               $${current.totalCost.toFixed(4)}`);
+	lines.push(`  Read/Edit ratio:    ${fmtNum(current.readEditRatio)}`);
+	lines.push(`  Write vs Edit:      ${fmtNum(current.writeVsEditPercent, "%")}`);
+	lines.push(`  Error rate:         ${fmtNum(current.errorRate, "%")}`);
+	lines.push(`  Self-corrections:   ${fmtNum(current.selfCorrectionPer1K, " per 1K calls")}`);
+	lines.push("");
+
+	// ── Tool Distribution ──
+	const dist = current.toolDistribution;
+	const entries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+	if (entries.length > 0) {
+		lines.push("── Tool Distribution ──");
+		lines.push("");
+		const maxCount = entries[0][1];
+		const maxNameLen = Math.max(...entries.map(([n]) => n.length));
+		const maxCountLen = Math.max(...entries.map(([, c]) => String(c).length));
+		for (const [name, count] of entries) {
+			const paddedName = name.padEnd(maxNameLen);
+			const paddedCount = String(count).padStart(maxCountLen);
+			lines.push(`  ${paddedName}  ${paddedCount}  ${bar(count, maxCount)}`);
+		}
+		lines.push("");
+	}
+
+	// ── Trends (sparkline section) ──
+	if (timeline) {
+		const weekCount = timeline.periods.length;
+		lines.push(`── Trends (${timeline.totalSessions} sessions, ${weekCount} weeks) ──`);
+		lines.push("");
+
+		// Period header labels
+		const periodLabels = timeline.periods.map((p) => p.label);
+		const labelHeader = `${"".padEnd(16)}${periodLabels.map((l) => l.padEnd(7)).join("")}`;
+		lines.push(labelHeader);
+
+		// Overall metric sparklines
+		const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
+		const errorValues = timeline.periods.map((p) => p.metrics.avgErrorRate);
+		const selfCorrValues = timeline.periods.map((p) => p.metrics.avgSelfCorrectionPer1K);
+
+		const avgRE = averageNonNull(readEditValues);
+		const avgErr = averageNonNull(errorValues);
+		const avgSC = averageNonNull(selfCorrValues);
+
+		const costValues = timeline.periods.map((p) => (p.metrics.totalCost > 0 ? p.metrics.totalCost : null));
+		const tokensPerCallValues = timeline.periods.map((p) => p.metrics.avgTokensPerToolCall);
+		const avgCost = averageNonNull(costValues);
+		const avgTPC = averageNonNull(tokensPerCallValues);
+
+		lines.push(`  Read:Edit     ${sparkline(readEditValues)}   avg ${fmtNum(avgRE)}`);
+		lines.push(`  Error Rate    ${sparkline(errorValues)}   avg ${fmtNum(avgErr, "%")}`);
+		lines.push(`  Self-Correct  ${sparkline(selfCorrValues)}   avg ${fmtNum(avgSC, "/1K")}`);
+		lines.push(`  Cost/week     ${sparkline(costValues)}   avg $${avgCost != null ? avgCost.toFixed(4) : "n/a"}`);
+		lines.push(
+			`  Tokens/call   ${sparkline(tokensPerCallValues)}   avg ${avgTPC != null ? Math.round(avgTPC).toLocaleString() : "n/a"}`,
+		);
+		lines.push("");
+
+		// Per-tool sparklines
+		const toolSparks = buildToolSparklines(timeline);
+		if (toolSparks.length > 0) {
+			const maxToolName = Math.max(...toolSparks.map((t) => t.toolName.length));
+			for (const { toolName, spark } of toolSparks) {
+				lines.push(`  Tool: ${toolName.padEnd(maxToolName)}  ${spark}`);
+			}
+			lines.push("");
+		}
+	}
+
+	// ── By Model ──
+	if (groups && groups.byModel.length > 0) {
+		lines.push("── By Model ──");
+		lines.push("");
+		const maxKeyLen = Math.max(...groups.byModel.map((g) => g.groupKey.length));
+		for (const g of groups.byModel) {
+			const key = g.groupKey.padEnd(maxKeyLen);
+			const count = `${g.sessionCount} sessions`.padEnd(14);
+			const re = `R:E ${fmtNum(g.avgReadEditRatio)}`.padEnd(10);
+			const err = `Err ${fmtNum(g.avgErrorRate, "%")}`.padEnd(11);
+			const spark = sparkline(g.sparklineReadEdit);
+			lines.push(`  ${key}  ${count}  ${re}  ${err}  ${spark}`);
+		}
+		lines.push("");
+	}
+
+	// ── By Type ──
+	if (groups && groups.byType.length > 0) {
+		lines.push("── By Type ──");
+		lines.push("");
+		const maxKeyLen = Math.max(...groups.byType.map((g) => g.groupKey.length));
+		for (const g of groups.byType) {
+			const key = g.groupKey.padEnd(maxKeyLen);
+			const count = `${g.sessionCount} sessions`.padEnd(14);
+			const re = `R:E ${fmtNum(g.avgReadEditRatio)}`.padEnd(10);
+			const err = `Err ${fmtNum(g.avgErrorRate, "%")}`.padEnd(11);
+			const spark = sparkline(g.sparklineReadEdit);
+			lines.push(`  ${key}  ${count}  ${re}  ${err}  ${spark}`);
+		}
+		lines.push("");
+	}
+
+	// ── Date Comparison ──
+	if (comparison) {
+		const splitStr = comparison.splitDate.toISOString().slice(0, 10);
+		lines.push(`── Comparison: split at ${splitStr} ──`);
+		lines.push("");
+		const { before: b, after: a } = comparison;
+		const colW = 13;
+		const hdrBefore = `Before (${b.sessionCount})`.padEnd(colW);
+		const hdrAfter = `After (${a.sessionCount})`.padEnd(colW);
+		lines.push(`${"".padEnd(20)} ${hdrBefore} ${hdrAfter}  Change`);
+		lines.push(
+			`  Read:Edit          ${fmtNum(b.avgReadEditRatio).padEnd(colW)} ${fmtNum(a.avgReadEditRatio).padEnd(colW)}  ${changeStr(a.avgReadEditRatio, b.avgReadEditRatio)}`,
+		);
+		lines.push(
+			`  Write vs Edit      ${fmtNum(b.avgWriteVsEditPercent, "%").padEnd(colW)} ${fmtNum(a.avgWriteVsEditPercent, "%").padEnd(colW)}  ${changeStr(a.avgWriteVsEditPercent, b.avgWriteVsEditPercent)}`,
+		);
+		lines.push(
+			`  Error Rate         ${fmtNum(b.avgErrorRate, "%").padEnd(colW)} ${fmtNum(a.avgErrorRate, "%").padEnd(colW)}  ${changeStr(a.avgErrorRate, b.avgErrorRate)}`,
+		);
+		lines.push(
+			`  Self-Correction    ${fmtNum(b.avgSelfCorrectionPer1K, "/1K").padEnd(colW)} ${fmtNum(a.avgSelfCorrectionPer1K, "/1K").padEnd(colW)}  ${changeStr(a.avgSelfCorrectionPer1K, b.avgSelfCorrectionPer1K)}`,
+		);
+		lines.push(
+			`  Cost               $${b.totalCost.toFixed(4).padEnd(colW - 1)} $${a.totalCost.toFixed(4).padEnd(colW - 1)}  ${changeStr(a.totalCost, b.totalCost)}`,
+		);
+		lines.push(
+			`  Tokens/call        ${fmtNum(b.avgTokensPerToolCall).padEnd(colW)} ${fmtNum(a.avgTokensPerToolCall).padEnd(colW)}  ${changeStr(a.avgTokensPerToolCall, b.avgTokensPerToolCall)}`,
+		);
+		lines.push("");
+	}
+
+	// ── Footer ──
+	lines.push("Note: These metrics are noisy proxies for session behavior, not quality scores.");
+	lines.push("Use them for self-reflection, not performance evaluation.");
+
+	return lines.join("\n");
+}
+
+// ── formatAnalysisForTelegram ───────────────────────────────────────────
+
+export function formatAnalysisForTelegram(analysis: FullSessionAnalysis): string {
+	const { current, timeline, groups, comparison } = analysis;
+	const lines: string[] = [];
+
+	// ── Current Session ──
+	lines.push("📊 *Session Analysis*");
+	lines.push("");
+	if (current.model) lines.push(`Model: \`${current.model}\``);
+	if (current.provider) lines.push(`Provider: \`${current.provider}\``);
+	lines.push(`Subagent: ${current.isSubagent ? "yes" : "no"}`);
+	if (current.agentType) lines.push(`Type: \`${current.agentType}\``);
+	lines.push(`Total tool calls: ${current.totalToolCalls}`);
+	lines.push(`Tokens: ${current.totalTokens.toLocaleString()} | Cost: $${current.totalCost.toFixed(4)}`);
+	lines.push("");
+	lines.push("```");
+	lines.push(`Read/Edit ratio:   ${fmtNum(current.readEditRatio)}`);
+	lines.push(`Write vs Edit:     ${fmtNum(current.writeVsEditPercent, "%")}`);
+	lines.push(`Error rate:        ${fmtNum(current.errorRate, "%")}`);
+	lines.push(`Self-corrections:  ${fmtNum(current.selfCorrectionPer1K, "/1K")}`);
+	lines.push("```");
+
+	// ── Tool Distribution ──
+	const dist = current.toolDistribution;
+	const distEntries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+	if (distEntries.length > 0) {
+		lines.push("");
+		lines.push("🔧 *Tool Distribution*");
+		lines.push("");
+		lines.push("```");
+		const maxNameLen = Math.max(...distEntries.map(([n]) => n.length));
+		const maxCountLen = Math.max(...distEntries.map(([, c]) => String(c).length));
+		for (const [name, count] of distEntries) {
+			lines.push(`${name.padEnd(maxNameLen)}  ${String(count).padStart(maxCountLen)}`);
+		}
+		lines.push("```");
+	}
+
+	// ── Trends ──
+	if (timeline) {
+		lines.push("");
+		lines.push(`📈 *Trends* (${timeline.totalSessions} sessions, ${timeline.periods.length} weeks)`);
+		lines.push("");
+
+		const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
+		const errorValues = timeline.periods.map((p) => p.metrics.avgErrorRate);
+		const selfCorrValues = timeline.periods.map((p) => p.metrics.avgSelfCorrectionPer1K);
+
+		const costValues = timeline.periods.map((p) => (p.metrics.totalCost > 0 ? p.metrics.totalCost : null));
+		const avgCostTg = averageNonNull(costValues);
+
+		lines.push("```");
+		lines.push(`Read:Edit    ${sparkline(readEditValues)}  avg ${fmtNum(averageNonNull(readEditValues))}`);
+		lines.push(`Error Rate   ${sparkline(errorValues)}  avg ${fmtNum(averageNonNull(errorValues), "%")}`);
+		lines.push(`Self-Corr    ${sparkline(selfCorrValues)}  avg ${fmtNum(averageNonNull(selfCorrValues), "/1K")}`);
+		lines.push(`Cost/week    ${sparkline(costValues)}  avg $${avgCostTg != null ? avgCostTg.toFixed(4) : "n/a"}`);
+		lines.push("```");
+	}
+
+	// ── By Model (top 3) ──
+	if (groups && groups.byModel.length > 0) {
+		lines.push("");
+		lines.push("🤖 *By Model*");
+		lines.push("");
+		lines.push("```");
+		const top = groups.byModel.slice(0, 3);
+		const maxKeyLen = Math.max(...top.map((g) => g.groupKey.length));
+		for (const g of top) {
+			const key = g.groupKey.padEnd(maxKeyLen);
+			const spark = sparkline(g.sparklineReadEdit);
+			lines.push(`${key}  ${String(g.sessionCount).padStart(3)}s  R:E ${fmtNum(g.avgReadEditRatio)}  ${spark}`);
+		}
+		lines.push("```");
+	}
+
+	// ── By Type (top 3) ──
+	if (groups && groups.byType.length > 0) {
+		lines.push("");
+		lines.push("🏷️ *By Type*");
+		lines.push("");
+		lines.push("```");
+		const top = groups.byType.slice(0, 3);
+		const maxKeyLen = Math.max(...top.map((g) => g.groupKey.length));
+		for (const g of top) {
+			const key = g.groupKey.padEnd(maxKeyLen);
+			const spark = sparkline(g.sparklineReadEdit);
+			lines.push(`${key}  ${String(g.sessionCount).padStart(3)}s  R:E ${fmtNum(g.avgReadEditRatio)}  ${spark}`);
+		}
+		lines.push("```");
+	}
+
+	// ── Date Comparison ──
+	if (comparison) {
+		const splitStr = comparison.splitDate.toISOString().slice(0, 10);
+		const { before: b, after: a } = comparison;
+		lines.push("");
+		lines.push(`📅 *Comparison: split at ${splitStr}*`);
+		lines.push("");
+		lines.push("```");
+		lines.push(`              Before(${b.sessionCount})  After(${a.sessionCount})  Change`);
+		lines.push(
+			`Read:Edit     ${fmtNum(b.avgReadEditRatio).padEnd(11)} ${fmtNum(a.avgReadEditRatio).padEnd(10)} ${changeStr(a.avgReadEditRatio, b.avgReadEditRatio)}`,
+		);
+		lines.push(
+			`Write/Edit    ${fmtNum(b.avgWriteVsEditPercent, "%").padEnd(11)} ${fmtNum(a.avgWriteVsEditPercent, "%").padEnd(10)} ${changeStr(a.avgWriteVsEditPercent, b.avgWriteVsEditPercent)}`,
+		);
+		lines.push(
+			`Error Rate    ${fmtNum(b.avgErrorRate, "%").padEnd(11)} ${fmtNum(a.avgErrorRate, "%").padEnd(10)} ${changeStr(a.avgErrorRate, b.avgErrorRate)}`,
+		);
+		lines.push(
+			`Self-Corr     ${fmtNum(b.avgSelfCorrectionPer1K, "/1K").padEnd(11)} ${fmtNum(a.avgSelfCorrectionPer1K, "/1K").padEnd(10)} ${changeStr(a.avgSelfCorrectionPer1K, b.avgSelfCorrectionPer1K)}`,
+		);
+		lines.push(
+			`Cost          $${b.totalCost.toFixed(4).padEnd(10)} $${a.totalCost.toFixed(4).padEnd(9)} ${changeStr(a.totalCost, b.totalCost)}`,
+		);
+		lines.push("```");
+	}
+
+	// ── Footer ──
+	lines.push("");
+	lines.push("_These metrics are noisy proxies, not quality scores._");
+
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/core/session-analyzer.ts
+++ b/packages/coding-agent/src/core/session-analyzer.ts
@@ -102,7 +102,7 @@ export interface FullSessionAnalysis {
 		byType: GroupSummary[];
 	} | null;
 	comparison: DateComparison | null;
-	trend: { currentPeriod: PeriodMetrics; previousPeriod: PeriodMetrics; totalSessions: number } | null;
+	trend: ProjectTrend | null;
 }
 
 // ── Read / Edit tool sets ───────────────────────────────────────────────
@@ -481,7 +481,7 @@ export function computeGroups(
 	// By type
 	const typeMap = new Map<string, SessionAnalysis[]>();
 	for (const s of sessions) {
-		const key = s.isSubagent ? (s.agentType ?? "unknown subagent") : "parent";
+		const key = s.isSubagent ? (s.agentType ?? "subagent (legacy)") : "parent";
 		const arr = typeMap.get(key);
 		if (arr) arr.push(s);
 		else typeMap.set(key, [s]);
@@ -598,13 +598,10 @@ export function formatAnalysisForTui(analysis: FullSessionAnalysis): string {
 	// ── Trends (sparkline section) ──
 	if (timeline) {
 		const weekCount = timeline.periods.length;
-		lines.push(`── Trends (${timeline.totalSessions} sessions, ${weekCount} weeks) ──`);
+		const firstLabel = timeline.periods[0].label;
+		const lastLabel = timeline.periods[timeline.periods.length - 1].label;
+		lines.push(`── Trends (${timeline.totalSessions} sessions, ${weekCount} weeks: ${firstLabel} – ${lastLabel}) ──`);
 		lines.push("");
-
-		// Period header labels
-		const periodLabels = timeline.periods.map((p) => p.label);
-		const labelHeader = `${"".padEnd(16)}${periodLabels.map((l) => l.padEnd(7)).join("")}`;
-		lines.push(labelHeader);
 
 		// Overall metric sparklines
 		const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
@@ -706,132 +703,6 @@ export function formatAnalysisForTui(analysis: FullSessionAnalysis): string {
 	// ── Footer ──
 	lines.push("Note: These metrics are noisy proxies for session behavior, not quality scores.");
 	lines.push("Use them for self-reflection, not performance evaluation.");
-
-	return lines.join("\n");
-}
-
-// ── formatAnalysisForTelegram ───────────────────────────────────────────
-
-export function formatAnalysisForTelegram(analysis: FullSessionAnalysis): string {
-	const { current, timeline, groups, comparison } = analysis;
-	const lines: string[] = [];
-
-	// ── Current Session ──
-	lines.push("📊 *Session Analysis*");
-	lines.push("");
-	if (current.model) lines.push(`Model: \`${current.model}\``);
-	if (current.provider) lines.push(`Provider: \`${current.provider}\``);
-	lines.push(`Subagent: ${current.isSubagent ? "yes" : "no"}`);
-	if (current.agentType) lines.push(`Type: \`${current.agentType}\``);
-	lines.push(`Total tool calls: ${current.totalToolCalls}`);
-	lines.push(`Tokens: ${current.totalTokens.toLocaleString()} | Cost: $${current.totalCost.toFixed(4)}`);
-	lines.push("");
-	lines.push("```");
-	lines.push(`Read/Edit ratio:   ${fmtNum(current.readEditRatio)}`);
-	lines.push(`Write vs Edit:     ${fmtNum(current.writeVsEditPercent, "%")}`);
-	lines.push(`Error rate:        ${fmtNum(current.errorRate, "%")}`);
-	lines.push(`Self-corrections:  ${fmtNum(current.selfCorrectionPer1K, "/1K")}`);
-	lines.push("```");
-
-	// ── Tool Distribution ──
-	const dist = current.toolDistribution;
-	const distEntries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
-	if (distEntries.length > 0) {
-		lines.push("");
-		lines.push("🔧 *Tool Distribution*");
-		lines.push("");
-		lines.push("```");
-		const maxNameLen = Math.max(...distEntries.map(([n]) => n.length));
-		const maxCountLen = Math.max(...distEntries.map(([, c]) => String(c).length));
-		for (const [name, count] of distEntries) {
-			lines.push(`${name.padEnd(maxNameLen)}  ${String(count).padStart(maxCountLen)}`);
-		}
-		lines.push("```");
-	}
-
-	// ── Trends ──
-	if (timeline) {
-		lines.push("");
-		lines.push(`📈 *Trends* (${timeline.totalSessions} sessions, ${timeline.periods.length} weeks)`);
-		lines.push("");
-
-		const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
-		const errorValues = timeline.periods.map((p) => p.metrics.avgErrorRate);
-		const selfCorrValues = timeline.periods.map((p) => p.metrics.avgSelfCorrectionPer1K);
-
-		const costValues = timeline.periods.map((p) => (p.metrics.totalCost > 0 ? p.metrics.totalCost : null));
-		const avgCostTg = averageNonNull(costValues);
-
-		lines.push("```");
-		lines.push(`Read:Edit    ${sparkline(readEditValues)}  avg ${fmtNum(averageNonNull(readEditValues))}`);
-		lines.push(`Error Rate   ${sparkline(errorValues)}  avg ${fmtNum(averageNonNull(errorValues), "%")}`);
-		lines.push(`Self-Corr    ${sparkline(selfCorrValues)}  avg ${fmtNum(averageNonNull(selfCorrValues), "/1K")}`);
-		lines.push(`Cost/week    ${sparkline(costValues)}  avg $${avgCostTg != null ? avgCostTg.toFixed(4) : "n/a"}`);
-		lines.push("```");
-	}
-
-	// ── By Model (top 3) ──
-	if (groups && groups.byModel.length > 0) {
-		lines.push("");
-		lines.push("🤖 *By Model*");
-		lines.push("");
-		lines.push("```");
-		const top = groups.byModel.slice(0, 3);
-		const maxKeyLen = Math.max(...top.map((g) => g.groupKey.length));
-		for (const g of top) {
-			const key = g.groupKey.padEnd(maxKeyLen);
-			const spark = sparkline(g.sparklineReadEdit);
-			lines.push(`${key}  ${String(g.sessionCount).padStart(3)}s  R:E ${fmtNum(g.avgReadEditRatio)}  ${spark}`);
-		}
-		lines.push("```");
-	}
-
-	// ── By Type (top 3) ──
-	if (groups && groups.byType.length > 0) {
-		lines.push("");
-		lines.push("🏷️ *By Type*");
-		lines.push("");
-		lines.push("```");
-		const top = groups.byType.slice(0, 3);
-		const maxKeyLen = Math.max(...top.map((g) => g.groupKey.length));
-		for (const g of top) {
-			const key = g.groupKey.padEnd(maxKeyLen);
-			const spark = sparkline(g.sparklineReadEdit);
-			lines.push(`${key}  ${String(g.sessionCount).padStart(3)}s  R:E ${fmtNum(g.avgReadEditRatio)}  ${spark}`);
-		}
-		lines.push("```");
-	}
-
-	// ── Date Comparison ──
-	if (comparison) {
-		const splitStr = comparison.splitDate.toISOString().slice(0, 10);
-		const { before: b, after: a } = comparison;
-		lines.push("");
-		lines.push(`📅 *Comparison: split at ${splitStr}*`);
-		lines.push("");
-		lines.push("```");
-		lines.push(`              Before(${b.sessionCount})  After(${a.sessionCount})  Change`);
-		lines.push(
-			`Read:Edit     ${fmtNum(b.avgReadEditRatio).padEnd(11)} ${fmtNum(a.avgReadEditRatio).padEnd(10)} ${changeStr(a.avgReadEditRatio, b.avgReadEditRatio)}`,
-		);
-		lines.push(
-			`Write/Edit    ${fmtNum(b.avgWriteVsEditPercent, "%").padEnd(11)} ${fmtNum(a.avgWriteVsEditPercent, "%").padEnd(10)} ${changeStr(a.avgWriteVsEditPercent, b.avgWriteVsEditPercent)}`,
-		);
-		lines.push(
-			`Error Rate    ${fmtNum(b.avgErrorRate, "%").padEnd(11)} ${fmtNum(a.avgErrorRate, "%").padEnd(10)} ${changeStr(a.avgErrorRate, b.avgErrorRate)}`,
-		);
-		lines.push(
-			`Self-Corr     ${fmtNum(b.avgSelfCorrectionPer1K, "/1K").padEnd(11)} ${fmtNum(a.avgSelfCorrectionPer1K, "/1K").padEnd(10)} ${changeStr(a.avgSelfCorrectionPer1K, b.avgSelfCorrectionPer1K)}`,
-		);
-		lines.push(
-			`Cost          $${b.totalCost.toFixed(4).padEnd(10)} $${a.totalCost.toFixed(4).padEnd(9)} ${changeStr(a.totalCost, b.totalCost)}`,
-		);
-		lines.push("```");
-	}
-
-	// ── Footer ──
-	lines.push("");
-	lines.push("_These metrics are noisy proxies, not quality scores._");
 
 	return lines.join("\n");
 }

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -33,11 +33,13 @@ export interface SessionHeader {
 	timestamp: string;
 	cwd: string;
 	parentSession?: string;
+	agentType?: string;
 }
 
 export interface NewSessionOptions {
 	id?: string;
 	parentSession?: string;
+	agentType?: string;
 }
 
 export interface SessionEntryBase {
@@ -674,7 +676,13 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
 
-	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
+	private constructor(
+		cwd: string,
+		sessionDir: string,
+		sessionFile: string | undefined,
+		persist: boolean,
+		newSessionOptions?: NewSessionOptions,
+	) {
 		this.cwd = cwd;
 		this.sessionDir = sessionDir;
 		this.persist = persist;
@@ -685,7 +693,7 @@ export class SessionManager {
 		if (sessionFile) {
 			this.setSessionFile(sessionFile);
 		} else {
-			this.newSession();
+			this.newSession(newSessionOptions);
 		}
 	}
 
@@ -732,6 +740,7 @@ export class SessionManager {
 			timestamp,
 			cwd: this.cwd,
 			parentSession: options?.parentSession,
+			agentType: options?.agentType,
 		};
 		this.fileEntries = [header];
 		this.byId.clear();
@@ -1255,9 +1264,9 @@ export class SessionManager {
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.dreb/agent/sessions/<encoded-cwd>/).
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, options?: NewSessionOptions): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, options);
 	}
 
 	/**

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -23,6 +23,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "copy", description: "Copy last agent message to clipboard" },
 	{ name: "name", description: "Set session display name" },
 	{ name: "session", description: "Show session info and stats" },
+	{ name: "session-analysis", description: "Behavioral quality metrics and trends" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
 	{ name: "fork", description: "Create a new fork from a previous message" },

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -190,6 +190,9 @@ async function spawnSubagent(
 	} else {
 		args.push("--no-session");
 	}
+	if (agentConfig.name) {
+		args.push("--agent-type", agentConfig.name);
+	}
 	// By spawn time, model should be a resolved single string (fallback resolution
 	// happens in executeSingle). Handle string[] defensively by taking the first entry.
 	const modelStr = Array.isArray(agentConfig.model) ? agentConfig.model[0] : agentConfig.model;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -495,7 +495,8 @@ async function createSessionManager(
 	// --resume is handled separately (needs picker UI)
 	// If effective session dir is set, create new session there
 	if (effectiveSessionDir) {
-		return SessionManager.create(cwd, effectiveSessionDir);
+		const newSessionOptions = parsed.agentType ? { agentType: parsed.agentType } : undefined;
+		return SessionManager.create(cwd, effectiveSessionDir, newSessionOptions);
 	}
 	// Default case (new session) returns undefined, SDK will create one
 	return undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,6 +56,7 @@ import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
 import type { ResourceDiagnostic } from "../../core/resource-loader.js";
+import { generateAnalysisHtml } from "../../core/session-analysis-html.js";
 import { sparkline } from "../../core/session-analyzer.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
@@ -4288,153 +4289,70 @@ export class InteractiveMode {
 			}
 
 			const analysis = await this.session.getSessionAnalysis(splitDate ? { splitDate } : undefined);
-			const { current, timeline, groups, comparison } = analysis;
+			const { current, timeline } = analysis;
 
 			this.chatContainer.removeChild(loader);
 
+			// ── Inline TUI summary ──
+			const fmtVal = (v: number | null, suffix = ""): string => (v !== null ? `${v.toFixed(1)}${suffix}` : "n/a");
+
 			let info = `${theme.bold("Session Analysis")}\n\n`;
 
-			// ── Current Session ──
-			info += `${theme.bold("Current Session")}\n`;
+			// Current session metrics
+			info += `${theme.bold("Current Session")}`;
 			if (current.model) {
-				info += `${theme.fg("dim", "Model:")} ${current.provider ? `${current.provider}/` : ""}${current.model}\n`;
+				info += `  ${theme.fg("dim", current.provider ? `${current.provider}/${current.model}` : current.model)}`;
 			}
-			info += `${theme.fg("dim", "Tool Calls:")} ${current.totalToolCalls}\n`;
-			info += `${theme.fg("dim", "Tokens:")} ${current.totalTokens.toLocaleString()}\n`;
+			info += "\n";
+			info += `${theme.fg("dim", "Tool Calls:")} ${current.totalToolCalls}`;
+			info += `  ${theme.fg("dim", "Tokens:")} ${current.totalTokens.toLocaleString()}`;
 			if (current.totalCost > 0) {
-				info += `${theme.fg("dim", "Cost:")} $${current.totalCost.toFixed(4)}\n`;
+				info += `  ${theme.fg("dim", "Cost:")} $${current.totalCost.toFixed(4)}`;
 			}
+			info += "\n";
 
 			if (current.totalToolCalls > 0) {
-				info += `\n${theme.fg("dim", "Read:Edit Ratio:")} ${current.readEditRatio != null ? current.readEditRatio.toFixed(1) : "N/A (no edits)"}\n`;
-				info += `${theme.fg("dim", "Write vs Edit:")} ${current.writeVsEditPercent != null ? `${current.writeVsEditPercent.toFixed(0)}%` : "N/A"}\n`;
-				info += `${theme.fg("dim", "Error Rate:")} ${current.errorRate != null ? `${current.errorRate.toFixed(1)}%` : "N/A"}\n`;
-				info += `${theme.fg("dim", "Self-Correction:")} ${current.selfCorrectionPer1K != null ? `${current.selfCorrectionPer1K.toFixed(1)} per 1K calls` : "N/A"}\n`;
+				info += `${theme.fg("dim", "Read:Edit:")} ${fmtVal(current.readEditRatio)}`;
+				info += `  ${theme.fg("dim", "Write%:")} ${fmtVal(current.writeVsEditPercent, "%")}`;
+				info += `  ${theme.fg("dim", "Errors:")} ${fmtVal(current.errorRate, "%")}`;
+				info += `  ${theme.fg("dim", "Self-Corr:")} ${fmtVal(current.selfCorrectionPer1K, "/1K")}`;
+				info += "\n";
 			}
 
-			// ── Tool Distribution ──
-			const dist = current.toolDistribution;
-			const toolEntries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+			// Top-5 tool counts (compact)
+			const toolEntries = Object.entries(current.toolDistribution).sort((a, b) => b[1] - a[1]);
 			if (toolEntries.length > 0) {
-				info += `\n${theme.bold("Tool Distribution")}\n`;
-				const maxCount = toolEntries[0][1];
-				const maxBarWidth = 25;
-				const maxNameLen = Math.max(...toolEntries.map(([n]) => n.length));
-				for (const [name, count] of toolEntries) {
-					const barLen = maxCount > 0 ? Math.max(1, Math.round((count / maxCount) * maxBarWidth)) : 0;
-					const barStr = "\u2588".repeat(barLen);
-					const paddedName = name.padEnd(maxNameLen);
-					info += `  ${theme.fg("dim", paddedName)}  ${String(count).padStart(4)}  ${theme.fg("accent", barStr)}\n`;
-				}
+				const top5 = toolEntries.slice(0, 5);
+				const toolLine = top5.map(([name, count]) => `${name}:${count}`).join("  ");
+				info += `${theme.fg("dim", "Top tools:")} ${toolLine}`;
+				if (toolEntries.length > 5) info += `  ${theme.fg("dim", `+${toolEntries.length - 5} more`)}`;
+				info += "\n";
 			}
 
-			// ── Sparkline Trends ──
+			// Sparkline trends (compact)
 			if (timeline && timeline.periods.length > 1) {
-				info += `\n${theme.bold("Trends")} ${theme.fg("dim", `(${timeline.totalSessions} sessions, ${timeline.periods.length} weeks)`)}\n`;
+				const firstLabel = timeline.periods[0].label;
+				const lastLabel = timeline.periods[timeline.periods.length - 1].label;
+				info += `\n${theme.bold("Trends")} ${theme.fg("dim", `(${timeline.totalSessions} sessions, ${timeline.periods.length} weeks: ${firstLabel} – ${lastLabel})`)}\n`;
 
-				// Period labels
-				const labels = timeline.periods.map((p) => p.label);
-				const labelRow = `  ${"  ".padEnd(18)}${labels.map((l) => l.padEnd(7)).join(" ")}`;
-				info += `${theme.fg("dim", labelRow)}\n`;
-
-				// Metric sparklines
 				const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
 				const errorValues = timeline.periods.map((p) => p.metrics.avgErrorRate);
 				const selfCorrValues = timeline.periods.map((p) => p.metrics.avgSelfCorrectionPer1K);
 
-				const fmtAvg = (vals: (number | null)[], suffix = ""): string => {
-					const valid = vals.filter((v): v is number => v !== null);
-					if (valid.length === 0) return "";
-					const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
-					return `  avg ${avg.toFixed(1)}${suffix}`;
-				};
-
-				info += `  ${theme.fg("dim", "Read:Edit".padEnd(16))}  ${theme.fg("accent", sparkline(readEditValues))}${fmtAvg(readEditValues)}\n`;
-				info += `  ${theme.fg("dim", "Error Rate".padEnd(16))}  ${theme.fg("accent", sparkline(errorValues))}${fmtAvg(errorValues, "%")}\n`;
-				info += `  ${theme.fg("dim", "Self-Correct".padEnd(16))}  ${theme.fg("accent", sparkline(selfCorrValues))}${fmtAvg(selfCorrValues, "/1K")}\n`;
-
-				// Per-tool sparklines (top 5 tools by total usage)
-				const toolTotals: Record<string, number> = {};
-				for (const p of timeline.periods) {
-					for (const [tool, count] of Object.entries(p.metrics.toolDistribution)) {
-						toolTotals[tool] = (toolTotals[tool] ?? 0) + count;
-					}
-				}
-				const topTools = Object.entries(toolTotals)
-					.sort((a, b) => b[1] - a[1])
-					.slice(0, 5);
-
-				if (topTools.length > 0) {
-					info += "\n";
-					for (const [toolName] of topTools) {
-						const toolValues = timeline.periods.map((p) => p.metrics.toolDistribution[toolName] ?? 0);
-						// Convert to nullable for sparkline (0 is valid, not null)
-						const sparkValues = toolValues.map((v) => v as number | null);
-						info += `  ${theme.fg("dim", `Tool: ${toolName}`.padEnd(16))}  ${theme.fg("accent", sparkline(sparkValues))}\n`;
-					}
-				}
+				info += `  ${theme.fg("dim", "Read:Edit")}    ${theme.fg("accent", sparkline(readEditValues))}`;
+				info += `  ${theme.fg("dim", "Error")} ${theme.fg("accent", sparkline(errorValues))}`;
+				info += `  ${theme.fg("dim", "Self-Corr")} ${theme.fg("accent", sparkline(selfCorrValues))}`;
+				info += "\n";
 			}
 
-			// ── By Model ──
-			if (groups && groups.byModel.length > 0) {
-				info += `\n${theme.bold("By Model")}\n`;
-				for (const g of groups.byModel.slice(0, 5)) {
-					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
-					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
-					const spark = sparkline(g.sparklineReadEdit);
-					info += `  ${theme.fg("dim", g.groupKey.padEnd(22))} ${String(g.sessionCount).padStart(3)} sessions  ${re.padEnd(9)} ${err.padEnd(10)} ${theme.fg("accent", spark)}\n`;
-				}
-			}
+			// Generate HTML report
+			const html = generateAnalysisHtml(analysis);
+			const timestamp = Date.now();
+			const htmlPath = `/tmp/dreb-analysis-${timestamp}.html`;
+			fs.writeFileSync(htmlPath, html, "utf-8");
+			const fileUrl = `file://${htmlPath}`;
 
-			// ── By Type ──
-			if (groups && groups.byType.length > 0) {
-				info += `\n${theme.bold("By Type")}\n`;
-				for (const g of groups.byType) {
-					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
-					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
-					const spark = sparkline(g.sparklineReadEdit);
-					info += `  ${theme.fg("dim", g.groupKey.padEnd(22))} ${String(g.sessionCount).padStart(3)} sessions  ${re.padEnd(9)} ${err.padEnd(10)} ${theme.fg("accent", spark)}\n`;
-				}
-			}
-
-			// ── Date Comparison ──
-			if (comparison) {
-				const dateStr = comparison.splitDate.toISOString().slice(0, 10);
-				info += `\n${theme.bold(`Comparison: split at ${dateStr}`)}\n`;
-
-				const b = comparison.before;
-				const a = comparison.after;
-
-				const hdr = `  ${"  ".padEnd(18)} ${theme.fg("dim", `Before (${b.sessionCount})`.padEnd(14))} ${theme.fg("dim", `After (${a.sessionCount})`.padEnd(14))} Change`;
-				info += `${hdr}\n`;
-
-				const compRow = (
-					label: string,
-					bv: number | null,
-					av: number | null,
-					suffix = "",
-					decimals = 1,
-				): string => {
-					const bs = bv != null ? bv.toFixed(decimals) + suffix : "\u2014";
-					const as_ = av != null ? av.toFixed(decimals) + suffix : "\u2014";
-					let change = "";
-					if (bv != null && av != null && bv !== 0) {
-						const pct = ((av - bv) / Math.abs(bv)) * 100;
-						const arrow = pct > 5 ? "\u2191" : pct < -5 ? "\u2193" : "\u2192";
-						change = `${arrow} ${pct > 0 ? "+" : ""}${pct.toFixed(0)}%`;
-					}
-					return `  ${label.padEnd(18)} ${bs.padEnd(14)} ${as_.padEnd(14)} ${change}`;
-				};
-
-				info += `${compRow("Read:Edit", b.avgReadEditRatio, a.avgReadEditRatio)}\n`;
-				info += `${compRow("Write vs Edit", b.avgWriteVsEditPercent, a.avgWriteVsEditPercent, "%", 0)}\n`;
-				info += `${compRow("Error Rate", b.avgErrorRate, a.avgErrorRate, "%")}\n`;
-				info += `${compRow("Self-Correction", b.avgSelfCorrectionPer1K, a.avgSelfCorrectionPer1K, "/1K")}\n`;
-			}
-
-			// ── Caveat ──
-			info += `\n${theme.fg("dim", "Note: These metrics are noisy proxies for task characteristics, not quality scores.")}\n`;
-			info += `${theme.fg("dim", "Interpret relative to your project's own baseline, not as absolute values.")}`;
+			info += `\n${theme.fg("accent", "Full report:")} ${fileUrl}`;
 
 			this.chatContainer.addChild(new Spacer(1));
 			this.chatContainer.addChild(new Text(info, 1, 0));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,6 +56,7 @@ import { createCompactionSummaryMessage } from "../../core/messages.js";
 import { findExactModelReferenceMatch, resolveModelScope } from "../../core/model-resolver.js";
 import { DefaultPackageManager } from "../../core/package-manager.js";
 import type { ResourceDiagnostic } from "../../core/resource-loader.js";
+import { sparkline } from "../../core/session-analyzer.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import type { SourceInfo } from "../../core/source-info.js";
@@ -2132,6 +2133,12 @@ export class InteractiveMode {
 			}
 			if (text === "/session") {
 				this.handleSessionCommand();
+				this.editor.setText("");
+				return;
+			}
+			if (text === "/session-analysis" || text.startsWith("/session-analysis ")) {
+				const arg = text.slice("/session-analysis".length).trim();
+				this.handleSessionAnalysisCommand(arg || undefined);
 				this.editor.setText("");
 				return;
 			}
@@ -4263,6 +4270,182 @@ export class InteractiveMode {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(info, 1, 0));
 		this.ui.requestRender();
+	}
+
+	private async handleSessionAnalysisCommand(dateArg?: string): Promise<void> {
+		const loader = new BorderedLoader(this.ui, theme, "Analyzing sessions...", { cancellable: false });
+		this.chatContainer.addChild(loader);
+		this.ui.requestRender();
+
+		try {
+			// Parse optional date arg (YYYYMMDD format)
+			let splitDate: Date | undefined;
+			if (dateArg) {
+				const match = dateArg.match(/^(\d{4})(\d{2})(\d{2})$/);
+				if (match) {
+					splitDate = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+				}
+			}
+
+			const analysis = await this.session.getSessionAnalysis(splitDate ? { splitDate } : undefined);
+			const { current, timeline, groups, comparison } = analysis;
+
+			this.chatContainer.removeChild(loader);
+
+			let info = `${theme.bold("Session Analysis")}\n\n`;
+
+			// ── Current Session ──
+			info += `${theme.bold("Current Session")}\n`;
+			if (current.model) {
+				info += `${theme.fg("dim", "Model:")} ${current.provider ? `${current.provider}/` : ""}${current.model}\n`;
+			}
+			info += `${theme.fg("dim", "Tool Calls:")} ${current.totalToolCalls}\n`;
+			info += `${theme.fg("dim", "Tokens:")} ${current.totalTokens.toLocaleString()}\n`;
+			if (current.totalCost > 0) {
+				info += `${theme.fg("dim", "Cost:")} $${current.totalCost.toFixed(4)}\n`;
+			}
+
+			if (current.totalToolCalls > 0) {
+				info += `\n${theme.fg("dim", "Read:Edit Ratio:")} ${current.readEditRatio != null ? current.readEditRatio.toFixed(1) : "N/A (no edits)"}\n`;
+				info += `${theme.fg("dim", "Write vs Edit:")} ${current.writeVsEditPercent != null ? `${current.writeVsEditPercent.toFixed(0)}%` : "N/A"}\n`;
+				info += `${theme.fg("dim", "Error Rate:")} ${current.errorRate != null ? `${current.errorRate.toFixed(1)}%` : "N/A"}\n`;
+				info += `${theme.fg("dim", "Self-Correction:")} ${current.selfCorrectionPer1K != null ? `${current.selfCorrectionPer1K.toFixed(1)} per 1K calls` : "N/A"}\n`;
+			}
+
+			// ── Tool Distribution ──
+			const dist = current.toolDistribution;
+			const toolEntries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+			if (toolEntries.length > 0) {
+				info += `\n${theme.bold("Tool Distribution")}\n`;
+				const maxCount = toolEntries[0][1];
+				const maxBarWidth = 25;
+				const maxNameLen = Math.max(...toolEntries.map(([n]) => n.length));
+				for (const [name, count] of toolEntries) {
+					const barLen = maxCount > 0 ? Math.max(1, Math.round((count / maxCount) * maxBarWidth)) : 0;
+					const barStr = "\u2588".repeat(barLen);
+					const paddedName = name.padEnd(maxNameLen);
+					info += `  ${theme.fg("dim", paddedName)}  ${String(count).padStart(4)}  ${theme.fg("accent", barStr)}\n`;
+				}
+			}
+
+			// ── Sparkline Trends ──
+			if (timeline && timeline.periods.length > 1) {
+				info += `\n${theme.bold("Trends")} ${theme.fg("dim", `(${timeline.totalSessions} sessions, ${timeline.periods.length} weeks)`)}\n`;
+
+				// Period labels
+				const labels = timeline.periods.map((p) => p.label);
+				const labelRow = `  ${"  ".padEnd(18)}${labels.map((l) => l.padEnd(7)).join(" ")}`;
+				info += `${theme.fg("dim", labelRow)}\n`;
+
+				// Metric sparklines
+				const readEditValues = timeline.periods.map((p) => p.metrics.avgReadEditRatio);
+				const errorValues = timeline.periods.map((p) => p.metrics.avgErrorRate);
+				const selfCorrValues = timeline.periods.map((p) => p.metrics.avgSelfCorrectionPer1K);
+
+				const fmtAvg = (vals: (number | null)[], suffix = ""): string => {
+					const valid = vals.filter((v): v is number => v !== null);
+					if (valid.length === 0) return "";
+					const avg = valid.reduce((a, b) => a + b, 0) / valid.length;
+					return `  avg ${avg.toFixed(1)}${suffix}`;
+				};
+
+				info += `  ${theme.fg("dim", "Read:Edit".padEnd(16))}  ${theme.fg("accent", sparkline(readEditValues))}${fmtAvg(readEditValues)}\n`;
+				info += `  ${theme.fg("dim", "Error Rate".padEnd(16))}  ${theme.fg("accent", sparkline(errorValues))}${fmtAvg(errorValues, "%")}\n`;
+				info += `  ${theme.fg("dim", "Self-Correct".padEnd(16))}  ${theme.fg("accent", sparkline(selfCorrValues))}${fmtAvg(selfCorrValues, "/1K")}\n`;
+
+				// Per-tool sparklines (top 5 tools by total usage)
+				const toolTotals: Record<string, number> = {};
+				for (const p of timeline.periods) {
+					for (const [tool, count] of Object.entries(p.metrics.toolDistribution)) {
+						toolTotals[tool] = (toolTotals[tool] ?? 0) + count;
+					}
+				}
+				const topTools = Object.entries(toolTotals)
+					.sort((a, b) => b[1] - a[1])
+					.slice(0, 5);
+
+				if (topTools.length > 0) {
+					info += "\n";
+					for (const [toolName] of topTools) {
+						const toolValues = timeline.periods.map((p) => p.metrics.toolDistribution[toolName] ?? 0);
+						// Convert to nullable for sparkline (0 is valid, not null)
+						const sparkValues = toolValues.map((v) => v as number | null);
+						info += `  ${theme.fg("dim", `Tool: ${toolName}`.padEnd(16))}  ${theme.fg("accent", sparkline(sparkValues))}\n`;
+					}
+				}
+			}
+
+			// ── By Model ──
+			if (groups && groups.byModel.length > 0) {
+				info += `\n${theme.bold("By Model")}\n`;
+				for (const g of groups.byModel.slice(0, 5)) {
+					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
+					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
+					const spark = sparkline(g.sparklineReadEdit);
+					info += `  ${theme.fg("dim", g.groupKey.padEnd(22))} ${String(g.sessionCount).padStart(3)} sessions  ${re.padEnd(9)} ${err.padEnd(10)} ${theme.fg("accent", spark)}\n`;
+				}
+			}
+
+			// ── By Type ──
+			if (groups && groups.byType.length > 0) {
+				info += `\n${theme.bold("By Type")}\n`;
+				for (const g of groups.byType) {
+					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
+					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
+					const spark = sparkline(g.sparklineReadEdit);
+					info += `  ${theme.fg("dim", g.groupKey.padEnd(22))} ${String(g.sessionCount).padStart(3)} sessions  ${re.padEnd(9)} ${err.padEnd(10)} ${theme.fg("accent", spark)}\n`;
+				}
+			}
+
+			// ── Date Comparison ──
+			if (comparison) {
+				const dateStr = comparison.splitDate.toISOString().slice(0, 10);
+				info += `\n${theme.bold(`Comparison: split at ${dateStr}`)}\n`;
+
+				const b = comparison.before;
+				const a = comparison.after;
+
+				const hdr = `  ${"  ".padEnd(18)} ${theme.fg("dim", `Before (${b.sessionCount})`.padEnd(14))} ${theme.fg("dim", `After (${a.sessionCount})`.padEnd(14))} Change`;
+				info += `${hdr}\n`;
+
+				const compRow = (
+					label: string,
+					bv: number | null,
+					av: number | null,
+					suffix = "",
+					decimals = 1,
+				): string => {
+					const bs = bv != null ? bv.toFixed(decimals) + suffix : "\u2014";
+					const as_ = av != null ? av.toFixed(decimals) + suffix : "\u2014";
+					let change = "";
+					if (bv != null && av != null && bv !== 0) {
+						const pct = ((av - bv) / Math.abs(bv)) * 100;
+						const arrow = pct > 5 ? "\u2191" : pct < -5 ? "\u2193" : "\u2192";
+						change = `${arrow} ${pct > 0 ? "+" : ""}${pct.toFixed(0)}%`;
+					}
+					return `  ${label.padEnd(18)} ${bs.padEnd(14)} ${as_.padEnd(14)} ${change}`;
+				};
+
+				info += `${compRow("Read:Edit", b.avgReadEditRatio, a.avgReadEditRatio)}\n`;
+				info += `${compRow("Write vs Edit", b.avgWriteVsEditPercent, a.avgWriteVsEditPercent, "%", 0)}\n`;
+				info += `${compRow("Error Rate", b.avgErrorRate, a.avgErrorRate, "%")}\n`;
+				info += `${compRow("Self-Correction", b.avgSelfCorrectionPer1K, a.avgSelfCorrectionPer1K, "/1K")}\n`;
+			}
+
+			// ── Caveat ──
+			info += `\n${theme.fg("dim", "Note: These metrics are noisy proxies for task characteristics, not quality scores.")}\n`;
+			info += `${theme.fg("dim", "Interpret relative to your project's own baseline, not as absolute values.")}`;
+
+			this.chatContainer.addChild(new Spacer(1));
+			this.chatContainer.addChild(new Text(info, 1, 0));
+			this.ui.requestRender();
+		} catch (e) {
+			this.chatContainer.removeChild(loader);
+			const errorMsg = `${theme.fg("error", "Failed to generate session analysis:")} ${e}`;
+			this.chatContainer.addChild(new Spacer(1));
+			this.chatContainer.addChild(new Text(errorMsg, 1, 0));
+			this.ui.requestRender();
+		}
 	}
 
 	private handleChangelogCommand(): void {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -7,7 +7,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@dreb/agent-core";
 import type { ImageContent } from "@dreb/ai";
-import type { SessionStats } from "../../core/agent-session.js";
+import type { FullSessionAnalysis, SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
@@ -358,6 +358,14 @@ export class RpcClient {
 	 */
 	async getSessionStats(): Promise<SessionStats> {
 		const response = await this.send({ type: "get_session_stats" });
+		return this.getData(response);
+	}
+
+	/**
+	 * Get session analysis with behavioral metrics and trends.
+	 */
+	async getSessionAnalysis(splitDate?: string): Promise<FullSessionAnalysis> {
+		const response = await this.send({ type: "get_session_analysis", splitDate });
 		return this.getData(response);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -549,6 +549,12 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				return success(id, "get_session_stats", stats);
 			}
 
+			case "get_session_analysis": {
+				const splitDate = command.splitDate ? new Date(command.splitDate) : undefined;
+				const analysis = await session.getSessionAnalysis(splitDate ? { splitDate } : undefined);
+				return success(id, "get_session_analysis", analysis);
+			}
+
 			case "export_html": {
 				const path = await session.exportToHtml(command.outputPath);
 				return success(id, "export_html", { path });

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -550,7 +550,13 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			}
 
 			case "get_session_analysis": {
-				const splitDate = command.splitDate ? new Date(command.splitDate) : undefined;
+				let splitDate: Date | undefined;
+				if (command.splitDate) {
+					splitDate = new Date(command.splitDate);
+					if (Number.isNaN(splitDate.getTime())) {
+						return error(id, "get_session_analysis", `Invalid splitDate: ${command.splitDate}`);
+					}
+				}
 				const analysis = await session.getSessionAnalysis(splitDate ? { splitDate } : undefined);
 				return success(id, "get_session_analysis", analysis);
 			}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -10,6 +10,7 @@ import type { ImageContent, Model } from "@dreb/ai";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
+import type { FullSessionAnalysis } from "../../core/session-analyzer.js";
 import type { SourceInfo } from "../../core/source-info.js";
 
 // ============================================================================
@@ -59,6 +60,7 @@ export type RpcCommand =
 
 	// Session
 	| { id?: string; type: "get_session_stats" }
+	| { id?: string; type: "get_session_analysis"; splitDate?: string }
 	| { id?: string; type: "export_html"; outputPath?: string }
 	| { id?: string; type: "switch_session"; sessionPath: string }
 	| { id?: string; type: "fork"; entryId: string }
@@ -206,6 +208,7 @@ export type RpcResponse =
 
 	// Session
 	| { id?: string; type: "response"; command: "get_session_stats"; success: true; data: SessionStats }
+	| { id?: string; type: "response"; command: "get_session_analysis"; success: true; data: FullSessionAnalysis }
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }
 	| { id?: string; type: "response"; command: "fork"; success: true; data: { text: string; cancelled: boolean } }

--- a/packages/coding-agent/test/session-analyzer.test.ts
+++ b/packages/coding-agent/test/session-analyzer.test.ts
@@ -1,0 +1,812 @@
+import type { AssistantMessage, Message, ToolResultMessage, Usage, UserMessage } from "@dreb/ai";
+import { describe, expect, it } from "vitest";
+import {
+	type AnalysisInput,
+	analyzeSession,
+	computeErrorRate,
+	computeProjectTrend,
+	computeReadEditRatio,
+	computeSelfCorrectionFrequency,
+	computeToolDistribution,
+	computeWriteVsEditPercent,
+	extractAnalysisInput,
+	type FullSessionAnalysis,
+	formatAnalysisForTelegram,
+	formatAnalysisForTui,
+	type SessionAnalysis,
+} from "../src/core/session-analyzer.js";
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+let idCounter = 0;
+function nextId(): string {
+	return `tc-${++idCounter}`;
+}
+
+function makeAssistantMessage(
+	toolCalls: Array<{ name: string; id?: string }>,
+	text?: string,
+	overrides?: Partial<AssistantMessage>,
+): AssistantMessage {
+	const content: AssistantMessage["content"] = [];
+	if (text) {
+		content.push({ type: "text", text });
+	}
+	for (const tc of toolCalls) {
+		content.push({
+			type: "toolCall",
+			id: tc.id ?? nextId(),
+			name: tc.name,
+			arguments: {},
+		});
+	}
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-20250514",
+		usage: ZERO_USAGE,
+		stopReason: toolCalls.length > 0 ? "toolUse" : "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+function makeToolResult(toolCallId: string, toolName: string, isError = false): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: isError ? "Error: something went wrong" : "ok" }],
+		isError,
+		timestamp: Date.now(),
+	};
+}
+
+function makeUserMessage(text: string): UserMessage {
+	return {
+		role: "user",
+		content: text,
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Build a simple AnalysisInput from tool call names for metric function tests.
+ */
+function makeInput(tools: Array<{ name: string; isError?: boolean }>, texts: string[] = []): AnalysisInput {
+	return {
+		toolCalls: tools.map((t) => ({ name: t.name, isError: t.isError ?? false, timestamp: Date.now() })),
+		assistantTexts: texts,
+		turns: [],
+		totalTurns: 0,
+		totalCost: 0,
+		totalTokens: 0,
+	};
+}
+
+// ── extractAnalysisInput ────────────────────────────────────────────────
+
+describe("extractAnalysisInput", () => {
+	it("returns empty everything for empty messages", () => {
+		const result = extractAnalysisInput([]);
+		expect(result.toolCalls).toEqual([]);
+		expect(result.assistantTexts).toEqual([]);
+		expect(result.turns).toEqual([]);
+		expect(result.totalTurns).toBe(0);
+	});
+
+	it("extracts tool calls from assistant messages", () => {
+		const id1 = nextId();
+		const id2 = nextId();
+		const assistant = makeAssistantMessage([
+			{ name: "read", id: id1 },
+			{ name: "edit", id: id2 },
+		]);
+		const tr1 = makeToolResult(id1, "read");
+		const tr2 = makeToolResult(id2, "edit");
+
+		const result = extractAnalysisInput([assistant, tr1, tr2]);
+		expect(result.toolCalls).toHaveLength(2);
+		expect(result.toolCalls[0].name).toBe("read");
+		expect(result.toolCalls[1].name).toBe("edit");
+	});
+
+	it("propagates isError from tool results", () => {
+		const id1 = nextId();
+		const id2 = nextId();
+		const assistant = makeAssistantMessage([
+			{ name: "read", id: id1 },
+			{ name: "write", id: id2 },
+		]);
+		const tr1 = makeToolResult(id1, "read", false);
+		const tr2 = makeToolResult(id2, "write", true);
+
+		const result = extractAnalysisInput([assistant, tr1, tr2]);
+		expect(result.toolCalls[0].isError).toBe(false);
+		expect(result.toolCalls[1].isError).toBe(true);
+	});
+
+	it("extracts text content from assistant messages", () => {
+		const assistant = makeAssistantMessage([], "Let me think about this");
+		const result = extractAnalysisInput([assistant]);
+		expect(result.assistantTexts).toEqual(["Let me think about this"]);
+	});
+
+	it("handles mixed messages correctly and builds turns", () => {
+		const id1 = nextId();
+		const id2 = nextId();
+		const messages: Message[] = [
+			makeUserMessage("Do something"),
+			makeAssistantMessage([{ name: "read", id: id1 }], "Reading the file"),
+			makeToolResult(id1, "read"),
+			makeAssistantMessage([{ name: "edit", id: id2 }], "Now editing"),
+			makeToolResult(id2, "edit"),
+		];
+
+		const result = extractAnalysisInput(messages);
+		expect(result.toolCalls).toHaveLength(2);
+		expect(result.assistantTexts).toEqual(["Reading the file", "Now editing"]);
+		expect(result.turns).toHaveLength(2);
+		expect(result.turns[0].index).toBe(0);
+		expect(result.turns[0].tools).toEqual(["read"]);
+		expect(result.turns[1].index).toBe(1);
+		expect(result.turns[1].tools).toEqual(["edit"]);
+		expect(result.totalTurns).toBe(2);
+	});
+
+	it("handles tool calls with no matching tool results", () => {
+		const id1 = nextId();
+		const assistant = makeAssistantMessage([{ name: "read", id: id1 }]);
+		// No tool result follows — the tool call won't appear in toolCalls (only tool results create records)
+		const result = extractAnalysisInput([assistant]);
+		expect(result.toolCalls).toHaveLength(0);
+		expect(result.turns).toHaveLength(1);
+		expect(result.turns[0].toolCalls).toBe(1);
+		expect(result.turns[0].tools).toEqual(["read"]);
+	});
+});
+
+// ── computeReadEditRatio ────────────────────────────────────────────────
+
+describe("computeReadEditRatio", () => {
+	it("returns null when no edit or write calls", () => {
+		const input = makeInput([{ name: "read" }, { name: "grep" }, { name: "search" }]);
+		expect(computeReadEditRatio(input)).toBeNull();
+	});
+
+	it("returns 0 when only edit tools, no read tools", () => {
+		const input = makeInput([{ name: "edit" }, { name: "write" }]);
+		expect(computeReadEditRatio(input)).toBe(0);
+	});
+
+	it("returns correct ratio for mix of read and edit tools", () => {
+		const input = makeInput([
+			{ name: "read" },
+			{ name: "grep" },
+			{ name: "search" },
+			{ name: "find" },
+			{ name: "edit" },
+			{ name: "write" },
+		]);
+		// 4 reads / 2 edits = 2
+		expect(computeReadEditRatio(input)).toBe(2);
+	});
+
+	it("counts all read tool types: read, grep, search, find, ls, web_search, web_fetch", () => {
+		const input = makeInput([
+			{ name: "read" },
+			{ name: "grep" },
+			{ name: "search" },
+			{ name: "find" },
+			{ name: "ls" },
+			{ name: "web_search" },
+			{ name: "web_fetch" },
+			{ name: "edit" },
+		]);
+		// 7 reads / 1 edit = 7
+		expect(computeReadEditRatio(input)).toBe(7);
+	});
+
+	it("counts both edit and write as edit tools", () => {
+		const input = makeInput([{ name: "read" }, { name: "edit" }, { name: "write" }]);
+		// 1 read / 2 edits = 0.5
+		expect(computeReadEditRatio(input)).toBe(0.5);
+	});
+});
+
+// ── computeWriteVsEditPercent ───────────────────────────────────────────
+
+describe("computeWriteVsEditPercent", () => {
+	it("returns null when no writes or edits", () => {
+		const input = makeInput([{ name: "read" }, { name: "grep" }]);
+		expect(computeWriteVsEditPercent(input)).toBeNull();
+	});
+
+	it("returns 100 when only writes", () => {
+		const input = makeInput([{ name: "write" }, { name: "write" }]);
+		expect(computeWriteVsEditPercent(input)).toBe(100);
+	});
+
+	it("returns 0 when only edits", () => {
+		const input = makeInput([{ name: "edit" }, { name: "edit" }]);
+		expect(computeWriteVsEditPercent(input)).toBe(0);
+	});
+
+	it("returns correct percentage for mix", () => {
+		const input = makeInput([{ name: "write" }, { name: "edit" }, { name: "edit" }, { name: "edit" }]);
+		// 1 write / 4 total = 25%
+		expect(computeWriteVsEditPercent(input)).toBe(25);
+	});
+});
+
+// ── computeErrorRate ────────────────────────────────────────────────────
+
+describe("computeErrorRate", () => {
+	it("returns null when no tool calls", () => {
+		const input = makeInput([]);
+		expect(computeErrorRate(input)).toBeNull();
+	});
+
+	it("returns 0 when no errors", () => {
+		const input = makeInput([
+			{ name: "read", isError: false },
+			{ name: "edit", isError: false },
+		]);
+		expect(computeErrorRate(input)).toBe(0);
+	});
+
+	it("returns 100 when all errors", () => {
+		const input = makeInput([
+			{ name: "read", isError: true },
+			{ name: "edit", isError: true },
+		]);
+		expect(computeErrorRate(input)).toBe(100);
+	});
+
+	it("returns correct percentage for mix", () => {
+		const input = makeInput([
+			{ name: "read", isError: false },
+			{ name: "edit", isError: true },
+			{ name: "write", isError: false },
+			{ name: "bash", isError: true },
+		]);
+		// 2 errors / 4 total = 50%
+		expect(computeErrorRate(input)).toBe(50);
+	});
+});
+
+// ── computeSelfCorrectionFrequency ──────────────────────────────────────
+
+describe("computeSelfCorrectionFrequency", () => {
+	it("returns null when no tool calls", () => {
+		const input = makeInput([], ["Actually, I was wrong"]);
+		expect(computeSelfCorrectionFrequency(input)).toBeNull();
+	});
+
+	it("returns 0 when no self-correction patterns", () => {
+		const input = makeInput([{ name: "read" }, { name: "edit" }], ["This looks correct", "No issues found"]);
+		expect(computeSelfCorrectionFrequency(input)).toBe(0);
+	});
+
+	it('detects "actually, " pattern', () => {
+		const input = makeInput([{ name: "read" }], ["Actually, that's not right"]);
+		const result = computeSelfCorrectionFrequency(input);
+		expect(result).toBe(1000); // 1 match / 1 tool call * 1000
+	});
+
+	it('detects "wait," pattern', () => {
+		const input = makeInput([{ name: "read" }, { name: "edit" }], ["wait, I need to check something"]);
+		const result = computeSelfCorrectionFrequency(input);
+		expect(result).toBe(500); // 1 match / 2 tool calls * 1000
+	});
+
+	it('detects "Actually" at start of sentence with word boundary', () => {
+		const input = makeInput([{ name: "read" }], ["Actually let me reconsider this approach"]);
+		const result = computeSelfCorrectionFrequency(input);
+		// "Actually " matches /\bactually,?\s/i → 1
+		// "let me reconsider" matches /\blet me reconsider\b/i → 1
+		expect(result).toBe(2000); // 2 matches / 1 tool call * 1000
+	});
+
+	it("counts multiple patterns in one text separately", () => {
+		const input = makeInput(
+			[{ name: "read" }, { name: "edit" }],
+			["Actually, I was wrong. Wait, no wait, let me reconsider. I made a mistake and I need to correct this."],
+		);
+		const result = computeSelfCorrectionFrequency(input);
+		// Patterns:
+		// "Actually, " → /\bactually,?\s/i → 1
+		// "I was wrong" → 1
+		// "Wait," → /\bwait,/i → matches both "Wait," and "wait," in "no wait," → 2
+		// "no wait" → 1
+		// "let me reconsider" → 1
+		// "I made a mistake" → 1
+		// "I need to correct" → 1
+		// Total: 8 matches, 2 tool calls → 8/2*1000 = 4000
+		expect(result).toBe(4000);
+	});
+
+	it("is case-insensitive", () => {
+		const input = makeInput([{ name: "read" }], ["ACTUALLY, I WAS WRONG"]);
+		const result = computeSelfCorrectionFrequency(input);
+		// "ACTUALLY, " and "I WAS WRONG" → 2 matches
+		expect(result).toBe(2000);
+	});
+});
+
+// ── computeToolDistribution ─────────────────────────────────────────────
+
+describe("computeToolDistribution", () => {
+	it("returns empty object for empty input", () => {
+		const input = makeInput([]);
+		expect(computeToolDistribution(input)).toEqual({});
+	});
+
+	it("counts tools correctly", () => {
+		const input = makeInput([
+			{ name: "read" },
+			{ name: "read" },
+			{ name: "edit" },
+			{ name: "write" },
+			{ name: "bash" },
+			{ name: "bash" },
+			{ name: "bash" },
+		]);
+		expect(computeToolDistribution(input)).toEqual({
+			read: 2,
+			edit: 1,
+			write: 1,
+			bash: 3,
+		});
+	});
+});
+
+// ── analyzeSession ──────────────────────────────────────────────────────
+
+describe("analyzeSession", () => {
+	it("handles empty session", () => {
+		const result = analyzeSession([], {
+			sessionId: "test-empty",
+			isSubagent: false,
+		});
+		expect(result.sessionId).toBe("test-empty");
+		expect(result.isSubagent).toBe(false);
+		expect(result.readEditRatio).toBeNull();
+		expect(result.writeVsEditPercent).toBeNull();
+		expect(result.errorRate).toBeNull();
+		expect(result.selfCorrectionPer1K).toBeNull();
+		expect(result.totalToolCalls).toBe(0);
+		expect(result.toolDistribution).toEqual({});
+		expect(result.timeline).toEqual([]);
+		expect(result.model).toBeUndefined();
+		expect(result.provider).toBeUndefined();
+	});
+
+	it("analyzes a full session with mixed messages", () => {
+		const readId = nextId();
+		const editId = nextId();
+		const writeId = nextId();
+		const grepId = nextId();
+		const ts = Date.now();
+
+		const messages: Message[] = [
+			{ ...makeUserMessage("Fix the bug"), timestamp: ts },
+			{
+				...makeAssistantMessage(
+					[
+						{ name: "read", id: readId },
+						{ name: "grep", id: grepId },
+					],
+					"Let me read the file first",
+				),
+				timestamp: ts + 100,
+			},
+			{ ...makeToolResult(readId, "read"), timestamp: ts + 200 },
+			{ ...makeToolResult(grepId, "grep"), timestamp: ts + 300 },
+			{
+				...makeAssistantMessage([{ name: "edit", id: editId }], "Actually, I need to fix this differently"),
+				timestamp: ts + 400,
+			},
+			{ ...makeToolResult(editId, "edit"), timestamp: ts + 500 },
+			{
+				...makeAssistantMessage([{ name: "write", id: writeId }]),
+				timestamp: ts + 600,
+			},
+			{ ...makeToolResult(writeId, "write", true), timestamp: ts + 700 },
+		];
+
+		const result = analyzeSession(messages, {
+			sessionId: "test-full",
+			sessionFile: "/tmp/session.json",
+			isSubagent: true,
+		});
+
+		expect(result.sessionId).toBe("test-full");
+		expect(result.sessionFile).toBe("/tmp/session.json");
+		expect(result.isSubagent).toBe(true);
+		expect(result.model).toBe("claude-sonnet-4-20250514");
+		expect(result.provider).toBe("anthropic");
+		expect(result.timestamp).toEqual(new Date(ts));
+		expect(result.totalToolCalls).toBe(4);
+		// Read tools: read + grep = 2, Edit tools: edit + write = 2 → ratio = 1
+		expect(result.readEditRatio).toBe(1);
+		// write: 1, edit: 1 → 50%
+		expect(result.writeVsEditPercent).toBe(50);
+		// 1 error / 4 calls = 25%
+		expect(result.errorRate).toBe(25);
+		// "Actually, " → 1 match in 4 tool calls → 250
+		expect(result.selfCorrectionPer1K).toBe(250);
+		expect(result.toolDistribution).toEqual({ read: 1, grep: 1, edit: 1, write: 1 });
+		expect(result.timeline).toHaveLength(3);
+	});
+
+	it("handles session with only user messages", () => {
+		const messages: Message[] = [makeUserMessage("Hello"), makeUserMessage("How are you?")];
+		const result = analyzeSession(messages, { sessionId: "users-only", isSubagent: false });
+		expect(result.totalToolCalls).toBe(0);
+		expect(result.model).toBeUndefined();
+		expect(result.timeline).toEqual([]);
+	});
+});
+
+// ── computeProjectTrend ─────────────────────────────────────────────────
+
+describe("computeProjectTrend", () => {
+	function makeSessionAnalysis(overrides: Partial<SessionAnalysis> & { timestamp: Date }): SessionAnalysis {
+		const { timestamp, ...rest } = overrides;
+		return {
+			sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
+			timestamp,
+			isSubagent: false,
+			readEditRatio: null,
+			writeVsEditPercent: null,
+			errorRate: null,
+			selfCorrectionPer1K: null,
+			toolDistribution: {},
+			totalToolCalls: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			timeline: [],
+			...rest,
+		};
+	}
+
+	it("returns null for fewer than 2 sessions", () => {
+		expect(computeProjectTrend([])).toBeNull();
+		expect(computeProjectTrend([makeSessionAnalysis({ timestamp: new Date() })])).toBeNull();
+	});
+
+	it("splits sessions into this week and previous week", () => {
+		const now = Date.now();
+		const oneDay = 24 * 60 * 60 * 1000;
+
+		const sessions: SessionAnalysis[] = [
+			makeSessionAnalysis({
+				timestamp: new Date(now - 1 * oneDay), // this week
+				readEditRatio: 3,
+				errorRate: 10,
+				totalToolCalls: 20,
+				toolDistribution: { read: 15, edit: 5 },
+			}),
+			makeSessionAnalysis({
+				timestamp: new Date(now - 2 * oneDay), // this week
+				readEditRatio: 5,
+				errorRate: 20,
+				totalToolCalls: 30,
+				toolDistribution: { read: 20, edit: 10 },
+			}),
+			makeSessionAnalysis({
+				timestamp: new Date(now - 8 * oneDay), // previous week
+				readEditRatio: 2,
+				errorRate: 30,
+				totalToolCalls: 10,
+				toolDistribution: { read: 7, edit: 3 },
+			}),
+		];
+
+		const result = computeProjectTrend(sessions);
+		expect(result).not.toBeNull();
+		expect(result!.totalSessions).toBe(3);
+		expect(result!.currentPeriod.sessionCount).toBe(2);
+		expect(result!.previousPeriod.sessionCount).toBe(1);
+		// Average readEditRatio this week: (3+5)/2 = 4
+		expect(result!.currentPeriod.avgReadEditRatio).toBe(4);
+		// Average errorRate this week: (10+20)/2 = 15
+		expect(result!.currentPeriod.avgErrorRate).toBe(15);
+		// Previous week
+		expect(result!.previousPeriod.avgReadEditRatio).toBe(2);
+		expect(result!.previousPeriod.avgErrorRate).toBe(30);
+		// Tool distribution merged
+		expect(result!.currentPeriod.toolDistribution).toEqual({ read: 35, edit: 15 });
+		expect(result!.currentPeriod.totalToolCalls).toBe(50);
+	});
+
+	it("handles all sessions in one period", () => {
+		const now = Date.now();
+		const oneDay = 24 * 60 * 60 * 1000;
+
+		const sessions: SessionAnalysis[] = [
+			makeSessionAnalysis({
+				timestamp: new Date(now - 1 * oneDay),
+				readEditRatio: 3,
+				totalToolCalls: 10,
+			}),
+			makeSessionAnalysis({
+				timestamp: new Date(now - 2 * oneDay),
+				readEditRatio: 5,
+				totalToolCalls: 20,
+			}),
+		];
+
+		const result = computeProjectTrend(sessions);
+		expect(result).not.toBeNull();
+		expect(result!.currentPeriod.sessionCount).toBe(2);
+		expect(result!.previousPeriod.sessionCount).toBe(0);
+		expect(result!.previousPeriod.avgReadEditRatio).toBeNull();
+		expect(result!.previousPeriod.totalToolCalls).toBe(0);
+	});
+
+	it("returns null when both periods have 0 sessions", () => {
+		const now = Date.now();
+		const threeWeeksAgo = now - 21 * 24 * 60 * 60 * 1000;
+
+		const sessions: SessionAnalysis[] = [
+			makeSessionAnalysis({ timestamp: new Date(threeWeeksAgo), totalToolCalls: 5 }),
+			makeSessionAnalysis({ timestamp: new Date(threeWeeksAgo - 1000), totalToolCalls: 5 }),
+		];
+
+		const result = computeProjectTrend(sessions);
+		expect(result).toBeNull();
+	});
+});
+
+// ── Edge cases ──────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+	it("division by zero: computeReadEditRatio with no edits returns null", () => {
+		expect(computeReadEditRatio(makeInput([{ name: "read" }]))).toBeNull();
+	});
+
+	it("division by zero: computeWriteVsEditPercent with no writes or edits returns null", () => {
+		expect(computeWriteVsEditPercent(makeInput([{ name: "bash" }]))).toBeNull();
+	});
+
+	it("division by zero: computeErrorRate with no tool calls returns null", () => {
+		expect(computeErrorRate(makeInput([]))).toBeNull();
+	});
+
+	it("division by zero: computeSelfCorrectionFrequency with no tool calls returns null", () => {
+		expect(computeSelfCorrectionFrequency(makeInput([], ["actually, wrong"]))).toBeNull();
+	});
+
+	it("sessions with tool calls but no matching tool results", () => {
+		const id1 = nextId();
+		const assistant = makeAssistantMessage([{ name: "read", id: id1 }]);
+		// Tool result with a DIFFERENT id — no match
+		const orphanResult = makeToolResult("unmatched-id", "read");
+
+		const result = extractAnalysisInput([assistant, orphanResult]);
+		// The tool result still creates a record, but uses toolName from the result message
+		expect(result.toolCalls).toHaveLength(1);
+		expect(result.toolCalls[0].name).toBe("read");
+	});
+
+	it("session with only user messages produces valid analysis", () => {
+		const messages: Message[] = [makeUserMessage("Hello")];
+		const result = analyzeSession(messages, { sessionId: "user-only", isSubagent: false });
+		expect(result.totalToolCalls).toBe(0);
+		expect(result.readEditRatio).toBeNull();
+		expect(result.writeVsEditPercent).toBeNull();
+		expect(result.errorRate).toBeNull();
+		expect(result.selfCorrectionPer1K).toBeNull();
+	});
+});
+
+// ── formatAnalysisForTui ────────────────────────────────────────────────
+
+describe("formatAnalysisForTui", () => {
+	it("produces formatted text with all sections", () => {
+		const analysis: FullSessionAnalysis = {
+			current: {
+				sessionId: "test-fmt",
+				timestamp: new Date(),
+				model: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				isSubagent: false,
+				readEditRatio: 3.5,
+				writeVsEditPercent: 25,
+				errorRate: 5,
+				selfCorrectionPer1K: 100,
+				toolDistribution: { read: 10, edit: 3, write: 1, bash: 5 },
+				totalToolCalls: 19,
+				totalCost: 0.1234,
+				totalTokens: 15000,
+				timeline: [
+					{ index: 0, timestamp: Date.now(), toolCalls: 3, tools: ["read", "grep", "search"] },
+					{ index: 1, timestamp: Date.now(), toolCalls: 1, tools: ["edit"] },
+				],
+			},
+			timeline: null,
+			groups: null,
+			comparison: null,
+			trend: {
+				currentPeriod: {
+					label: "This week",
+					sessionCount: 5,
+					avgReadEditRatio: 3.0,
+					avgWriteVsEditPercent: 20,
+					avgErrorRate: 8,
+					avgSelfCorrectionPer1K: 50,
+					toolDistribution: { read: 40, edit: 15 },
+					totalToolCalls: 55,
+					totalCost: 0.5,
+					totalTokens: 50000,
+					avgCostPerToolCall: null,
+					avgTokensPerToolCall: null,
+				},
+				previousPeriod: {
+					label: "Previous week",
+					sessionCount: 3,
+					avgReadEditRatio: 2.5,
+					avgWriteVsEditPercent: 30,
+					avgErrorRate: 12,
+					avgSelfCorrectionPer1K: 80,
+					toolDistribution: { read: 25, edit: 10 },
+					totalToolCalls: 35,
+					totalCost: 0.3,
+					totalTokens: 30000,
+					avgCostPerToolCall: null,
+					avgTokensPerToolCall: null,
+				},
+				totalSessions: 8,
+			},
+		};
+
+		const output = formatAnalysisForTui(analysis);
+
+		expect(output).toContain("── Current Session ──");
+		expect(output).toContain("claude-sonnet-4-20250514");
+		expect(output).toContain("3.5");
+		expect(output).toContain("25.0%");
+		expect(output).toContain("5.0%");
+		expect(output).toContain("── Tool Distribution ──");
+		expect(output).toContain("read");
+		expect(output).toContain("█");
+		expect(output).toContain("noisy proxies");
+	});
+
+	it("handles null trend gracefully", () => {
+		const analysis: FullSessionAnalysis = {
+			current: {
+				sessionId: "no-trend",
+				timestamp: new Date(),
+				isSubagent: false,
+				readEditRatio: null,
+				writeVsEditPercent: null,
+				errorRate: null,
+				selfCorrectionPer1K: null,
+				toolDistribution: {},
+				totalToolCalls: 0,
+				totalCost: 0,
+				totalTokens: 0,
+				timeline: [],
+			},
+			timeline: null,
+			groups: null,
+			comparison: null,
+			trend: null,
+		};
+
+		const output = formatAnalysisForTui(analysis);
+		expect(output).toContain("── Current Session ──");
+		expect(output).not.toContain("── Project Trend ──");
+		expect(output).not.toContain("── Timeline");
+		expect(output).toContain("n/a");
+	});
+});
+
+// ── formatAnalysisForTelegram ───────────────────────────────────────────
+
+describe("formatAnalysisForTelegram", () => {
+	it("produces Telegram-compatible Markdown", () => {
+		const analysis: FullSessionAnalysis = {
+			current: {
+				sessionId: "tg-test",
+				timestamp: new Date(),
+				model: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				isSubagent: false,
+				readEditRatio: 2.0,
+				writeVsEditPercent: 50,
+				errorRate: 10,
+				selfCorrectionPer1K: 200,
+				toolDistribution: { read: 5, edit: 3 },
+				totalToolCalls: 8,
+				totalCost: 0.05,
+				totalTokens: 8000,
+				timeline: [],
+			},
+			timeline: null,
+			groups: null,
+			comparison: null,
+			trend: null,
+		};
+
+		const output = formatAnalysisForTelegram(analysis);
+		expect(output).toContain("📊");
+		expect(output).toContain("🔧");
+		expect(output).toContain("```");
+		expect(output).toContain("`claude-sonnet-4-20250514`");
+		expect(output).toContain("noisy proxies");
+	});
+
+	it("includes trend section when available", () => {
+		const analysis: FullSessionAnalysis = {
+			current: {
+				sessionId: "tg-trend",
+				timestamp: new Date(),
+				isSubagent: false,
+				readEditRatio: null,
+				writeVsEditPercent: null,
+				errorRate: null,
+				selfCorrectionPer1K: null,
+				toolDistribution: {},
+				totalToolCalls: 0,
+				totalCost: 0,
+				totalTokens: 0,
+				timeline: [],
+			},
+			timeline: null,
+			groups: null,
+			comparison: null,
+			trend: {
+				currentPeriod: {
+					label: "This week",
+					sessionCount: 2,
+					avgReadEditRatio: 3.0,
+					avgWriteVsEditPercent: null,
+					avgErrorRate: 5,
+					avgSelfCorrectionPer1K: null,
+					toolDistribution: {},
+					totalToolCalls: 10,
+					totalCost: 0.1,
+					totalTokens: 10000,
+					avgCostPerToolCall: null,
+					avgTokensPerToolCall: null,
+				},
+				previousPeriod: {
+					label: "Previous week",
+					sessionCount: 1,
+					avgReadEditRatio: 2.0,
+					avgWriteVsEditPercent: null,
+					avgErrorRate: 10,
+					avgSelfCorrectionPer1K: null,
+					toolDistribution: {},
+					totalToolCalls: 5,
+					totalCost: 0.05,
+					totalTokens: 5000,
+					avgCostPerToolCall: null,
+					avgTokensPerToolCall: null,
+				},
+				totalSessions: 3,
+			},
+		};
+
+		const output = formatAnalysisForTelegram(analysis);
+		// The formatter uses timeline (not trend) for display now,
+		// but should still produce valid output without crashing
+		expect(output).toContain("📊");
+		expect(output).toContain("noisy proxies");
+	});
+});

--- a/packages/coding-agent/test/session-analyzer.test.ts
+++ b/packages/coding-agent/test/session-analyzer.test.ts
@@ -2,18 +2,23 @@ import type { AssistantMessage, Message, ToolResultMessage, Usage, UserMessage }
 import { describe, expect, it } from "vitest";
 import {
 	type AnalysisInput,
+	type AnalysisTimeline,
 	analyzeSession,
+	computeDateComparison,
 	computeErrorRate,
+	computeGroups,
 	computeProjectTrend,
 	computeReadEditRatio,
 	computeSelfCorrectionFrequency,
+	computeTimeline,
 	computeToolDistribution,
 	computeWriteVsEditPercent,
 	extractAnalysisInput,
 	type FullSessionAnalysis,
-	formatAnalysisForTelegram,
 	formatAnalysisForTui,
 	type SessionAnalysis,
+	sparkline,
+	type TimePeriod,
 } from "../src/core/session-analyzer.js";
 
 // ── Test helpers ────────────────────────────────────────────────────────
@@ -714,47 +719,78 @@ describe("formatAnalysisForTui", () => {
 		expect(output).not.toContain("── Timeline");
 		expect(output).toContain("n/a");
 	});
-});
 
-// ── formatAnalysisForTelegram ───────────────────────────────────────────
+	it("renders Trends section when timeline is provided", () => {
+		const now = new Date();
+		const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
 
-describe("formatAnalysisForTelegram", () => {
-	it("produces Telegram-compatible Markdown", () => {
+		const makePeriod = (weeksAgo: number, sessionCount: number): TimePeriod => {
+			const start = new Date(now.getTime() - weeksAgo * oneWeekMs);
+			const end = new Date(start.getTime() + oneWeekMs);
+			return {
+				label: `W${weeksAgo}`,
+				start,
+				end,
+				metrics: {
+					label: `W${weeksAgo}`,
+					sessionCount,
+					avgReadEditRatio: sessionCount > 0 ? 2 + weeksAgo * 0.5 : null,
+					avgWriteVsEditPercent: null,
+					avgErrorRate: sessionCount > 0 ? 10 - weeksAgo : null,
+					avgSelfCorrectionPer1K: null,
+					toolDistribution: sessionCount > 0 ? { read: 5 * sessionCount, edit: 2 * sessionCount } : {},
+					totalToolCalls: sessionCount > 0 ? 7 * sessionCount : 0,
+					totalCost: sessionCount > 0 ? 0.05 * sessionCount : 0,
+					totalTokens: sessionCount > 0 ? 5000 * sessionCount : 0,
+					avgCostPerToolCall: sessionCount > 0 ? 0.05 / 7 : null,
+					avgTokensPerToolCall: sessionCount > 0 ? 5000 / 7 : null,
+				},
+			};
+		};
+
+		const timeline: AnalysisTimeline = {
+			periods: [makePeriod(3, 2), makePeriod(2, 3), makePeriod(1, 1), makePeriod(0, 4)],
+			totalSessions: 10,
+		};
+
 		const analysis: FullSessionAnalysis = {
 			current: {
-				sessionId: "tg-test",
-				timestamp: new Date(),
-				model: "claude-sonnet-4-20250514",
-				provider: "anthropic",
+				sessionId: "trend-test",
+				timestamp: now,
 				isSubagent: false,
-				readEditRatio: 2.0,
-				writeVsEditPercent: 50,
-				errorRate: 10,
-				selfCorrectionPer1K: 200,
-				toolDistribution: { read: 5, edit: 3 },
-				totalToolCalls: 8,
+				readEditRatio: 3.0,
+				writeVsEditPercent: null,
+				errorRate: 5,
+				selfCorrectionPer1K: null,
+				toolDistribution: { read: 5, edit: 2 },
+				totalToolCalls: 7,
 				totalCost: 0.05,
-				totalTokens: 8000,
+				totalTokens: 5000,
 				timeline: [],
 			},
-			timeline: null,
+			timeline,
 			groups: null,
 			comparison: null,
 			trend: null,
 		};
 
-		const output = formatAnalysisForTelegram(analysis);
-		expect(output).toContain("📊");
-		expect(output).toContain("🔧");
-		expect(output).toContain("```");
-		expect(output).toContain("`claude-sonnet-4-20250514`");
-		expect(output).toContain("noisy proxies");
+		const output = formatAnalysisForTui(analysis);
+		expect(output).toContain("── Trends");
+		expect(output).toContain("10 sessions");
+		expect(output).toContain("4 weeks");
+		expect(output).toContain("W3");
+		expect(output).toContain("W0");
+		// Sparkline chars should be present
+		expect(output).toMatch(/[▁▂▃▄▅▆▇█]/);
+		// Should have Read:Edit and Error Rate sparkline rows
+		expect(output).toContain("Read:Edit");
+		expect(output).toContain("Error Rate");
 	});
 
-	it("includes trend section when available", () => {
+	it("renders By Model section when groups are provided", () => {
 		const analysis: FullSessionAnalysis = {
 			current: {
-				sessionId: "tg-trend",
+				sessionId: "groups-test",
 				timestamp: new Date(),
 				isSubagent: false,
 				readEditRatio: null,
@@ -768,45 +804,409 @@ describe("formatAnalysisForTelegram", () => {
 				timeline: [],
 			},
 			timeline: null,
-			groups: null,
-			comparison: null,
-			trend: {
-				currentPeriod: {
-					label: "This week",
-					sessionCount: 2,
-					avgReadEditRatio: 3.0,
-					avgWriteVsEditPercent: null,
-					avgErrorRate: 5,
-					avgSelfCorrectionPer1K: null,
-					toolDistribution: {},
-					totalToolCalls: 10,
-					totalCost: 0.1,
-					totalTokens: 10000,
-					avgCostPerToolCall: null,
-					avgTokensPerToolCall: null,
-				},
-				previousPeriod: {
-					label: "Previous week",
-					sessionCount: 1,
-					avgReadEditRatio: 2.0,
-					avgWriteVsEditPercent: null,
-					avgErrorRate: 10,
-					avgSelfCorrectionPer1K: null,
-					toolDistribution: {},
-					totalToolCalls: 5,
-					totalCost: 0.05,
-					totalTokens: 5000,
-					avgCostPerToolCall: null,
-					avgTokensPerToolCall: null,
-				},
-				totalSessions: 3,
+			groups: {
+				byModel: [
+					{
+						groupKey: "claude-sonnet-4-20250514",
+						sessionCount: 5,
+						totalToolCalls: 50,
+						avgReadEditRatio: 3.0,
+						avgErrorRate: 8,
+						sparklineReadEdit: [],
+						sparklineErrorRate: [],
+					},
+					{
+						groupKey: "gpt-4o",
+						sessionCount: 2,
+						totalToolCalls: 15,
+						avgReadEditRatio: 2.5,
+						avgErrorRate: 12,
+						sparklineReadEdit: [],
+						sparklineErrorRate: [],
+					},
+				],
+				byType: [
+					{
+						groupKey: "parent",
+						sessionCount: 4,
+						totalToolCalls: 40,
+						avgReadEditRatio: 3.0,
+						avgErrorRate: 7,
+						sparklineReadEdit: [],
+						sparklineErrorRate: [],
+					},
+				],
 			},
+			comparison: null,
+			trend: null,
 		};
 
-		const output = formatAnalysisForTelegram(analysis);
-		// The formatter uses timeline (not trend) for display now,
-		// but should still produce valid output without crashing
-		expect(output).toContain("📊");
-		expect(output).toContain("noisy proxies");
+		const output = formatAnalysisForTui(analysis);
+		expect(output).toContain("── By Model ──");
+		expect(output).toContain("claude-sonnet-4-20250514");
+		expect(output).toContain("gpt-4o");
+		expect(output).toContain("── By Type ──");
+		expect(output).toContain("parent");
+	});
+});
+
+// ── sparkline ───────────────────────────────────────────────────────────
+
+describe("sparkline", () => {
+	it("returns empty string for all null input", () => {
+		expect(sparkline([null, null, null])).toBe("");
+	});
+
+	it("returns empty string for empty array", () => {
+		expect(sparkline([])).toBe("");
+	});
+
+	it("returns mid char for single non-null value (max === min)", () => {
+		expect(sparkline([42])).toBe("▅");
+	});
+
+	it("maps ascending sequence correctly", () => {
+		const result = sparkline([1, 2, 3, 4, 5, 6, 7, 8]);
+		expect(result[0]).toBe("▁");
+		expect(result[result.length - 1]).toBe("█");
+		expect(result.length).toBe(8);
+	});
+
+	it("null values produce a space in the sequence", () => {
+		const result = sparkline([1, null, 8]);
+		expect(result).toBe("▁ █");
+		expect(result.length).toBe(3);
+	});
+});
+
+// ── computeTimeline ─────────────────────────────────────────────────────
+
+describe("computeTimeline", () => {
+	function makeSessionAnalysis(overrides: Partial<SessionAnalysis> & { timestamp: Date }): SessionAnalysis {
+		const { timestamp, ...rest } = overrides;
+		return {
+			sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
+			timestamp,
+			isSubagent: false,
+			readEditRatio: null,
+			writeVsEditPercent: null,
+			errorRate: null,
+			selfCorrectionPer1K: null,
+			toolDistribution: {},
+			totalToolCalls: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			timeline: [],
+			...rest,
+		};
+	}
+
+	it("returns null for 0 sessions", () => {
+		expect(computeTimeline([])).toBeNull();
+	});
+
+	it("returns null for 1 session", () => {
+		expect(computeTimeline([makeSessionAnalysis({ timestamp: new Date() })])).toBeNull();
+	});
+
+	it("returns exactly numWeeks periods", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 1000) }),
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 2000) }),
+		];
+		const result = computeTimeline(sessions, 8);
+		expect(result).not.toBeNull();
+		expect(result!.periods).toHaveLength(8);
+	});
+
+	it("totalSessions equals the input session count", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 1000) }),
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 2000) }),
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 3000) }),
+		];
+		const result = computeTimeline(sessions, 8);
+		expect(result!.totalSessions).toBe(3);
+	});
+
+	it("sessions from the same week land in the same period", () => {
+		const now = new Date();
+		// Two sessions very close together (same week for sure)
+		const sessions = [
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 1000), totalToolCalls: 10 }),
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 2000), totalToolCalls: 20 }),
+		];
+		const result = computeTimeline(sessions, 8);
+		expect(result).not.toBeNull();
+		// The last period (current week) should have both sessions
+		const lastPeriod = result!.periods[result!.periods.length - 1];
+		expect(lastPeriod.metrics.sessionCount).toBe(2);
+		expect(lastPeriod.metrics.totalToolCalls).toBe(30);
+	});
+
+	it("sessions older than the window have 0 in their period buckets", () => {
+		const now = new Date();
+		const tenWeeksAgo = new Date(now.getTime() - 10 * 7 * 24 * 60 * 60 * 1000);
+		const sessions = [
+			makeSessionAnalysis({ timestamp: tenWeeksAgo, totalToolCalls: 5 }),
+			makeSessionAnalysis({ timestamp: new Date(now.getTime() - 1000), totalToolCalls: 10 }),
+		];
+		const result = computeTimeline(sessions, 8);
+		expect(result).not.toBeNull();
+		// totalSessions includes all sessions even if outside window
+		expect(result!.totalSessions).toBe(2);
+		// Only 1 session should appear in the bucketed periods
+		const totalBucketed = result!.periods.reduce((sum, p) => sum + p.metrics.sessionCount, 0);
+		expect(totalBucketed).toBe(1);
+	});
+});
+
+// ── computeGroups ───────────────────────────────────────────────────────
+
+describe("computeGroups", () => {
+	function makeSessionAnalysis(overrides: Partial<SessionAnalysis> & { timestamp: Date }): SessionAnalysis {
+		const { timestamp, ...rest } = overrides;
+		return {
+			sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
+			timestamp,
+			isSubagent: false,
+			readEditRatio: null,
+			writeVsEditPercent: null,
+			errorRate: null,
+			selfCorrectionPer1K: null,
+			toolDistribution: {},
+			totalToolCalls: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			timeline: [],
+			...rest,
+		};
+	}
+
+	it("returns null for fewer than 2 sessions", () => {
+		expect(computeGroups([], null)).toBeNull();
+		expect(computeGroups([makeSessionAnalysis({ timestamp: new Date() })], null)).toBeNull();
+	});
+
+	it("groups sessions by model correctly", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: now, model: "model-a", totalToolCalls: 10 }),
+			makeSessionAnalysis({ timestamp: now, model: "model-a", totalToolCalls: 20 }),
+			makeSessionAnalysis({ timestamp: now, model: "model-b", totalToolCalls: 5 }),
+		];
+		const result = computeGroups(sessions, null);
+		expect(result).not.toBeNull();
+		expect(result!.byModel).toHaveLength(2);
+		// model-a has more sessions, sorted first
+		expect(result!.byModel[0].groupKey).toBe("model-a");
+		expect(result!.byModel[0].sessionCount).toBe(2);
+		expect(result!.byModel[0].totalToolCalls).toBe(30);
+		expect(result!.byModel[1].groupKey).toBe("model-b");
+		expect(result!.byModel[1].sessionCount).toBe(1);
+	});
+
+	it("subagent sessions with no agentType group as 'subagent (legacy)'", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: now, isSubagent: true }),
+			makeSessionAnalysis({ timestamp: now, isSubagent: true }),
+		];
+		const result = computeGroups(sessions, null);
+		expect(result).not.toBeNull();
+		const legacyGroup = result!.byType.find((g) => g.groupKey === "subagent (legacy)");
+		expect(legacyGroup).toBeDefined();
+		expect(legacyGroup!.sessionCount).toBe(2);
+	});
+
+	it("parent sessions group as 'parent'", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: now, isSubagent: false }),
+			makeSessionAnalysis({ timestamp: now, isSubagent: false }),
+		];
+		const result = computeGroups(sessions, null);
+		expect(result).not.toBeNull();
+		const parentGroup = result!.byType.find((g) => g.groupKey === "parent");
+		expect(parentGroup).toBeDefined();
+		expect(parentGroup!.sessionCount).toBe(2);
+	});
+
+	it("byModel is capped at 5 entries even with 6+ different models", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: now, model: "m1" }),
+			makeSessionAnalysis({ timestamp: now, model: "m2" }),
+			makeSessionAnalysis({ timestamp: now, model: "m3" }),
+			makeSessionAnalysis({ timestamp: now, model: "m4" }),
+			makeSessionAnalysis({ timestamp: now, model: "m5" }),
+			makeSessionAnalysis({ timestamp: now, model: "m6" }),
+			makeSessionAnalysis({ timestamp: now, model: "m7" }),
+		];
+		const result = computeGroups(sessions, null);
+		expect(result).not.toBeNull();
+		expect(result!.byModel.length).toBeLessThanOrEqual(5);
+	});
+});
+
+// ── computeDateComparison ───────────────────────────────────────────────
+
+describe("computeDateComparison", () => {
+	function makeSessionAnalysis(overrides: Partial<SessionAnalysis> & { timestamp: Date }): SessionAnalysis {
+		const { timestamp, ...rest } = overrides;
+		return {
+			sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
+			timestamp,
+			isSubagent: false,
+			readEditRatio: null,
+			writeVsEditPercent: null,
+			errorRate: null,
+			selfCorrectionPer1K: null,
+			toolDistribution: {},
+			totalToolCalls: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			timeline: [],
+			...rest,
+		};
+	}
+
+	it("sessions before splitDate appear in before, sessions after appear in after", () => {
+		const splitDate = new Date("2025-06-01");
+		const sessions = [
+			makeSessionAnalysis({ timestamp: new Date("2025-05-01"), totalToolCalls: 10 }),
+			makeSessionAnalysis({ timestamp: new Date("2025-05-15"), totalToolCalls: 20 }),
+			makeSessionAnalysis({ timestamp: new Date("2025-06-15"), totalToolCalls: 30 }),
+		];
+		const result = computeDateComparison(sessions, splitDate);
+		expect(result.before.sessionCount).toBe(2);
+		expect(result.after.sessionCount).toBe(1);
+	});
+
+	it("empty before slice produces 0 sessionCount and null metrics", () => {
+		const splitDate = new Date("2025-01-01");
+		const sessions = [makeSessionAnalysis({ timestamp: new Date("2025-06-01"), totalToolCalls: 10 })];
+		const result = computeDateComparison(sessions, splitDate);
+		expect(result.before.sessionCount).toBe(0);
+		expect(result.before.avgReadEditRatio).toBeNull();
+		expect(result.before.avgErrorRate).toBeNull();
+		expect(result.before.totalToolCalls).toBe(0);
+	});
+
+	it("empty after slice produces 0 sessionCount and null metrics", () => {
+		const splitDate = new Date("2026-12-31");
+		const sessions = [makeSessionAnalysis({ timestamp: new Date("2025-06-01"), totalToolCalls: 10 })];
+		const result = computeDateComparison(sessions, splitDate);
+		expect(result.after.sessionCount).toBe(0);
+		expect(result.after.avgReadEditRatio).toBeNull();
+		expect(result.after.avgErrorRate).toBeNull();
+		expect(result.after.totalToolCalls).toBe(0);
+	});
+
+	it("before.totalToolCalls equals sum of tool calls from before-sessions", () => {
+		const splitDate = new Date("2025-06-01");
+		const sessions = [
+			makeSessionAnalysis({ timestamp: new Date("2025-05-01"), totalToolCalls: 7 }),
+			makeSessionAnalysis({ timestamp: new Date("2025-05-15"), totalToolCalls: 13 }),
+			makeSessionAnalysis({ timestamp: new Date("2025-07-01"), totalToolCalls: 99 }),
+		];
+		const result = computeDateComparison(sessions, splitDate);
+		expect(result.before.totalToolCalls).toBe(20);
+	});
+});
+
+// ── analyzeSession idempotency (finding 9) ──────────────────────────────
+
+describe("analyzeSession idempotency", () => {
+	it("produces identical results when called twice on the same messages", () => {
+		const readId = nextId();
+		const editId = nextId();
+		const ts = Date.now();
+		const messages: Message[] = [
+			makeUserMessage("Fix the bug"),
+			makeAssistantMessage([{ name: "read", id: readId }], "Reading the file"),
+			{ ...makeToolResult(readId, "read"), timestamp: ts + 100 },
+			makeAssistantMessage([{ name: "edit", id: editId }], "Editing"),
+			{ ...makeToolResult(editId, "edit"), timestamp: ts + 200 },
+		];
+
+		const meta = { sessionId: "idem-test", isSubagent: false };
+		const result1 = analyzeSession(messages, meta);
+		const result2 = analyzeSession(messages, meta);
+
+		expect(result1.totalToolCalls).toBe(result2.totalToolCalls);
+		expect(result1.readEditRatio).toBe(result2.readEditRatio);
+		expect(result1.errorRate).toBe(result2.errorRate);
+		expect(result1.writeVsEditPercent).toBe(result2.writeVsEditPercent);
+		expect(result1.selfCorrectionPer1K).toBe(result2.selfCorrectionPer1K);
+		expect(result1.toolDistribution).toEqual(result2.toolDistribution);
+	});
+
+	it("doubling messages doubles the tool call count (no dedup)", () => {
+		const readId1 = nextId();
+		const readId2 = nextId();
+		const ts = Date.now();
+		const messages: Message[] = [
+			makeUserMessage("Fix the bug"),
+			makeAssistantMessage([{ name: "read", id: readId1 }], "Reading"),
+			{ ...makeToolResult(readId1, "read"), timestamp: ts + 100 },
+			makeAssistantMessage([{ name: "read", id: readId2 }], "Reading again"),
+			{ ...makeToolResult(readId2, "read"), timestamp: ts + 200 },
+		];
+
+		const singleResult = analyzeSession(messages, { sessionId: "single", isSubagent: false });
+		// Duplicate messages to simulate double-counting
+		const doubled = [...messages, ...messages];
+		const doubledResult = analyzeSession(doubled, { sessionId: "doubled", isSubagent: false });
+
+		expect(doubledResult.totalToolCalls).toBe(singleResult.totalToolCalls * 2);
+	});
+});
+
+// ── computeGroups CWD-like filtering via agentType (finding 9) ──────────
+
+describe("computeGroups grouping correctness", () => {
+	function makeSessionAnalysis(overrides: Partial<SessionAnalysis> & { timestamp: Date }): SessionAnalysis {
+		const { timestamp, ...rest } = overrides;
+		return {
+			sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
+			timestamp,
+			isSubagent: false,
+			readEditRatio: null,
+			writeVsEditPercent: null,
+			errorRate: null,
+			selfCorrectionPer1K: null,
+			toolDistribution: {},
+			totalToolCalls: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			timeline: [],
+			...rest,
+		};
+	}
+
+	it("sessions with different agentType values are grouped separately in byType", () => {
+		const now = new Date();
+		const sessions = [
+			makeSessionAnalysis({ timestamp: now, isSubagent: true, agentType: "code-reviewer" }),
+			makeSessionAnalysis({ timestamp: now, isSubagent: true, agentType: "code-reviewer" }),
+			makeSessionAnalysis({ timestamp: now, isSubagent: true, agentType: "error-auditor" }),
+			makeSessionAnalysis({ timestamp: now, isSubagent: false }),
+		];
+		const result = computeGroups(sessions, null);
+		expect(result).not.toBeNull();
+		// Should have 3 type groups: code-reviewer, error-auditor, parent
+		expect(result!.byType).toHaveLength(3);
+		const codeReviewer = result!.byType.find((g) => g.groupKey === "code-reviewer");
+		expect(codeReviewer).toBeDefined();
+		expect(codeReviewer!.sessionCount).toBe(2);
+		const errorAuditor = result!.byType.find((g) => g.groupKey === "error-auditor");
+		expect(errorAuditor).toBeDefined();
+		expect(errorAuditor!.sessionCount).toBe(1);
+		const parent = result!.byType.find((g) => g.groupKey === "parent");
+		expect(parent).toBeDefined();
+		expect(parent!.sessionCount).toBe(1);
 	});
 });

--- a/packages/telegram/src/agent-bridge.ts
+++ b/packages/telegram/src/agent-bridge.ts
@@ -238,6 +238,19 @@ export class AgentBridge {
 	}
 
 	/**
+	 * Get session analysis with behavioral metrics and trends.
+	 */
+	async getSessionAnalysis(): Promise<any> {
+		if (!this.client) return null;
+		try {
+			return await this.client.getSessionAnalysis();
+		} catch (e) {
+			this.handleProcessError(e);
+			throw e;
+		}
+	}
+
+	/**
 	 * Get current state.
 	 */
 	async getState(): Promise<any> {

--- a/packages/telegram/src/commands/agent.ts
+++ b/packages/telegram/src/commands/agent.ts
@@ -6,6 +6,22 @@ import type { Context } from "grammy";
 import type { UserState } from "../types.js";
 import { log, safeSend } from "../util/telegram.js";
 
+const SPARK_CHARS = "▁▂▃▄▅▆▇█";
+function _sparkline(values: (number | null)[]): string {
+	const nonNull = values.filter((v): v is number => v !== null);
+	if (nonNull.length === 0) return "";
+	const min = Math.min(...nonNull);
+	const max = Math.max(...nonNull);
+	return values
+		.map((v) => {
+			if (v === null) return " ";
+			if (max === min) return SPARK_CHARS[4]; // mid for constant data
+			const idx = Math.round(((v - min) / (max - min)) * 7);
+			return SPARK_CHARS[idx];
+		})
+		.join("");
+}
+
 export async function cmdCompact(ctx: Context, userState: UserState): Promise<void> {
 	const chatId = ctx.chat!.id;
 	const bridge = userState.bridge;
@@ -155,18 +171,8 @@ export async function cmdSessionAnalysis(ctx: Context, userState: UserState): Pr
 			lines.push(`\n\ud83d\udcc8 *Trends* (${timeline.totalSessions} sessions, ${timeline.periods.length} weeks):`);
 			const readEditVals = timeline.periods.map((p: any) => p.metrics?.avgReadEditRatio ?? null);
 			const errorVals = timeline.periods.map((p: any) => p.metrics?.avgErrorRate ?? null);
-			// Simple sparkline using block chars
-			const spark = (vals: (number | null)[]): string => {
-				const chars = " \u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
-				const valid = vals.filter((v): v is number => v !== null);
-				if (valid.length === 0) return "";
-				const min = Math.min(...valid);
-				const max = Math.max(...valid);
-				const range = max - min || 1;
-				return vals.map((v) => (v === null ? " " : chars[Math.round(((v - min) / range) * 7) + 1])).join("");
-			};
-			lines.push(`  Read:Edit:  ${spark(readEditVals)}`);
-			lines.push(`  Error Rate: ${spark(errorVals)}`);
+			lines.push(`  Read:Edit:  ${_sparkline(readEditVals)}`);
+			lines.push(`  Error Rate: ${_sparkline(errorVals)}`);
 		}
 
 		// Groups (compact: top 3 each)

--- a/packages/telegram/src/commands/agent.ts
+++ b/packages/telegram/src/commands/agent.ts
@@ -94,6 +94,126 @@ export async function cmdStats(ctx: Context, userState: UserState): Promise<void
 	}
 }
 
+export async function cmdSessionAnalysis(ctx: Context, userState: UserState): Promise<void> {
+	const chatId = ctx.chat!.id;
+	const bridge = userState.bridge;
+
+	if (!bridge?.isAlive) {
+		await safeSend(ctx.api, chatId, "No active session.");
+		return;
+	}
+
+	await safeSend(ctx.api, chatId, "\ud83d\udd2c _Analyzing sessions..._");
+
+	try {
+		const analysis = await bridge.getSessionAnalysis();
+		if (!analysis) {
+			await safeSend(ctx.api, chatId, "No analysis available.");
+			return;
+		}
+
+		const { current, timeline, groups, comparison } = analysis;
+		const lines: string[] = ["\ud83d\udcca *Session Analysis*\n"];
+
+		// Current session
+		if (current.model) {
+			lines.push(`\ud83e\udde0 Model: \`${current.provider ? `${current.provider}/` : ""}${current.model}\``);
+		}
+		lines.push(`\ud83d\udd27 Tool calls: ${current.totalToolCalls}`);
+		if (current.totalTokens) {
+			lines.push(
+				`📊 Tokens: ${current.totalTokens.toLocaleString()} | Cost: $${current.totalCost?.toFixed(4) ?? "0"}`,
+			);
+		}
+
+		if (current.totalToolCalls > 0) {
+			lines.push("");
+			lines.push(`Read:Edit ratio: ${current.readEditRatio != null ? current.readEditRatio.toFixed(1) : "N/A"}`);
+			lines.push(
+				`Write vs Edit: ${current.writeVsEditPercent != null ? `${current.writeVsEditPercent.toFixed(0)}%` : "N/A"}`,
+			);
+			lines.push(`Error rate: ${current.errorRate != null ? `${current.errorRate.toFixed(1)}%` : "N/A"}`);
+			lines.push(
+				`Self-correction: ${current.selfCorrectionPer1K != null ? `${current.selfCorrectionPer1K.toFixed(1)}/1K` : "N/A"}`,
+			);
+		}
+
+		// Tool distribution (top 8)
+		const dist = Object.entries(current.toolDistribution || {}).sort((a, b) => (b[1] as number) - (a[1] as number));
+		if (dist.length > 0) {
+			lines.push("\n\ud83d\udd27 *Tool Distribution*:");
+			for (const [name, count] of dist.slice(0, 8)) {
+				lines.push(`  ${name}: ${count}`);
+			}
+			if (dist.length > 8) {
+				lines.push(`  ...and ${dist.length - 8} more`);
+			}
+		}
+
+		// Timeline sparklines
+		if (timeline && timeline.periods.length > 1) {
+			lines.push(`\n\ud83d\udcc8 *Trends* (${timeline.totalSessions} sessions, ${timeline.periods.length} weeks):`);
+			const readEditVals = timeline.periods.map((p: any) => p.metrics?.avgReadEditRatio ?? null);
+			const errorVals = timeline.periods.map((p: any) => p.metrics?.avgErrorRate ?? null);
+			// Simple sparkline using block chars
+			const spark = (vals: (number | null)[]): string => {
+				const chars = " \u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
+				const valid = vals.filter((v): v is number => v !== null);
+				if (valid.length === 0) return "";
+				const min = Math.min(...valid);
+				const max = Math.max(...valid);
+				const range = max - min || 1;
+				return vals.map((v) => (v === null ? " " : chars[Math.round(((v - min) / range) * 7) + 1])).join("");
+			};
+			lines.push(`  Read:Edit:  ${spark(readEditVals)}`);
+			lines.push(`  Error Rate: ${spark(errorVals)}`);
+		}
+
+		// Groups (compact: top 3 each)
+		if (groups) {
+			if (groups.byModel.length > 0) {
+				lines.push("\n\ud83e\udde0 *By Model*:");
+				for (const g of groups.byModel.slice(0, 3)) {
+					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
+					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
+					lines.push(`  ${g.groupKey}: ${g.sessionCount} sessions  ${re}  ${err}`);
+				}
+			}
+			if (groups.byType.length > 0) {
+				lines.push("\n\ud83d\udcdd *By Type*:");
+				for (const g of groups.byType.slice(0, 5)) {
+					const re = g.avgReadEditRatio != null ? `R:E ${g.avgReadEditRatio.toFixed(1)}` : "";
+					const err = g.avgErrorRate != null ? `Err ${g.avgErrorRate.toFixed(1)}%` : "";
+					lines.push(`  ${g.groupKey}: ${g.sessionCount} sessions  ${re}  ${err}`);
+				}
+			}
+		}
+
+		// Date comparison
+		if (comparison) {
+			const dateStr = new Date(comparison.splitDate).toISOString().slice(0, 10);
+			lines.push(`\n\ud83d\udcc5 *Split at ${dateStr}*:`);
+			const b = comparison.before;
+			const a = comparison.after;
+			const tl = (label: string, bv: number | null, av: number | null, suffix = ""): string => {
+				const bs = bv != null ? bv.toFixed(1) + suffix : "\u2014";
+				const as_ = av != null ? av.toFixed(1) + suffix : "\u2014";
+				return `  ${label}: ${bs} \u2192 ${as_}`;
+			};
+			lines.push(tl("Read:Edit", b.avgReadEditRatio, a.avgReadEditRatio));
+			lines.push(tl("Error Rate", b.avgErrorRate, a.avgErrorRate, "%"));
+			lines.push(`  Sessions: ${b.sessionCount} before, ${a.sessionCount} after`);
+		}
+
+		lines.push("\n_Metrics are noisy proxies \u2014 interpret relative to your baseline._");
+
+		await safeSend(ctx.api, chatId, lines.join("\n"));
+	} catch (e) {
+		log(`[CMD] /session_analysis error: ${e}`);
+		await safeSend(ctx.api, chatId, `\u274c Failed to get analysis: ${e}`);
+	}
+}
+
 export async function cmdModel(ctx: Context, userState: UserState, args: string): Promise<void> {
 	const chatId = ctx.chat!.id;
 	const bridge = userState.bridge;

--- a/packages/telegram/src/commands/index.ts
+++ b/packages/telegram/src/commands/index.ts
@@ -7,7 +7,7 @@ import { ensureBridgeWithSession } from "../bridge-lifecycle.js";
 import type { Config } from "../config.js";
 import type { UserState } from "../types.js";
 import { log, safeSend } from "../util/telegram.js";
-import { cmdAgents, cmdCompact, cmdModel, cmdStats, cmdThinking } from "./agent.js";
+import { cmdAgents, cmdCompact, cmdModel, cmdSessionAnalysis, cmdStats, cmdThinking } from "./agent.js";
 import { cmdBuddy } from "./buddy.js";
 import { cmdCwd, cmdNew, cmdRestart, cmdStart, cmdStatus, cmdStop } from "./core.js";
 import { STATIC_COMMANDS } from "./refresh.js";
@@ -78,6 +78,11 @@ export function registerCommands(bot: Bot, config: Config, getUserState: (userId
 	bot.command("stats", (ctx) => {
 		const us = getUserState(ctx.from!.id);
 		return cmdStats(ctx, us);
+	});
+
+	bot.command("session_analysis", (ctx) => {
+		const us = getUserState(ctx.from!.id);
+		return cmdSessionAnalysis(ctx, us);
 	});
 
 	bot.command("model", (ctx) => {

--- a/packages/telegram/src/commands/refresh.ts
+++ b/packages/telegram/src/commands/refresh.ts
@@ -17,6 +17,7 @@ export const STATIC_COMMANDS: Array<{ command: string; description: string }> = 
 	{ command: "recent", description: "Resend last N messages" },
 	{ command: "skills", description: "List available skills" },
 	{ command: "stats", description: "Token usage & cost" },
+	{ command: "session_analysis", description: "Behavioral quality metrics" },
 	{ command: "compact", description: "Compact context" },
 	{ command: "model", description: "View/switch model" },
 	{ command: "thinking", description: "View/set thinking level" },

--- a/packages/telegram/test/commands-analysis.test.ts
+++ b/packages/telegram/test/commands-analysis.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../src/config.js";
+import type { UserState } from "../src/types.js";
+
+const { mockSafeSend } = vi.hoisted(() => ({
+	mockSafeSend: vi.fn().mockResolvedValue(1),
+}));
+
+vi.mock("../src/util/telegram.js", () => ({
+	safeSend: mockSafeSend,
+	log: vi.fn(),
+}));
+
+import { cmdSessionAnalysis } from "../src/commands/agent.js";
+
+function createConfig(overrides?: Partial<Config>): Config {
+	return {
+		botToken: "test-token",
+		allowedUserIds: [],
+		workingDir: "/default/dir",
+		drebPath: "/usr/bin/dreb",
+		serviceName: "dreb-telegram",
+		...overrides,
+	};
+}
+
+function createUserState(overrides?: Partial<UserState>): UserState {
+	return {
+		bridge: null,
+		config: createConfig(),
+		promptInFlight: false,
+		newSessionFlag: false,
+		newSessionCwd: null,
+		effectiveCwd: null,
+		backgroundAgents: new Map(),
+		stopRequested: false,
+		buddyController: null,
+		outbox: [],
+		...overrides,
+	};
+}
+
+function createMockContext() {
+	return {
+		reply: vi.fn().mockResolvedValue({}),
+		api: {
+			sendMessage: vi.fn().mockResolvedValue({ message_id: 1 }),
+		},
+		chat: { id: 100 },
+		from: { id: 42 },
+	} as any;
+}
+
+describe("cmdSessionAnalysis", () => {
+	let ctx: ReturnType<typeof createMockContext>;
+
+	beforeEach(() => {
+		ctx = createMockContext();
+		vi.clearAllMocks();
+	});
+
+	it("sends 'No active session' when bridge is null", async () => {
+		const userState = createUserState({ bridge: null });
+		await cmdSessionAnalysis(ctx, userState);
+
+		expect(mockSafeSend).toHaveBeenCalledWith(expect.anything(), 100, "No active session.");
+	});
+
+	it("sends 'No active session' when bridge is not alive", async () => {
+		const mockBridge = { isAlive: false } as any;
+		const userState = createUserState({ bridge: mockBridge });
+		await cmdSessionAnalysis(ctx, userState);
+
+		expect(mockSafeSend).toHaveBeenCalledWith(expect.anything(), 100, "No active session.");
+	});
+
+	it("sends 'No analysis available' when bridge returns null", async () => {
+		const mockBridge = {
+			isAlive: true,
+			getSessionAnalysis: vi.fn().mockResolvedValue(null),
+		} as any;
+		const userState = createUserState({ bridge: mockBridge });
+		await cmdSessionAnalysis(ctx, userState);
+
+		// First call is the "Analyzing..." message, second is the result
+		expect(mockSafeSend).toHaveBeenCalledWith(expect.anything(), 100, expect.stringContaining("Analyzing"));
+		expect(mockSafeSend).toHaveBeenCalledWith(expect.anything(), 100, "No analysis available.");
+	});
+
+	it("formats and sends analysis data when available", async () => {
+		const mockAnalysis = {
+			current: {
+				sessionId: "test-123",
+				model: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				totalToolCalls: 42,
+				totalCost: 0.15,
+				totalTokens: 20000,
+				readEditRatio: 3.5,
+				writeVsEditPercent: 15,
+				errorRate: 2.4,
+				selfCorrectionPer1K: 1.2,
+				toolDistribution: { read: 20, edit: 10, bash: 8, grep: 4 },
+				timeline: [],
+			},
+			timeline: null,
+			groups: null,
+			comparison: null,
+			trend: null,
+		};
+
+		const mockBridge = {
+			isAlive: true,
+			getSessionAnalysis: vi.fn().mockResolvedValue(mockAnalysis),
+		} as any;
+		const userState = createUserState({ bridge: mockBridge });
+		await cmdSessionAnalysis(ctx, userState);
+
+		// Should have sent the analyzing message + the result
+		expect(mockSafeSend).toHaveBeenCalledTimes(2);
+
+		// The result message should contain key metrics
+		const resultCall = mockSafeSend.mock.calls[1];
+		const message = resultCall[2] as string;
+		expect(message).toContain("Session Analysis");
+		expect(message).toContain("3.5"); // readEditRatio
+		expect(message).toContain("15%"); // writeVsEditPercent
+		expect(message).toContain("2.4%"); // errorRate
+		expect(message).toContain("Tool Distribution");
+		expect(message).toContain("noisy proxies");
+	});
+
+	it("handles bridge error gracefully", async () => {
+		const mockBridge = {
+			isAlive: true,
+			getSessionAnalysis: vi.fn().mockRejectedValue(new Error("connection lost")),
+		} as any;
+		const userState = createUserState({ bridge: mockBridge });
+		await cmdSessionAnalysis(ctx, userState);
+
+		expect(mockSafeSend).toHaveBeenCalledWith(
+			expect.anything(),
+			100,
+			expect.stringContaining("Failed to get analysis"),
+		);
+	});
+});


### PR DESCRIPTION
Closes #106

Add a `/session-analysis` slash command that computes behavioral quality metrics (read:edit ratio, write vs edit %, tool distribution, error rate, self-correction frequency) for the current session and shows trend comparisons across all project sessions (including subagent sessions). Works in both TUI and Telegram.

Implementation plan posted as a comment below.