### PR TITLE
Hotfix 2.5.2: subagent model fallback and workspace link safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,22 @@ This builds all packages in dependency order: tui → ai → agent → coding-ag
 - `packages/tui` — Terminal UI components
 - `packages/telegram` — Telegram bot integration
 
+## Workspace Link Safety
+
+**Always run `npm install` from the monorepo root.** Running it inside `packages/telegram/` or any subdirectory causes npm to pull `@dreb/*` packages from the registry as stale tarballs instead of symlinking to the local workspace source. This produces silent, hard-to-debug failures (outdated agent definitions, old model resolution logic, etc.).
+
+Verify workspace links are healthy before declaring a build good:
+
+```bash
+npm run verify-workspace-links
+```
+
+If it reports stale packages, fix with:
+
+```bash
+rm -rf packages/*/node_modules/@dreb && npm install
+```
+
 ## Release Protocol
 
 **Every release MUST follow these steps in order. No exceptions.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dreb",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dreb",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "workspaces": [
         "packages/*",
         "packages/coding-agent/examples/extensions/with-deps",
@@ -15,7 +15,7 @@
         "packages/coding-agent/examples/extensions/custom-provider-qwen-cli"
       ],
       "dependencies": {
-        "@dreb/coding-agent": "^1.0.0",
+        "@dreb/coding-agent": "*",
         "@mariozechner/jiti": "^2.6.5",
         "get-east-asian-width": "^1.4.0"
       },
@@ -8733,7 +8733,7 @@
     },
     "packages/agent": {
       "name": "@dreb/agent-core",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@dreb/ai": "^2.0.0"
@@ -8762,7 +8762,7 @@
     },
     "packages/ai": {
       "name": "@dreb/ai",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
     },
     "packages/coding-agent": {
       "name": "@dreb/coding-agent",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@dreb/agent-core": "^2.0.0",
@@ -8933,7 +8933,7 @@
     },
     "packages/semantic-search": {
       "name": "@dreb/semantic-search",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
     },
     "packages/telegram": {
       "name": "@dreb/telegram",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "@dreb/coding-agent": "^2.0.0",
         "grammy": "^1.35.0"
@@ -8999,112 +8999,9 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/telegram/node_modules/@dreb/agent-core": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@dreb/agent-core/-/agent-core-2.4.5.tgz",
-      "integrity": "sha512-pOml8qQW6HM4CqgKSbHzGrsjJZakcc3DWMiV07mRkvPgcdCSQ4P1ybVDW4tACS6wOICzMFjqh/yVjGlX9+huAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@dreb/ai": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "packages/telegram/node_modules/@dreb/ai": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@dreb/ai/-/ai-2.4.5.tgz",
-      "integrity": "sha512-ckkxT1Jk/ZK8iDbUiSsi1lLIrt/P61ZrtLt6q1BBD8M6CUHxfoyqscJqXmEMtz0qPm363JCT19ShDxNpvRLAhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "dreb-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "packages/telegram/node_modules/@dreb/coding-agent": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@dreb/coding-agent/-/coding-agent-2.4.5.tgz",
-      "integrity": "sha512-eI7wd8HdLsjHR1j2AdGP6TH9fAxXFMOgFehL9zATpy3R+EADKdUvbyCW+DCyuEtSbtITUM9Pd5p/ynSJMB6gHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@dreb/agent-core": "^2.0.0",
-        "@dreb/ai": "^2.0.0",
-        "@dreb/semantic-search": "^2.0.0",
-        "@dreb/tui": "^2.0.0",
-        "@huggingface/transformers": "^4.0.1",
-        "@mariozechner/jiti": "^2.6.2",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "ajv": "^8.17.1",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "terminal-render": "^1.5.1",
-        "tree-sitter-c": "^0.24.1",
-        "tree-sitter-cpp": "^0.23.4",
-        "tree-sitter-go": "^0.25.0",
-        "tree-sitter-java": "^0.23.5",
-        "tree-sitter-javascript": "^0.25.0",
-        "tree-sitter-python": "^0.25.0",
-        "tree-sitter-rust": "^0.24.0",
-        "tree-sitter-typescript": "^0.23.2",
-        "undici": "^7.19.1",
-        "web-tree-sitter": "^0.26.8",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "dreb": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
-      }
-    },
-    "packages/telegram/node_modules/@dreb/tui": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@dreb/tui/-/tui-2.4.5.tgz",
-      "integrity": "sha512-yT3OK+UIqHcGx8GyQyjDFSiW8H294dG6YSucClFNWEIKcGlGfvZsF6TLf9NtBf976v924H0UWrhltSeUcsuIkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
-      }
+      "resolved": "packages/coding-agent",
+      "link": true
     },
     "packages/telegram/node_modules/@types/node": {
       "version": "24.12.0",
@@ -9114,18 +9011,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "packages/telegram/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "packages/telegram/node_modules/undici-types": {
       "version": "7.16.0",
       "dev": true,
@@ -9133,7 +9018,7 @@
     },
     "packages/tui": {
       "name": "@dreb/tui",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "bash scripts/sync-version.sh && cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../semantic-search && npm run build && cd ../coding-agent && npm run build && cd ../telegram && npm run build",
     "dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
     "check": "biome check --write --error-on-warnings . && tsgo --noEmit",
+    "verify-workspace-links": "node scripts/verify-workspace-links.js",
     "test": "npm run test --workspaces --if-present",
     "prepare": "husky"
   },
@@ -33,10 +34,10 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "version": "2.5.1",
+  "version": "2.5.2",
   "dependencies": {
     "@mariozechner/jiti": "^2.6.5",
-    "@dreb/coding-agent": "^1.0.0",
+    "@dreb/coding-agent": "*",
     "get-east-asian-width": "^1.4.0"
   },
   "overrides": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -109,6 +109,11 @@ export function getEnvApiKey(provider: any): string | undefined {
 		}
 	}
 
+	// z.ai (zai) provider uses ZHIPU_API_KEY in models.json, but also accept ZAI_API_KEY
+	if (provider === "zai") {
+		return process.env.ZAI_API_KEY || process.env.ZHIPU_API_KEY;
+	}
+
 	const envMap: Record<string, string> = {
 		openai: "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/scripts/verify-workspace-links.js
+++ b/scripts/verify-workspace-links.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Verify that all @dreb/* workspace packages are symlinked from nested
+ * node_modules, never installed as stale npm tarballs.
+ *
+ * Exit code 1 if any workspace package is a real directory instead of a link.
+ */
+import { lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const workspacePackages = [
+	"@dreb/agent-core",
+	"@dreb/ai",
+	"@dreb/coding-agent",
+	"@dreb/semantic-search",
+	"@dreb/telegram",
+	"@dreb/tui",
+];
+
+const packagesDir = "packages";
+const packageDirs = readdirSync(packagesDir);
+
+let foundStale = false;
+
+for (const pkgDir of packageDirs) {
+	const nestedScope = join(packagesDir, pkgDir, "node_modules", "@dreb");
+	let entries = [];
+	try {
+		entries = readdirSync(nestedScope);
+	} catch {
+		continue;
+	}
+
+	for (const entry of entries) {
+		const fullPath = join(nestedScope, entry);
+		const name = `@dreb/${entry}`;
+		if (!workspacePackages.includes(name)) continue;
+
+		let isLink = false;
+		try {
+			isLink = lstatSync(fullPath).isSymbolicLink();
+		} catch {
+			continue;
+		}
+
+		if (!isLink) {
+			console.error(`STALE PACKAGE: ${fullPath} is a real directory, not a workspace symlink`);
+			foundStale = true;
+		}
+	}
+}
+
+if (foundStale) {
+	console.error("\nFix: rm -rf packages/*/node_modules/@dreb && npm install");
+	process.exit(1);
+}
+
+console.log("All workspace packages are correctly symlinked.");


### PR DESCRIPTION
## Summary

Fixes subagents with default settings failing when the parent provider is <kimi-coding>.

## Root Cause

 was a stale npm tarball (v2.4.5) instead of a workspace symlink. This caused Telegram to load old agent definitions with bare model names (), which resolved against the parent provider () and failed. The local workspace source had already been updated to use provider-prefixed IDs ().

## Changes

- **packages/ai/src/env-api-keys.ts**:  provider now checks , matching the  config name in .
- **package-lock.json**: Replaced stale tarball entries for  with workspace links.
- **package.json**: Changed  dep from  to  to enforce workspace resolution.
- **scripts/verify-workspace-links.js**: New script + 
> dreb@2.5.2 verify-workspace-links
> node scripts/verify-workspace-links.js

All workspace packages are correctly symlinked. command to detect stale nested tarball installs before they cause silent failures.
- **AGENTS.md**: Added workspace link safety rules.

## Verification

- 
> dreb@2.5.2 verify-workspace-links
> node scripts/verify-workspace-links.js

All workspace packages are correctly symlinked. passes
- All 532 vitest tests pass
-  → 
- Explore subagent with default settings works correctly
