### PR TITLE
Add /dream — memory consolidation with backup and session scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dreb",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dreb",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "workspaces": [
         "packages/*",
         "packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
     },
     "packages/agent": {
       "name": "@dreb/agent-core",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@dreb/ai": "^2.0.0"
@@ -8762,7 +8762,7 @@
     },
     "packages/ai": {
       "name": "@dreb/ai",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
     },
     "packages/coding-agent": {
       "name": "@dreb/coding-agent",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@dreb/agent-core": "^2.0.0",
@@ -8933,7 +8933,7 @@
     },
     "packages/semantic-search": {
       "name": "@dreb/semantic-search",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
     },
     "packages/telegram": {
       "name": "@dreb/telegram",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "dependencies": {
         "@dreb/coding-agent": "^2.0.0",
         "grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
     },
     "packages/tui": {
       "name": "@dreb/tui",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "version": "2.5.2",
+  "version": "2.6.0",
   "dependencies": {
     "@mariozechner/jiti": "^2.6.5",
     "@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Added skill system enhancements: `argument-hint` frontmatter field shown in `/` menu autocomplete, `user-invocable` field to hide skills from the `/` menu while keeping them available to the model, `disable-model-invocation` field to restrict skills to user-only invocation, and a dedicated `skill` tool for model-invocable skill execution with full content substitution (`$ARGUMENTS`, `$0`..`$N`, `$@`, `${@:N}`, `${DREB_SKILL_DIR}`, `${DREB_SESSION_ID}`) ([#7](https://github.com/aebrer/dreb/issues/7))
 - Added `sessionDir` setting support in global and project `settings.json` so session storage can be configured without passing `--session-dir` on every invocation ([#2598](https://github.com/badlogic/pi-mono/pull/2598) by [@smcllns](https://github.com/smcllns))
+- Added `/dream` memory consolidation command — backs up all memory directories, merges duplicates, scans session history for unrecorded patterns, prunes stale entries, and validates links. Uses tar.gz archives with retention policy (keep last 10), lockfile-based concurrency protection, and a 10-step LLM pipeline with explicit backup verification. Configurable archive path via `dream.archivePath` setting. ([#99](https://github.com/aebrer/dreb/issues/99))
 
 ### Fixed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -161,6 +161,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/fork` | Create a new session from the current branch |
 | `/compact [prompt]` | Manually compact context, optional custom instructions |
 | `/copy` | Copy last assistant message to clipboard |
+| `/dream` | Consolidate and prune memories — backs up, merges duplicates, scans sessions for patterns |
 | `/export [file]` | Export session to HTML file |
 | `/buddy` | Terminal companion — hatch, pet, reroll, set model, or hide. See [docs/buddy.md](docs/buddy.md) |
 | `/reload` | Reload keybindings, extensions, skills, prompts, and context files (themes hot-reload automatically) |

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/dream.ts
+++ b/packages/coding-agent/src/core/dream.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
 	closeSync,
@@ -16,6 +16,7 @@ import {
 import { cp, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
 import lockfile from "proper-lockfile";
 import { getSessionsDir } from "../config.js";
 import type { SettingsManager } from "./settings-manager.js";
@@ -93,11 +94,11 @@ export function parseDreamCommand(text: string): DreamCommand {
  * Uses synchronous low-level reads to avoid loading entire files.
  */
 function readSessionCwd(filePath: string): string | undefined {
+	let fd: number | undefined;
 	try {
-		const fd = openSync(filePath, "r");
+		fd = openSync(filePath, "r");
 		const buffer = Buffer.alloc(4096);
 		const bytesRead = readSync(fd, buffer, 0, 4096, 0);
-		closeSync(fd);
 		const firstLine = buffer.toString("utf8", 0, bytesRead).split("\n")[0];
 		if (!firstLine) return undefined;
 		const header = JSON.parse(firstLine);
@@ -106,12 +107,20 @@ function readSessionCwd(filePath: string): string | undefined {
 		}
 	} catch {
 		// Corrupt or unreadable — skip
+	} finally {
+		if (fd !== undefined) {
+			try {
+				closeSync(fd);
+			} catch {
+				// Best-effort close
+			}
+		}
 	}
 	return undefined;
 }
 
-export function discoverAllProjectMemoryDirs(): string[] {
-	const sessionsDir = getSessionsDir();
+export function discoverAllProjectMemoryDirs(overrideSessionsDir?: string): string[] {
+	const sessionsDir = overrideSessionsDir ?? getSessionsDir();
 	if (!existsSync(sessionsDir)) return [];
 
 	let dirEntries: string[];
@@ -393,7 +402,8 @@ export async function performDreamBackup(context: DreamContext): Promise<BackupR
 		}
 
 		// Create .tar.gz archive from staging directory
-		execFileSync("tar", ["czf", backupPath, "-C", dirname(stagingDir), basename(stagingDir)]);
+		const execFileAsync = promisify(execFile);
+		await execFileAsync("tar", ["czf", backupPath, "-C", dirname(stagingDir), basename(stagingDir)]);
 	} finally {
 		// Clean up staging directory
 		try {
@@ -565,8 +575,8 @@ Write the current ISO timestamp to ${dreamLastRunPath}
 // Locking
 // =============================================================================
 
-export async function acquireDreamLock(): Promise<() => void> {
-	const memDir = join(homedir(), ".dreb", "memory");
+export async function acquireDreamLock(overrideMemDir?: string): Promise<() => void> {
+	const memDir = overrideMemDir ?? join(homedir(), ".dreb", "memory");
 	const lockPath = join(memDir, DREAM_LOCK_FILE);
 
 	// Ensure directory and lock file exist (proper-lockfile requires the file to exist)

--- a/packages/coding-agent/src/core/dream.ts
+++ b/packages/coding-agent/src/core/dream.ts
@@ -1,0 +1,615 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cp, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import lockfile from "proper-lockfile";
+import { getSessionsDir } from "../config.js";
+import type { SettingsManager } from "./settings-manager.js";
+import { expandPath } from "./tools/path-utils.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface DreamContext {
+	archivePath: string;
+	lastRunTimestamp: string | null;
+	globalMemoryDir: string;
+	projectMemoryDirs: string[];
+	claudeMemoryDirs: string[];
+	sessionsDir: string;
+}
+
+export interface BackupResult {
+	backupDir: string;
+	timestamp: string;
+	fileCount: number;
+	totalSize: number;
+	verified: boolean;
+}
+
+export interface LinkValidationResult {
+	valid: boolean;
+	brokenLinks: Array<{ memoryDir: string; indexFile: string; pointer: string; target: string }>;
+}
+
+export type DreamCommand = { type: "run" } | { type: "setBackup"; path: string } | { type: "showBackup" };
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DEFAULT_ARCHIVE_DIR = "~/.dreb/memory-archive/";
+const DREAM_LAST_RUN_FILE = ".dream-last-run";
+const DREAM_LOCK_FILE = ".dream.lock";
+const DREAM_TMP_DIR = ".dream-tmp";
+const BACKUP_PREFIX = "dream-backup-";
+const DEFAULT_KEEP_COUNT = 10;
+const LARGE_LISTING_THRESHOLD = 10_000;
+
+// =============================================================================
+// Command Parsing
+// =============================================================================
+
+export function parseDreamCommand(text: string): DreamCommand {
+	const stripped = text.replace(/^\/dream\s*/, "").trim();
+
+	if (!stripped) {
+		return { type: "run" };
+	}
+
+	if (stripped === "backup") {
+		return { type: "showBackup" };
+	}
+
+	const backupMatch = stripped.match(/^backup\s+(.+)$/);
+	if (backupMatch) {
+		return { type: "setBackup", path: backupMatch[1].trim() };
+	}
+
+	// Unknown subcommand — treat as a plain run
+	return { type: "run" };
+}
+
+// =============================================================================
+// Discovery
+// =============================================================================
+
+/**
+ * Decode a session directory name back into a candidate filesystem path.
+ *
+ * The encoding replaces path separators and colons with dashes, but original
+ * dash characters are preserved — making the decode lossy. We return the
+ * simplest candidate (all dashes become path separators) and rely on
+ * existsSync to filter false positives.
+ */
+function decodeSessionDirName(encoded: string): string[] {
+	const simple = `/${encoded.replace(/-/g, "/")}`;
+	return [simple];
+}
+
+export function discoverAllProjectMemoryDirs(): string[] {
+	const sessionsDir = getSessionsDir();
+	if (!existsSync(sessionsDir)) return [];
+
+	let dirEntries: string[];
+	try {
+		dirEntries = readdirSync(sessionsDir);
+	} catch {
+		return [];
+	}
+
+	const memoryDirs: string[] = [];
+	const seen = new Set<string>();
+
+	for (const name of dirEntries) {
+		if (!name.startsWith("--") || !name.endsWith("--")) continue;
+
+		const encoded = name.slice(2, -2); // strip --..--
+		if (!encoded) continue;
+
+		const candidates = decodeSessionDirName(encoded);
+		for (const candidate of candidates) {
+			const memDir = join(candidate, ".dreb", "memory");
+			if (!seen.has(memDir) && existsSync(memDir)) {
+				seen.add(memDir);
+				memoryDirs.push(memDir);
+				break;
+			}
+		}
+	}
+
+	return memoryDirs;
+}
+
+/**
+ * Discover claude compatibility memory directories (read-only imports).
+ * Scans ~/.claude/projects/ for subdirectories containing a memory/ folder.
+ */
+function discoverClaudeMemoryDirs(): string[] {
+	const claudeProjectsDir = join(homedir(), ".claude", "projects");
+	if (!existsSync(claudeProjectsDir)) return [];
+
+	let dirEntries: string[];
+	try {
+		dirEntries = readdirSync(claudeProjectsDir);
+	} catch {
+		return [];
+	}
+
+	const memoryDirs: string[] = [];
+	for (const name of dirEntries) {
+		const memDir = join(claudeProjectsDir, name, "memory");
+		if (existsSync(memDir)) {
+			memoryDirs.push(memDir);
+		}
+	}
+	return memoryDirs;
+}
+
+// =============================================================================
+// Context Resolution
+// =============================================================================
+
+export async function resolveDreamContext(settingsManager: SettingsManager): Promise<DreamContext> {
+	// Archive path from settings, or default
+	const rawArchivePath =
+		(settingsManager as unknown as { getDreamArchivePath?: () => string | undefined }).getDreamArchivePath?.() ??
+		DEFAULT_ARCHIVE_DIR;
+	const archivePath = resolve(expandPath(rawArchivePath));
+
+	// Global memory dir
+	const globalMemoryDir = join(homedir(), ".dreb", "memory");
+
+	// Last run timestamp
+	let lastRunTimestamp: string | null = null;
+	const markerPath = join(globalMemoryDir, DREAM_LAST_RUN_FILE);
+	try {
+		if (existsSync(markerPath)) {
+			const content = readFileSync(markerPath, "utf-8").trim();
+			if (content) {
+				lastRunTimestamp = content;
+			}
+		}
+	} catch {
+		// Marker unreadable — treat as first run
+	}
+
+	// Discover memory directories
+	const projectMemoryDirs = discoverAllProjectMemoryDirs();
+	const claudeMemoryDirs = discoverClaudeMemoryDirs();
+	const sessionsDir = getSessionsDir();
+
+	return {
+		archivePath,
+		lastRunTimestamp,
+		globalMemoryDir,
+		projectMemoryDirs,
+		claudeMemoryDirs,
+		sessionsDir,
+	};
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+export function validateArchivePath(archivePath: string, memoryDirs: string[]): void {
+	if (!archivePath || !archivePath.trim()) {
+		throw new Error("Dream archive path cannot be empty");
+	}
+
+	if (!isAbsolute(archivePath)) {
+		throw new Error(`Dream archive path must be absolute, got: ${archivePath}`);
+	}
+
+	const normalized = resolve(archivePath);
+
+	for (const memDir of memoryDirs) {
+		const normalizedMem = resolve(memDir);
+
+		// Archive is inside a memory dir
+		if (normalized.startsWith(`${normalizedMem}/`) || normalized === normalizedMem) {
+			throw new Error(
+				`Dream archive path "${archivePath}" overlaps with memory directory "${memDir}". ` +
+					"The archive must be outside all memory directories.",
+			);
+		}
+
+		// Memory dir is inside the archive
+		if (normalizedMem.startsWith(`${normalized}/`) || normalizedMem === normalized) {
+			throw new Error(
+				`Memory directory "${memDir}" is inside the dream archive path "${archivePath}". ` +
+					"The archive must be outside all memory directories.",
+			);
+		}
+	}
+}
+
+export function validateMemoryLinks(memoryDirs: string[]): LinkValidationResult {
+	const brokenLinks: LinkValidationResult["brokenLinks"] = [];
+	const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+	for (const memDir of memoryDirs) {
+		const indexFile = join(memDir, "MEMORY.md");
+		if (!existsSync(indexFile)) continue;
+
+		let content: string;
+		try {
+			content = readFileSync(indexFile, "utf-8");
+		} catch {
+			continue;
+		}
+
+		for (const match of content.matchAll(linkPattern)) {
+			const pointer = match[0];
+			const target = match[2];
+
+			// Skip external URLs
+			if (target.startsWith("http://") || target.startsWith("https://")) continue;
+
+			const targetPath = join(memDir, target);
+			if (!existsSync(targetPath)) {
+				brokenLinks.push({ memoryDir: memDir, indexFile, pointer, target });
+			}
+		}
+	}
+
+	return { valid: brokenLinks.length === 0, brokenLinks };
+}
+
+// =============================================================================
+// Backup
+// =============================================================================
+
+/** Convert a filesystem path to a safe directory name (same encoding as session dirs). */
+export function safeDirName(path: string): string {
+	return path.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
+}
+
+/** Recursively count files and total size in a directory. */
+async function countFilesAndSize(dir: string): Promise<{ fileCount: number; totalSize: number }> {
+	let fileCount = 0;
+	let totalSize = 0;
+
+	async function walk(current: string): Promise<void> {
+		let entries: import("node:fs").Dirent[];
+		try {
+			entries = await readdir(current, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			const fullPath = join(current, entry.name as string);
+			if (entry.isDirectory()) {
+				await walk(fullPath);
+			} else if (entry.isFile()) {
+				fileCount++;
+				try {
+					const st = await stat(fullPath);
+					totalSize += st.size;
+				} catch {
+					// File disappeared between readdir and stat — skip
+				}
+			}
+		}
+	}
+
+	await walk(dir);
+	return { fileCount, totalSize };
+}
+
+export async function performDreamBackup(context: DreamContext): Promise<BackupResult> {
+	const timestamp = `${new Date().toISOString().replace(/[:.]/g, "-")}_${randomUUID().slice(0, 8)}`;
+	const backupDir = join(context.archivePath, `${BACKUP_PREFIX}${timestamp}`);
+
+	try {
+		mkdirSync(backupDir, { recursive: true });
+	} catch (error) {
+		throw new Error(
+			`Failed to create backup directory "${backupDir}": ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	// Count source files before copying
+	let sourceFileCount = 0;
+	let sourceTotalSize = 0;
+
+	const allSourceDirs: Array<{ dir: string; backupTarget: string }> = [];
+
+	// Global memory
+	if (existsSync(context.globalMemoryDir)) {
+		allSourceDirs.push({ dir: context.globalMemoryDir, backupTarget: join(backupDir, "global") });
+	}
+
+	// Project memories
+	for (const dir of context.projectMemoryDirs) {
+		if (existsSync(dir)) {
+			allSourceDirs.push({
+				dir,
+				backupTarget: join(backupDir, "projects", safeDirName(dir)),
+			});
+		}
+	}
+
+	// Claude compat memories
+	for (const dir of context.claudeMemoryDirs) {
+		if (existsSync(dir)) {
+			allSourceDirs.push({
+				dir,
+				backupTarget: join(backupDir, "claude", safeDirName(dir)),
+			});
+		}
+	}
+
+	// Count source files
+	for (const { dir } of allSourceDirs) {
+		const counts = await countFilesAndSize(dir);
+		sourceFileCount += counts.fileCount;
+		sourceTotalSize += counts.totalSize;
+	}
+
+	// Copy all source directories
+	for (const { dir, backupTarget } of allSourceDirs) {
+		try {
+			await cp(dir, backupTarget, { recursive: true });
+		} catch (error) {
+			throw new Error(
+				`Failed to copy "${dir}" to "${backupTarget}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	// Verify: count files in backup
+	const backupCounts = await countFilesAndSize(backupDir);
+	const verified = backupCounts.fileCount === sourceFileCount && backupCounts.totalSize === sourceTotalSize;
+
+	return {
+		backupDir,
+		timestamp,
+		fileCount: backupCounts.fileCount,
+		totalSize: backupCounts.totalSize,
+		verified,
+	};
+}
+
+// =============================================================================
+// Prompt Building
+// =============================================================================
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} bytes`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function buildDreamPrompt(context: DreamContext, backupResult: BackupResult): string {
+	const verifiedStatus = backupResult.verified ? "✓ Verified" : "⚠ Verification mismatch — check backup integrity";
+	const lastRun = context.lastRunTimestamp ?? "Never (first run)";
+
+	// Build the file listing section
+	let fileListing = "";
+	const allDirs = [
+		{ label: "Global", dir: context.globalMemoryDir },
+		...context.projectMemoryDirs.map((d) => ({ label: `Project: ${d}`, dir: d })),
+		...context.claudeMemoryDirs.map((d) => ({ label: `Claude (READ-ONLY): ${d}`, dir: d })),
+	];
+
+	for (const { label, dir } of allDirs) {
+		if (!existsSync(dir)) continue;
+		fileListing += `\n### ${label}\n`;
+		try {
+			const entries = readdirSync(dir);
+			for (const entry of entries) {
+				if (entry === DREAM_TMP_DIR || entry === DREAM_LOCK_FILE || entry === DREAM_LAST_RUN_FILE) continue;
+				fileListing += `- ${entry}\n`;
+			}
+		} catch {
+			fileListing += `- (unreadable)\n`;
+		}
+	}
+
+	// If file listing is too large, spill to a temp file
+	let fileListingSection: string;
+	if (fileListing.length > LARGE_LISTING_THRESHOLD) {
+		const tmpDir = join(context.globalMemoryDir, DREAM_TMP_DIR);
+		try {
+			mkdirSync(tmpDir, { recursive: true });
+		} catch {
+			// Best-effort
+		}
+		const tmpPath = join(tmpDir, `dream-listing-${Date.now()}.md`);
+		try {
+			writeFileSync(tmpPath, fileListing, "utf-8");
+			fileListingSection =
+				`File listing too large to include inline. Full listing written to: ${tmpPath}\n` +
+				"Read this file for the complete list of memory files.";
+		} catch {
+			// Fallback: include inline anyway
+			fileListingSection = fileListing;
+		}
+	} else {
+		fileListingSection = fileListing;
+	}
+
+	const projectDirsList =
+		context.projectMemoryDirs.length > 0
+			? context.projectMemoryDirs.map((d) => `  - ${d}`).join("\n")
+			: "  (none discovered)";
+
+	const claudeDirsList =
+		context.claudeMemoryDirs.length > 0
+			? context.claudeMemoryDirs.map((d) => `  - ${d}`).join("\n")
+			: "  (none discovered)";
+
+	const dreamTmpDirName = DREAM_TMP_DIR;
+	const dreamLastRunPath = join(context.globalMemoryDir, DREAM_LAST_RUN_FILE);
+
+	return `You are running a memory consolidation (/dream). A backup has been created at: ${backupResult.backupDir}
+Backup verification: ${backupResult.fileCount} files, ${formatBytes(backupResult.totalSize)} — ${verifiedStatus}
+
+## Context
+- Global memory: ${context.globalMemoryDir}
+- Project memories:
+${projectDirsList}
+- Claude Code memories (READ-ONLY):
+${claudeDirsList}
+- Last dream run: ${lastRun}
+- Sessions directory: ${context.sessionsDir}
+
+## Memory Files
+${fileListingSection}
+
+## HARD CONSTRAINTS
+- The \`.claude/\` memory directories are read-only compatibility imports. Do NOT modify, delete, or rewrite any files under \`.claude/\` paths. Only \`~/.dreb/memory/\` and \`<project>/.dreb/memory/\` are writable.
+- NEVER remove session JSONL data files.
+- Explicitly EXCLUDE \`subagent-sessions/\` from scanning scope.
+
+## Pipeline
+
+### Step 1: Read All Memories
+Read every MEMORY.md index and every referenced memory file from global, all project scopes, and \`.claude/\` read-only paths.
+
+### Step 2: Analyze & Plan
+Group related entries, identify duplicates, overlapping content, stale references (deleted files, resolved issues). Present the consolidation plan to the user before making any changes.
+
+### Step 3: Consolidate
+Merge related entries, deduplicate, reorganize semantically. Write changes to temp files first (\`<memory-dir>/${dreamTmpDirName}/\`), then atomic rename per file. Maintain a rollback manifest listing every original→tmp→final path.
+
+### Step 4: Rewrite Indexes
+Produce new MEMORY.md indexes organized semantically, under 200 lines. Every pointer must reference an existing file. Write to temp first, then rename.
+
+### Step 5: Remove Dead Files
+Only after indexes are rewritten and validated, delete memory files that have ZERO remaining references in any MEMORY.md index. Never delete a file that is still referenced.
+
+### Step 6: Scan Sessions
+Spawn background Explore subagents to read session JSONL logs from ${context.sessionsDir} (EXCLUDE subagent-sessions/). Only scan sessions since ${lastRun}. First-run cap: 30 days maximum.
+
+Session JSONL format: Each line is a JSON object. Relevant entry types:
+- \`{"type":"message","message":{"role":"user"|"assistant","content":...}}\` — conversation messages
+- \`{"type":"tool_use","name":"...","input":{...}}\` — tool calls
+- \`{"type":"tool_result","content":...}\` — tool outputs
+
+Each subagent should return findings in structured format:
+\`{"findings": [{"type": "user-preferences|good-practices|project|navigation", "name": "...", "description": "...", "content": "..."}]}\`
+
+### Step 7: STOP AND WAIT
+After spawning subagents, stop generating and wait for ALL background-agent-complete messages before proceeding. Do not continue to Step 8 until every subagent has reported back.
+
+### Step 8: Incorporate Findings
+Create new memory entries from subagent findings, update MEMORY.md indexes.
+
+### Step 9: Report
+Structured summary: X merged, Y pruned, Z added from sessions, W files removed, backup location, any warnings.
+
+### Step 10: Mark Complete
+Write the current ISO timestamp to ${dreamLastRunPath}
+`;
+}
+
+// =============================================================================
+// Locking
+// =============================================================================
+
+export async function acquireDreamLock(): Promise<() => void> {
+	const memDir = join(homedir(), ".dreb", "memory");
+	const lockPath = join(memDir, DREAM_LOCK_FILE);
+
+	// Ensure directory and lock file exist (proper-lockfile requires the file to exist)
+	try {
+		mkdirSync(memDir, { recursive: true });
+	} catch {
+		// Directory already exists
+	}
+
+	if (!existsSync(lockPath)) {
+		try {
+			writeFileSync(lockPath, "", "utf-8");
+		} catch (error) {
+			throw new Error(
+				`Failed to create dream lock file "${lockPath}": ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	let release: () => Promise<void>;
+	try {
+		release = await lockfile.lock(lockPath, {
+			stale: 60000,
+			retries: {
+				retries: 5,
+				factor: 2,
+				minTimeout: 200,
+				maxTimeout: 5000,
+				randomize: true,
+			},
+		});
+	} catch (error) {
+		const code =
+			typeof error === "object" && error !== null && "code" in error
+				? String((error as { code?: unknown }).code)
+				: undefined;
+		if (code === "ELOCKED") {
+			throw new Error(
+				"Another /dream operation is already running. " +
+					"If this is stale, wait 60 seconds or manually remove " +
+					`the lock: ${lockPath}.lock`,
+			);
+		}
+		throw new Error(`Failed to acquire dream lock: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	return () => {
+		release().catch(() => {
+			// Best-effort unlock — if it fails the stale timeout will clean up
+		});
+	};
+}
+
+// =============================================================================
+// Backup Pruning
+// =============================================================================
+
+export async function pruneOldBackups(archivePath: string, keepCount: number = DEFAULT_KEEP_COUNT): Promise<void> {
+	if (!existsSync(archivePath)) return;
+
+	let dirEntries: string[];
+	try {
+		dirEntries = readdirSync(archivePath);
+	} catch {
+		return;
+	}
+
+	const backupDirs = dirEntries.filter((name) => name.startsWith(BACKUP_PREFIX)).sort();
+
+	if (backupDirs.length <= keepCount) return;
+
+	const toRemove = backupDirs.slice(0, backupDirs.length - keepCount);
+	for (const dirName of toRemove) {
+		const fullPath = join(archivePath, dirName);
+		try {
+			rmSync(fullPath, { recursive: true, force: true });
+		} catch {
+			// Best-effort — log would be nice but we don't have a logger here
+		}
+	}
+}
+
+// =============================================================================
+// Temp Dir Cleanup
+// =============================================================================
+
+export function cleanupDreamTmpDirs(memoryDirs: string[]): void {
+	for (const memDir of memoryDirs) {
+		const tmpDir = join(memDir, DREAM_TMP_DIR);
+		if (existsSync(tmpDir)) {
+			try {
+				rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/core/dream.ts
+++ b/packages/coding-agent/src/core/dream.ts
@@ -466,7 +466,13 @@ export function buildDreamPrompt(context: DreamContext, backupResult: BackupResu
 		try {
 			const entries = readdirSync(dir);
 			for (const entry of entries) {
-				if (entry === DREAM_TMP_DIR || entry === DREAM_LOCK_FILE || entry === DREAM_LAST_RUN_FILE) continue;
+				if (
+					entry === DREAM_TMP_DIR ||
+					entry === DREAM_LOCK_FILE ||
+					entry === `${DREAM_LOCK_FILE}.lock` ||
+					entry === DREAM_LAST_RUN_FILE
+				)
+					continue;
 				fileListing += `- ${entry}\n`;
 			}
 		} catch {
@@ -528,6 +534,7 @@ ${fileListingSection}
 ## HARD CONSTRAINTS
 - The \`.claude/\` memory directories are read-only compatibility imports. Do NOT modify, delete, or rewrite any files under \`.claude/\` paths. Only \`~/.dreb/memory/\` and \`<project>/.dreb/memory/\` are writable.
 - NEVER remove session JSONL data files.
+- NEVER delete or modify \`.dream.lock\`, \`.dream.lock.lock\`, or \`.dream-last-run\` files — these are managed by the dream infrastructure, not by you.
 - Explicitly EXCLUDE \`subagent-sessions/\` from scanning scope.
 
 ## Pipeline

--- a/packages/coding-agent/src/core/dream.ts
+++ b/packages/coding-agent/src/core/dream.ts
@@ -1,12 +1,24 @@
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	readSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { cp, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { getSessionsDir } from "../config.js";
 import type { SettingsManager } from "./settings-manager.js";
-import { expandPath } from "./tools/path-utils.js";
 
 // =============================================================================
 // Types
@@ -22,7 +34,7 @@ export interface DreamContext {
 }
 
 export interface BackupResult {
-	backupDir: string;
+	backupPath: string;
 	timestamp: string;
 	fileCount: number;
 	totalSize: number;
@@ -40,7 +52,6 @@ export type DreamCommand = { type: "run" } | { type: "setBackup"; path: string }
 // Constants
 // =============================================================================
 
-const DEFAULT_ARCHIVE_DIR = "~/.dreb/memory-archive/";
 const DREAM_LAST_RUN_FILE = ".dream-last-run";
 const DREAM_LOCK_FILE = ".dream.lock";
 const DREAM_TMP_DIR = ".dream-tmp";
@@ -77,16 +88,26 @@ export function parseDreamCommand(text: string): DreamCommand {
 // =============================================================================
 
 /**
- * Decode a session directory name back into a candidate filesystem path.
- *
- * The encoding replaces path separators and colons with dashes, but original
- * dash characters are preserved — making the decode lossy. We return the
- * simplest candidate (all dashes become path separators) and rely on
- * existsSync to filter false positives.
+ * Read the `cwd` field from the JSONL session header (first line) of a file.
+ * Returns `undefined` if the file cannot be read or the header is invalid.
+ * Uses synchronous low-level reads to avoid loading entire files.
  */
-function decodeSessionDirName(encoded: string): string[] {
-	const simple = `/${encoded.replace(/-/g, "/")}`;
-	return [simple];
+function readSessionCwd(filePath: string): string | undefined {
+	try {
+		const fd = openSync(filePath, "r");
+		const buffer = Buffer.alloc(4096);
+		const bytesRead = readSync(fd, buffer, 0, 4096, 0);
+		closeSync(fd);
+		const firstLine = buffer.toString("utf8", 0, bytesRead).split("\n")[0];
+		if (!firstLine) return undefined;
+		const header = JSON.parse(firstLine);
+		if (header.type === "session" && typeof header.cwd === "string") {
+			return header.cwd;
+		}
+	} catch {
+		// Corrupt or unreadable — skip
+	}
+	return undefined;
 }
 
 export function discoverAllProjectMemoryDirs(): string[] {
@@ -106,17 +127,24 @@ export function discoverAllProjectMemoryDirs(): string[] {
 	for (const name of dirEntries) {
 		if (!name.startsWith("--") || !name.endsWith("--")) continue;
 
-		const encoded = name.slice(2, -2); // strip --..--
-		if (!encoded) continue;
+		const sessionSubDir = join(sessionsDir, name);
 
-		const candidates = decodeSessionDirName(encoded);
-		for (const candidate of candidates) {
-			const memDir = join(candidate, ".dreb", "memory");
-			if (!seen.has(memDir) && existsSync(memDir)) {
-				seen.add(memDir);
-				memoryDirs.push(memDir);
-				break;
-			}
+		// Find any .jsonl file in this session directory
+		let jsonlFiles: string[];
+		try {
+			jsonlFiles = readdirSync(sessionSubDir).filter((f) => f.endsWith(".jsonl"));
+		} catch {
+			continue;
+		}
+		if (jsonlFiles.length === 0) continue;
+
+		const cwd = readSessionCwd(join(sessionSubDir, jsonlFiles[0]));
+		if (!cwd) continue;
+
+		const memDir = join(cwd, ".dreb", "memory");
+		if (!seen.has(memDir) && existsSync(memDir)) {
+			seen.add(memDir);
+			memoryDirs.push(memDir);
 		}
 	}
 
@@ -154,10 +182,7 @@ function discoverClaudeMemoryDirs(): string[] {
 
 export async function resolveDreamContext(settingsManager: SettingsManager): Promise<DreamContext> {
 	// Archive path from settings, or default
-	const rawArchivePath =
-		(settingsManager as unknown as { getDreamArchivePath?: () => string | undefined }).getDreamArchivePath?.() ??
-		DEFAULT_ARCHIVE_DIR;
-	const archivePath = resolve(expandPath(rawArchivePath));
+	const archivePath = settingsManager.getDreamArchivePath();
 
 	// Global memory dir
 	const globalMemoryDir = join(homedir(), ".dreb", "memory");
@@ -282,13 +307,13 @@ async function countFilesAndSize(dir: string): Promise<{ fileCount: number; tota
 		}
 
 		for (const entry of entries) {
-			const fullPath = join(current, entry.name as string);
+			const fullPath = join(current, entry.name);
 			if (entry.isDirectory()) {
 				await walk(fullPath);
 			} else if (entry.isFile()) {
-				fileCount++;
 				try {
 					const st = await stat(fullPath);
+					fileCount++;
 					totalSize += st.size;
 				} catch {
 					// File disappeared between readdir and stat — skip
@@ -303,25 +328,25 @@ async function countFilesAndSize(dir: string): Promise<{ fileCount: number; tota
 
 export async function performDreamBackup(context: DreamContext): Promise<BackupResult> {
 	const timestamp = `${new Date().toISOString().replace(/[:.]/g, "-")}_${randomUUID().slice(0, 8)}`;
-	const backupDir = join(context.archivePath, `${BACKUP_PREFIX}${timestamp}`);
+	const archiveName = `${BACKUP_PREFIX}${timestamp}`;
+	const backupPath = join(context.archivePath, `${archiveName}.tar.gz`);
+	const stagingDir = join(context.archivePath, `.staging-${timestamp}`);
 
+	// Ensure archive directory exists
 	try {
-		mkdirSync(backupDir, { recursive: true });
+		mkdirSync(context.archivePath, { recursive: true });
 	} catch (error) {
 		throw new Error(
-			`Failed to create backup directory "${backupDir}": ${error instanceof Error ? error.message : String(error)}`,
+			`Failed to create archive directory "${context.archivePath}": ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 
-	// Count source files before copying
-	let sourceFileCount = 0;
-	let sourceTotalSize = 0;
-
-	const allSourceDirs: Array<{ dir: string; backupTarget: string }> = [];
+	// Build list of source directories
+	const allSourceDirs: Array<{ dir: string; stagingTarget: string }> = [];
 
 	// Global memory
 	if (existsSync(context.globalMemoryDir)) {
-		allSourceDirs.push({ dir: context.globalMemoryDir, backupTarget: join(backupDir, "global") });
+		allSourceDirs.push({ dir: context.globalMemoryDir, stagingTarget: join(stagingDir, "global") });
 	}
 
 	// Project memories
@@ -329,7 +354,7 @@ export async function performDreamBackup(context: DreamContext): Promise<BackupR
 		if (existsSync(dir)) {
 			allSourceDirs.push({
 				dir,
-				backupTarget: join(backupDir, "projects", safeDirName(dir)),
+				stagingTarget: join(stagingDir, "projects", safeDirName(dir)),
 			});
 		}
 	}
@@ -339,38 +364,59 @@ export async function performDreamBackup(context: DreamContext): Promise<BackupR
 		if (existsSync(dir)) {
 			allSourceDirs.push({
 				dir,
-				backupTarget: join(backupDir, "claude", safeDirName(dir)),
+				stagingTarget: join(stagingDir, "claude", safeDirName(dir)),
 			});
 		}
 	}
 
-	// Count source files
+	// Count source files before copying
+	let sourceFileCount = 0;
+	let sourceTotalSize = 0;
 	for (const { dir } of allSourceDirs) {
 		const counts = await countFilesAndSize(dir);
 		sourceFileCount += counts.fileCount;
 		sourceTotalSize += counts.totalSize;
 	}
 
-	// Copy all source directories
-	for (const { dir, backupTarget } of allSourceDirs) {
+	// Copy source directories into staging area
+	try {
+		mkdirSync(stagingDir, { recursive: true });
+
+		for (const { dir, stagingTarget } of allSourceDirs) {
+			try {
+				await cp(dir, stagingTarget, { recursive: true });
+			} catch (error) {
+				throw new Error(
+					`Failed to copy "${dir}" to "${stagingTarget}": ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+
+		// Create .tar.gz archive from staging directory
+		execFileSync("tar", ["czf", backupPath, "-C", dirname(stagingDir), basename(stagingDir)]);
+	} finally {
+		// Clean up staging directory
 		try {
-			await cp(dir, backupTarget, { recursive: true });
-		} catch (error) {
-			throw new Error(
-				`Failed to copy "${dir}" to "${backupTarget}": ${error instanceof Error ? error.message : String(error)}`,
-			);
+			rmSync(stagingDir, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup
 		}
 	}
 
-	// Verify: count files in backup
-	const backupCounts = await countFilesAndSize(backupDir);
-	const verified = backupCounts.fileCount === sourceFileCount && backupCounts.totalSize === sourceTotalSize;
+	// Verify: archive exists and has non-zero size
+	let verified = false;
+	try {
+		const archiveStat = statSync(backupPath);
+		verified = archiveStat.size > 0;
+	} catch {
+		// Archive missing or unreadable
+	}
 
 	return {
-		backupDir,
+		backupPath,
 		timestamp,
-		fileCount: backupCounts.fileCount,
-		totalSize: backupCounts.totalSize,
+		fileCount: sourceFileCount,
+		totalSize: sourceTotalSize,
 		verified,
 	};
 }
@@ -447,7 +493,7 @@ export function buildDreamPrompt(context: DreamContext, backupResult: BackupResu
 	const dreamTmpDirName = DREAM_TMP_DIR;
 	const dreamLastRunPath = join(context.globalMemoryDir, DREAM_LAST_RUN_FILE);
 
-	return `You are running a memory consolidation (/dream). A backup has been created at: ${backupResult.backupDir}
+	return `You are running a memory consolidation (/dream). A backup archive has been created at: ${backupResult.backupPath}
 Backup verification: ${backupResult.fileCount} files, ${formatBytes(backupResult.totalSize)} — ${verifiedStatus}
 
 ## Context
@@ -468,6 +514,12 @@ ${fileListingSection}
 - Explicitly EXCLUDE \`subagent-sessions/\` from scanning scope.
 
 ## Pipeline
+
+### Step 0: Verify Backup
+Before proceeding, verify the backup archive exists and is intact:
+1. Check that the backup file exists at the path shown above
+2. List its contents (e.g., \`tar tzf <path> | head -20\`) to confirm memory files are present
+3. If the backup appears incomplete or missing, STOP and inform the user — do not proceed with consolidation
 
 ### Step 1: Read All Memories
 Read every MEMORY.md index and every referenced memory file from global, all project scopes, and \`.claude/\` read-only paths.
@@ -582,15 +634,15 @@ export async function pruneOldBackups(archivePath: string, keepCount: number = D
 		return;
 	}
 
-	const backupDirs = dirEntries.filter((name) => name.startsWith(BACKUP_PREFIX)).sort();
+	const backupFiles = dirEntries.filter((name) => name.startsWith(BACKUP_PREFIX) && name.endsWith(".tar.gz")).sort();
 
-	if (backupDirs.length <= keepCount) return;
+	if (backupFiles.length <= keepCount) return;
 
-	const toRemove = backupDirs.slice(0, backupDirs.length - keepCount);
-	for (const dirName of toRemove) {
-		const fullPath = join(archivePath, dirName);
+	const toRemove = backupFiles.slice(0, backupFiles.length - keepCount);
+	for (const fileName of toRemove) {
+		const fullPath = join(archivePath, fileName);
 		try {
-			rmSync(fullPath, { recursive: true, force: true });
+			unlinkSync(fullPath);
 		} catch {
 			// Best-effort — log would be nice but we don't have a logger here
 		}

--- a/packages/coding-agent/src/core/dream.ts
+++ b/packages/coding-agent/src/core/dream.ts
@@ -147,7 +147,11 @@ export function discoverAllProjectMemoryDirs(overrideSessionsDir?: string): stri
 		}
 		if (jsonlFiles.length === 0) continue;
 
-		const cwd = readSessionCwd(join(sessionSubDir, jsonlFiles[0]));
+		let cwd: string | undefined;
+		for (const f of jsonlFiles) {
+			cwd = readSessionCwd(join(sessionSubDir, f));
+			if (cwd) break;
+		}
 		if (!cwd) continue;
 
 		const memDir = join(cwd, ".dreb", "memory");
@@ -189,12 +193,15 @@ function discoverClaudeMemoryDirs(): string[] {
 // Context Resolution
 // =============================================================================
 
-export async function resolveDreamContext(settingsManager: SettingsManager): Promise<DreamContext> {
+export async function resolveDreamContext(
+	settingsManager: SettingsManager,
+	overrideGlobalMemDir?: string,
+): Promise<DreamContext> {
 	// Archive path from settings, or default
 	const archivePath = settingsManager.getDreamArchivePath();
 
 	// Global memory dir
-	const globalMemoryDir = join(homedir(), ".dreb", "memory");
+	const globalMemoryDir = overrideGlobalMemDir ?? join(homedir(), ".dreb", "memory");
 
 	// Last run timestamp
 	let lastRunTimestamp: string | null = null;
@@ -297,9 +304,9 @@ export function validateMemoryLinks(memoryDirs: string[]): LinkValidationResult 
 // Backup
 // =============================================================================
 
-/** Convert a filesystem path to a safe directory name (same encoding as session dirs). */
+/** Convert a filesystem path to a collision-resistant directory name for backup staging. */
 export function safeDirName(path: string): string {
-	return path.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
+	return encodeURIComponent(path).replace(/%2F/gi, "_");
 }
 
 /** Recursively count files and total size in a directory. */

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import { expandPath } from "./tools/path-utils.js";
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -950,12 +951,7 @@ export class SettingsManager {
 	getDreamArchivePath(): string {
 		const configured = this.settings.dream?.archivePath;
 		if (configured) {
-			const expanded = configured.startsWith("~/")
-				? join(homedir(), configured.slice(2))
-				: configured === "~"
-					? homedir()
-					: configured;
-			return resolve(expanded);
+			return resolve(expandPath(configured));
 		}
 		return join(homedir(), ".dreb", "memory-archive");
 	}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,6 +1,7 @@
+import { homedir } from "node:os";
 import type { Transport } from "@dreb/ai";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 
@@ -95,6 +96,9 @@ export interface Settings {
 	markdown?: MarkdownSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
 	forbiddenCommands?: string[]; // Regex patterns for commands blocked by the forbidden-commands guard
+	dream?: {
+		archivePath?: string; // Custom archive location for dream backups (default: ~/.dreb/memory-archive/)
+	};
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -941,5 +945,25 @@ export class SettingsManager {
 
 	getForbiddenCommands(): string[] | undefined {
 		return this.settings.forbiddenCommands;
+	}
+
+	getDreamArchivePath(): string {
+		const configured = this.settings.dream?.archivePath;
+		if (configured) {
+			const expanded = configured.startsWith("~/")
+				? join(homedir(), configured.slice(2))
+				: configured === "~"
+					? homedir()
+					: configured;
+			return resolve(expanded);
+		}
+		return join(homedir(), ".dreb", "memory-archive");
+	}
+
+	setDreamArchivePath(path: string): void {
+		if (!this.globalSettings.dream) this.globalSettings.dream = {};
+		this.globalSettings.dream.archivePath = path;
+		this.markModified("dream", "archivePath");
+		this.save();
 	}
 }

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -31,6 +31,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "logout", description: "Logout from OAuth provider" },
 	{ name: "new", description: "Start a new session" },
 	{ name: "compact", description: "Manually compact the session context" },
+	{ name: "dream", description: "Consolidate and prune memories (backup, merge, scan sessions)" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "buddy", description: "Hatch or manage your terminal companion (pet, reroll, off)" },

--- a/packages/coding-agent/src/core/tools/path-utils.ts
+++ b/packages/coding-agent/src/core/tools/path-utils.ts
@@ -37,8 +37,16 @@ function normalizeAtPrefix(filePath: string): string {
 	return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
+/** Strip matching surrounding quotes (single or double) — users instinctively quote paths with spaces */
+function stripSurroundingQuotes(str: string): string {
+	if (str.length >= 2 && ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'")))) {
+		return str.slice(1, -1);
+	}
+	return str;
+}
+
 export function expandPath(filePath: string): string {
-	const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
+	const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(stripSurroundingQuotes(filePath)));
 	if (normalized === "~") {
 		return os.homedir();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2200,9 +2200,8 @@ export class InteractiveMode {
 				return;
 			}
 			if (text === "/dream" || text.startsWith("/dream ")) {
-				const args = text.startsWith("/dream ") ? text.slice(7).trim() : undefined;
 				this.editor.setText("");
-				await this.handleDreamCommand(args);
+				await this.handleDreamCommand(text);
 				return;
 			}
 			if (text === "/reload") {
@@ -4629,8 +4628,8 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 	// Dream (memory consolidation) handler
 	// =========================================================================
 
-	private async handleDreamCommand(args?: string): Promise<void> {
-		const command = parseDreamCommand(args ? `/dream ${args}` : "/dream");
+	private async handleDreamCommand(text: string): Promise<void> {
+		const command = parseDreamCommand(text);
 
 		switch (command.type) {
 			case "showBackup": {
@@ -4725,9 +4724,10 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 			try {
 				backupResult = await performDreamBackup(dreamContext);
 				if (!backupResult.verified) {
-					this.showWarning(
-						`Backup verification failed — file counts may not match. Backup at: ${backupResult.backupDir}`,
+					this.showError(
+						`Backup verification failed — aborting to protect your data. Check backup at: ${backupResult.backupPath}`,
 					);
+					return;
 				}
 			} catch (error) {
 				this.showError(`Backup failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4749,16 +4749,9 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 
 			// Prune old backups
 			await pruneOldBackups(dreamContext.archivePath);
-
-			// Clean up dream temp dirs
-			cleanupDreamTmpDirs(allMemoryDirs);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			if (error instanceof Error && error.name === "AbortError") {
-				this.showError("Dream cancelled");
-			} else {
-				this.showError(`Dream failed: ${message}`);
-			}
+			this.showError(`Dream failed: ${message}`);
 		} finally {
 			// Always clean up
 			dreamLoader.stop();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -43,6 +43,17 @@ import { BuddyManager, checkOllama } from "../../core/buddy/buddy-manager.js";
 import { Rarity, Stat } from "../../core/buddy/buddy-types.js";
 import { BuddyController } from "../../core/buddy/index.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
+import {
+	acquireDreamLock,
+	buildDreamPrompt,
+	cleanupDreamTmpDirs,
+	parseDreamCommand,
+	performDreamBackup,
+	pruneOldBackups,
+	resolveDreamContext,
+	validateArchivePath,
+	validateMemoryLinks,
+} from "../../core/dream.js";
 import type {
 	ExtensionContext,
 	ExtensionRunner,
@@ -59,6 +70,7 @@ import type { ResourceDiagnostic } from "../../core/resource-loader.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import type { SourceInfo } from "../../core/source-info.js";
+import { expandPath } from "../../core/tools/path-utils.js";
 import { abortBackgroundAgents, getRunningBackgroundAgents } from "../../core/tools/subagent.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";
@@ -400,6 +412,17 @@ export class InteractiveMode {
 					label: item.id,
 					description: item.provider,
 				}));
+			};
+		}
+
+		const dreamCommand = slashCommands.find((command) => command.name === "dream");
+		if (dreamCommand) {
+			dreamCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null => {
+				const subcommands = [
+					{ value: "backup", label: "backup", description: "Show or set the backup archive path" },
+				];
+				const filtered = prefix ? subcommands.filter((s) => s.value.startsWith(prefix.toLowerCase())) : subcommands;
+				return filtered.length > 0 ? filtered : null;
 			};
 		}
 
@@ -2174,6 +2197,12 @@ export class InteractiveMode {
 				const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
 				this.editor.setText("");
 				await this.handleCompactCommand(customInstructions);
+				return;
+			}
+			if (text === "/dream" || text.startsWith("/dream ")) {
+				const args = text.startsWith("/dream ") ? text.slice(7).trim() : undefined;
+				this.editor.setText("");
+				await this.handleDreamCommand(args);
 				return;
 			}
 			if (text === "/reload") {
@@ -4594,6 +4623,162 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 
 		this.bashComponent = undefined;
 		this.ui.requestRender();
+	}
+
+	// =========================================================================
+	// Dream (memory consolidation) handler
+	// =========================================================================
+
+	private async handleDreamCommand(args?: string): Promise<void> {
+		const command = parseDreamCommand(args ? `/dream ${args}` : "/dream");
+
+		switch (command.type) {
+			case "showBackup": {
+				const archivePath = this.settingsManager.getDreamArchivePath();
+				this.showStatus(`Dream backup path: ${archivePath}`);
+				return;
+			}
+			case "setBackup": {
+				try {
+					const expandedPath = expandPath(command.path);
+					const absolutePath = path.isAbsolute(expandedPath)
+						? expandedPath
+						: path.resolve(process.cwd(), expandedPath);
+					const context = await resolveDreamContext(this.settingsManager);
+					const allMemoryDirs = [
+						context.globalMemoryDir,
+						...context.projectMemoryDirs,
+						...context.claudeMemoryDirs,
+					];
+					validateArchivePath(absolutePath, allMemoryDirs);
+					this.settingsManager.setDreamArchivePath(absolutePath);
+					this.showStatus(`Dream backup path set to: ${absolutePath}`);
+				} catch (error) {
+					this.showError(`Invalid backup path: ${error instanceof Error ? error.message : String(error)}`);
+				}
+				return;
+			}
+			case "run": {
+				await this.executeDream();
+				return;
+			}
+		}
+	}
+
+	private async executeDream(): Promise<void> {
+		// Stop any existing loading animation
+		if (this.loadingAnimation) {
+			this.loadingAnimation.stop();
+			this.loadingAnimation = undefined;
+		}
+		this.statusContainer.clear();
+
+		let releaseLock: (() => void) | undefined;
+		let dreamContext: Awaited<ReturnType<typeof resolveDreamContext>> | undefined;
+
+		// Override escape to cancel
+		const originalOnEscape = this.defaultEditor.onEscape;
+		this.defaultEditor.onEscape = () => {
+			// User pressed escape — abort the dream
+			this.session.abort();
+		};
+
+		// Show loading spinner
+		this.chatContainer.addChild(new Spacer(1));
+		const cancelHint = `(${keyText("app.interrupt")} to cancel)`;
+		const dreamLoader = new Loader(
+			this.ui,
+			(spinner) => theme.fg("accent", spinner),
+			(text) => theme.fg("muted", text),
+			`Dreaming... ${cancelHint}`,
+		);
+		this.statusContainer.addChild(dreamLoader);
+		this.ui.requestRender();
+
+		try {
+			// Acquire lock
+			try {
+				releaseLock = await acquireDreamLock();
+			} catch (error) {
+				this.showError(`Cannot start dream: ${error instanceof Error ? error.message : String(error)}`);
+				return;
+			}
+
+			// Resolve context
+			dreamContext = await resolveDreamContext(this.settingsManager);
+
+			// Validate archive path
+			try {
+				const allMemoryDirs = [
+					dreamContext.globalMemoryDir,
+					...dreamContext.projectMemoryDirs,
+					...dreamContext.claudeMemoryDirs,
+				];
+				validateArchivePath(dreamContext.archivePath, allMemoryDirs);
+			} catch (error) {
+				this.showError(`Invalid archive path: ${error instanceof Error ? error.message : String(error)}`);
+				return;
+			}
+
+			// Perform backup
+			let backupResult: Awaited<ReturnType<typeof performDreamBackup>>;
+			try {
+				backupResult = await performDreamBackup(dreamContext);
+				if (!backupResult.verified) {
+					this.showWarning(
+						`Backup verification failed — file counts may not match. Backup at: ${backupResult.backupDir}`,
+					);
+				}
+			} catch (error) {
+				this.showError(`Backup failed: ${error instanceof Error ? error.message : String(error)}`);
+				return;
+			}
+
+			// Update loader text
+			dreamLoader.setText(`Consolidating memories... ${cancelHint}`);
+			this.ui.requestRender();
+
+			// Build prompt and inject into session
+			const prompt = buildDreamPrompt(dreamContext, backupResult);
+			await this.session.prompt(prompt);
+
+			// Post-consolidation: validate links
+			const allMemoryDirs = [dreamContext.globalMemoryDir, ...dreamContext.projectMemoryDirs];
+			const linkResult = validateMemoryLinks(allMemoryDirs);
+			if (!linkResult.valid) {
+				const broken = linkResult.brokenLinks.map((l) => `  ${l.indexFile}: ${l.pointer} → ${l.target}`).join("\n");
+				this.showWarning(`Broken memory links detected:\n${broken}`);
+			}
+
+			// Prune old backups
+			await pruneOldBackups(dreamContext.archivePath);
+
+			// Clean up dream temp dirs
+			cleanupDreamTmpDirs(allMemoryDirs);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (error instanceof Error && error.name === "AbortError") {
+				this.showError("Dream cancelled");
+			} else {
+				this.showError(`Dream failed: ${message}`);
+			}
+		} finally {
+			// Always clean up
+			dreamLoader.stop();
+			this.statusContainer.clear();
+			this.defaultEditor.onEscape = originalOnEscape;
+			if (releaseLock) {
+				try {
+					releaseLock();
+				} catch {
+					/* ignore release errors */
+				}
+			}
+			// Clean up temp dirs on abort/crash too
+			if (dreamContext) {
+				cleanupDreamTmpDirs([dreamContext.globalMemoryDir, ...dreamContext.projectMemoryDirs]);
+			}
+		}
 	}
 
 	private async handleCompactCommand(customInstructions?: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -70,7 +70,7 @@ import type { ResourceDiagnostic } from "../../core/resource-loader.js";
 import { type SessionContext, SessionManager } from "../../core/session-manager.js";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.js";
 import type { SourceInfo } from "../../core/source-info.js";
-import { expandPath } from "../../core/tools/path-utils.js";
+import { resolveToCwd } from "../../core/tools/path-utils.js";
 import { abortBackgroundAgents, getRunningBackgroundAgents } from "../../core/tools/subagent.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.js";
@@ -4639,10 +4639,7 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 			}
 			case "setBackup": {
 				try {
-					const expandedPath = expandPath(command.path);
-					const absolutePath = path.isAbsolute(expandedPath)
-						? expandedPath
-						: path.resolve(process.cwd(), expandedPath);
+					const absolutePath = resolveToCwd(command.path, process.cwd());
 					const context = await resolveDreamContext(this.settingsManager);
 					const allMemoryDirs = [
 						context.globalMemoryDir,

--- a/packages/coding-agent/test/core/dream.test.ts
+++ b/packages/coding-agent/test/core/dream.test.ts
@@ -302,6 +302,28 @@ describe("dream", () => {
 			expect(prompt).toContain("READ-ONLY");
 		});
 
+		it("shows verification warning when verified is false", () => {
+			const context: DreamContext = {
+				archivePath: "/tmp/archive",
+				lastRunTimestamp: null,
+				globalMemoryDir: "/home/user/.dreb/memory",
+				projectMemoryDirs: [],
+				claudeMemoryDirs: [],
+				sessionsDir: "/home/user/.dreb/agent/sessions",
+			};
+			const backup: BackupResult = {
+				backupPath: "/tmp/archive/dream-backup-2026-04-15.tar.gz",
+				timestamp: "2026-04-15T00-00-00-000Z",
+				fileCount: 3,
+				totalSize: 512,
+				verified: false,
+			};
+
+			const prompt = buildDreamPrompt(context, backup);
+			expect(prompt).toContain("⚠ Verification mismatch");
+			expect(prompt).not.toContain("✓ Verified");
+		});
+
 		it("spills large file listings to temp file", () => {
 			const memDir = mkdtempSync(join(tmpdir(), "dreb-dream-listing-"));
 			try {
@@ -340,16 +362,35 @@ describe("dream", () => {
 	});
 
 	describe("acquireDreamLock", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-lock-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
 		it("acquires and releases lock", async () => {
-			const release = await acquireDreamLock();
+			const release = await acquireDreamLock(tempDir);
 			expect(typeof release).toBe("function");
 			release();
 		});
 
 		it("prevents concurrent acquisition", async () => {
-			const release = await acquireDreamLock();
+			const release = await acquireDreamLock(tempDir);
 			try {
-				await expect(acquireDreamLock()).rejects.toThrow();
+				await expect(acquireDreamLock(tempDir)).rejects.toThrow(/already running/);
+			} finally {
+				release();
+			}
+		});
+
+		it("creates lock file in specified directory", async () => {
+			const release = await acquireDreamLock(tempDir);
+			try {
+				expect(existsSync(join(tempDir, ".dream.lock"))).toBe(true);
 			} finally {
 				release();
 			}
@@ -428,6 +469,16 @@ describe("dream", () => {
 	});
 
 	describe("discoverAllProjectMemoryDirs", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-discover-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
 		it("returns an array", () => {
 			const result = discoverAllProjectMemoryDirs();
 			expect(Array.isArray(result)).toBe(true);
@@ -439,6 +490,104 @@ describe("dream", () => {
 				expect(dir).toMatch(/\.dreb\/memory$/);
 				expect(existsSync(dir)).toBe(true);
 			}
+		});
+
+		it("discovers project memory dirs from session JSONL headers", () => {
+			// Create a fake sessions dir with a --encoded-- session dir
+			const sessionsDir = join(tempDir, "sessions");
+			const sessionSubDir = join(sessionsDir, "--home-testuser-myproject--");
+			mkdirSync(sessionSubDir, { recursive: true });
+
+			// Create a fake project with .dreb/memory
+			const projectDir = join(tempDir, "myproject");
+			const memDir = join(projectDir, ".dreb", "memory");
+			mkdirSync(memDir, { recursive: true });
+			writeFileSync(join(memDir, "MEMORY.md"), "# Test");
+
+			// Write a JSONL session file with a valid header pointing to the project
+			const sessionFile = join(sessionSubDir, "2026-04-15T00-00-00-000Z_abc.jsonl");
+			writeFileSync(sessionFile, `${JSON.stringify({ type: "session", cwd: projectDir })}\n`);
+
+			const result = discoverAllProjectMemoryDirs(sessionsDir);
+			expect(result).toContain(memDir);
+		});
+
+		it("skips directories not matching --name-- pattern", () => {
+			const sessionsDir = join(tempDir, "sessions");
+			// Create a dir that doesn't match the pattern
+			const otherDir = join(sessionsDir, "not-encoded");
+			mkdirSync(otherDir, { recursive: true });
+			writeFileSync(join(otherDir, "session.jsonl"), `${JSON.stringify({ type: "session", cwd: tempDir })}\n`);
+
+			// Also create .dreb/memory at tempDir so it would be found if not filtered
+			mkdirSync(join(tempDir, ".dreb", "memory"), { recursive: true });
+
+			const result = discoverAllProjectMemoryDirs(sessionsDir);
+			// Should NOT include tempDir's memory — the session dir doesn't match --name--
+			expect(result).not.toContain(join(tempDir, ".dreb", "memory"));
+		});
+
+		it("deduplicates sessions pointing to the same project", () => {
+			const sessionsDir = join(tempDir, "sessions");
+			const projectDir = join(tempDir, "myproject");
+			const memDir = join(projectDir, ".dreb", "memory");
+			mkdirSync(memDir, { recursive: true });
+
+			// Two session dirs both pointing to the same cwd
+			for (const name of ["--session-a--", "--session-b--"]) {
+				const sessionSubDir = join(sessionsDir, name);
+				mkdirSync(sessionSubDir, { recursive: true });
+				writeFileSync(
+					join(sessionSubDir, "session.jsonl"),
+					`${JSON.stringify({ type: "session", cwd: projectDir })}\n`,
+				);
+			}
+
+			const result = discoverAllProjectMemoryDirs(sessionsDir);
+			const matches = result.filter((d) => d === memDir);
+			expect(matches).toHaveLength(1);
+		});
+
+		it("skips sessions with corrupt or missing JSONL headers", () => {
+			const sessionsDir = join(tempDir, "sessions");
+
+			// Session dir with corrupt JSONL
+			const corruptDir = join(sessionsDir, "--corrupt-session--");
+			mkdirSync(corruptDir, { recursive: true });
+			writeFileSync(join(corruptDir, "session.jsonl"), "not json\n");
+
+			// Session dir with wrong header type
+			const wrongTypeDir = join(sessionsDir, "--wrong-type--");
+			mkdirSync(wrongTypeDir, { recursive: true });
+			writeFileSync(
+				join(wrongTypeDir, "session.jsonl"),
+				`${JSON.stringify({ type: "message", content: "hello" })}\n`,
+			);
+
+			const result = discoverAllProjectMemoryDirs(sessionsDir);
+			expect(result).toHaveLength(0);
+		});
+
+		it("excludes sessions whose project has no .dreb/memory dir", () => {
+			const sessionsDir = join(tempDir, "sessions");
+			const projectDir = join(tempDir, "no-memory-project");
+			mkdirSync(projectDir, { recursive: true });
+			// Deliberately NOT creating .dreb/memory
+
+			const sessionSubDir = join(sessionsDir, "--no-memory--");
+			mkdirSync(sessionSubDir, { recursive: true });
+			writeFileSync(
+				join(sessionSubDir, "session.jsonl"),
+				`${JSON.stringify({ type: "session", cwd: projectDir })}\n`,
+			);
+
+			const result = discoverAllProjectMemoryDirs(sessionsDir);
+			expect(result).toHaveLength(0);
+		});
+
+		it("returns empty array for non-existent sessions dir", () => {
+			const result = discoverAllProjectMemoryDirs(join(tempDir, "nonexistent"));
+			expect(result).toEqual([]);
 		});
 	});
 
@@ -477,14 +626,39 @@ describe("dream", () => {
 		});
 
 		it("lastRunTimestamp is null when no marker file exists", async () => {
+			// resolveDreamContext reads ~/.dreb/memory/.dream-last-run — we can't
+			// easily redirect that without env var overrides. But we can verify the
+			// type contract and that it returns null OR a valid ISO timestamp string.
 			const mockSettingsManager = {
 				getDreamArchivePath: () => "/tmp/test-archive-no-marker",
 			} as unknown as SettingsManager;
 
-			// This relies on there being no .dream-last-run in a fresh/test ~/.dreb/memory,
-			// or the test environment not having one. We verify it's either null or a string.
 			const ctx = await resolveDreamContext(mockSettingsManager);
-			expect(ctx.lastRunTimestamp === null || typeof ctx.lastRunTimestamp === "string").toBe(true);
+			if (ctx.lastRunTimestamp !== null) {
+				// If a marker file exists on this machine, it should be a valid timestamp
+				expect(new Date(ctx.lastRunTimestamp).toISOString()).toBe(ctx.lastRunTimestamp);
+			} else {
+				expect(ctx.lastRunTimestamp).toBeNull();
+			}
+		});
+
+		it("reads lastRunTimestamp from marker file in temp dir", async () => {
+			// Create a temp dir with a known marker file to verify reading logic.
+			// resolveDreamContext hardcodes ~/.dreb/memory — so we test the underlying
+			// logic by writing a marker and reading it directly.
+			const tempMemDir = mkdtempSync(join(tmpdir(), "dreb-dream-marker-test-"));
+			try {
+				const markerPath = join(tempMemDir, ".dream-last-run");
+				const knownTimestamp = "2026-04-10T12:00:00.000Z";
+				writeFileSync(markerPath, knownTimestamp, "utf-8");
+
+				// Verify readFileSync on the marker produces the expected content
+				const { readFileSync } = await import("node:fs");
+				const content = readFileSync(markerPath, "utf-8").trim();
+				expect(content).toBe(knownTimestamp);
+			} finally {
+				rmSync(tempMemDir, { recursive: true, force: true });
+			}
 		});
 
 		it("sessionsDir is a string", async () => {

--- a/packages/coding-agent/test/core/dream.test.ts
+++ b/packages/coding-agent/test/core/dream.test.ts
@@ -12,9 +12,12 @@ import {
 	parseDreamCommand,
 	performDreamBackup,
 	pruneOldBackups,
+	resolveDreamContext,
+	safeDirName,
 	validateArchivePath,
 	validateMemoryLinks,
 } from "../../src/core/dream.js";
+import type { SettingsManager } from "../../src/core/settings-manager.js";
 
 describe("dream", () => {
 	describe("parseDreamCommand", () => {
@@ -51,6 +54,10 @@ describe("dream", () => {
 				type: "setBackup",
 				path: '"/mnt/c/path with spaces"',
 			});
+		});
+
+		it("treats unknown subcommand as run", () => {
+			expect(parseDreamCommand("/dream unknownthing")).toEqual({ type: "run" });
 		});
 	});
 
@@ -112,6 +119,16 @@ describe("dream", () => {
 			const result = validateMemoryLinks(["/nonexistent/path"]);
 			expect(result.valid).toBe(true);
 		});
+
+		it("skips external URLs", () => {
+			writeFileSync(
+				join(tempDir, "MEMORY.md"),
+				"- [Docs](https://example.com) — external link\n- [API](http://api.test) — another\n",
+			);
+			const result = validateMemoryLinks([tempDir]);
+			expect(result.valid).toBe(true);
+			expect(result.brokenLinks).toHaveLength(0);
+		});
 	});
 
 	describe("performDreamBackup", () => {
@@ -144,7 +161,8 @@ describe("dream", () => {
 			const result = await performDreamBackup(context);
 			expect(result.verified).toBe(true);
 			expect(result.fileCount).toBe(2);
-			expect(existsSync(result.backupDir)).toBe(true);
+			expect(existsSync(result.backupPath)).toBe(true);
+			expect(result.backupPath).toMatch(/\.tar\.gz$/);
 		});
 
 		it("copies project memory dirs", async () => {
@@ -183,7 +201,31 @@ describe("dream", () => {
 
 			const result = await performDreamBackup(context);
 			expect(result.fileCount).toBe(0);
-			expect(existsSync(result.backupDir)).toBe(true);
+			expect(existsSync(result.backupPath)).toBe(true);
+			expect(result.backupPath).toMatch(/\.tar\.gz$/);
+		});
+
+		it("includes claude memory dirs in backup", async () => {
+			const globalDir = join(tempDir, "global");
+			const claudeDir = join(tempDir, "claude", "project", "memory");
+			const archiveDir = join(tempDir, "archive");
+			mkdirSync(globalDir, { recursive: true });
+			mkdirSync(claudeDir, { recursive: true });
+			writeFileSync(join(globalDir, "MEMORY.md"), "# Global");
+			writeFileSync(join(claudeDir, "MEMORY.md"), "# Claude");
+
+			const context: DreamContext = {
+				archivePath: archiveDir,
+				lastRunTimestamp: null,
+				globalMemoryDir: globalDir,
+				projectMemoryDirs: [],
+				claudeMemoryDirs: [claudeDir],
+				sessionsDir: join(tempDir, "sessions"),
+			};
+
+			const result = await performDreamBackup(context);
+			expect(result.verified).toBe(true);
+			expect(result.fileCount).toBe(2);
 		});
 	});
 
@@ -198,7 +240,7 @@ describe("dream", () => {
 				sessionsDir: "/home/user/.dreb/agent/sessions",
 			};
 			const backup: BackupResult = {
-				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				backupPath: "/tmp/archive/dream-backup-2026-04-15.tar.gz",
 				timestamp: "2026-04-15T13-29-13-106Z",
 				fileCount: 5,
 				totalSize: 1024,
@@ -206,6 +248,7 @@ describe("dream", () => {
 			};
 
 			const prompt = buildDreamPrompt(context, backup);
+			expect(prompt).toContain("Step 0");
 			expect(prompt).toContain("Step 1");
 			expect(prompt).toContain("Step 10");
 			expect(prompt).toContain("read-only");
@@ -225,7 +268,7 @@ describe("dream", () => {
 				sessionsDir: "/home/user/.dreb/agent/sessions",
 			};
 			const backup: BackupResult = {
-				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				backupPath: "/tmp/archive/dream-backup-2026-04-15.tar.gz",
 				timestamp: "2026-04-15T00-00-00-000Z",
 				fileCount: 3,
 				totalSize: 512,
@@ -247,7 +290,7 @@ describe("dream", () => {
 				sessionsDir: "/home/user/.dreb/agent/sessions",
 			};
 			const backup: BackupResult = {
-				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				backupPath: "/tmp/archive/dream-backup-2026-04-15.tar.gz",
 				timestamp: "2026-04-15T00-00-00-000Z",
 				fileCount: 1,
 				totalSize: 256,
@@ -257,6 +300,42 @@ describe("dream", () => {
 			const prompt = buildDreamPrompt(context, backup);
 			expect(prompt).toContain(".claude/");
 			expect(prompt).toContain("READ-ONLY");
+		});
+
+		it("spills large file listings to temp file", () => {
+			const memDir = mkdtempSync(join(tmpdir(), "dreb-dream-listing-"));
+			try {
+				// Each entry in the listing is "- entry-XXXX.md\n" (16 chars)
+				// Need >10000/16 = 625+ files, plus header overhead. Use 700 for safety.
+				for (let i = 0; i < 700; i++) {
+					writeFileSync(join(memDir, `entry-${String(i).padStart(4, "0")}.md`), "content");
+				}
+
+				const context: DreamContext = {
+					archivePath: "/tmp/archive",
+					lastRunTimestamp: null,
+					globalMemoryDir: memDir,
+					projectMemoryDirs: [],
+					claudeMemoryDirs: [],
+					sessionsDir: "/tmp/sessions",
+				};
+				const backup: BackupResult = {
+					backupPath: "/tmp/archive/dream-backup-test.tar.gz",
+					timestamp: "test",
+					fileCount: 700,
+					totalSize: 4200,
+					verified: true,
+				};
+
+				const prompt = buildDreamPrompt(context, backup);
+				expect(prompt).toContain("File listing too large");
+				expect(prompt).toContain(".dream-tmp");
+				// Verify the temp file was actually created
+				const tmpDreamDir = join(memDir, ".dream-tmp");
+				expect(existsSync(tmpDreamDir)).toBe(true);
+			} finally {
+				rmSync(memDir, { recursive: true, force: true });
+			}
 		});
 	});
 
@@ -290,21 +369,21 @@ describe("dream", () => {
 
 		it("keeps last N backups and removes older ones", async () => {
 			for (let i = 1; i <= 5; i++) {
-				const dir = join(tempDir, `dream-backup-2026-04-${String(i).padStart(2, "0")}T00-00-00-000Z_abc`);
-				mkdirSync(dir);
+				const file = join(tempDir, `dream-backup-2026-04-${String(i).padStart(2, "0")}T00-00-00-000Z_abc.tar.gz`);
+				writeFileSync(file, "fake archive");
 			}
 
 			await pruneOldBackups(tempDir, 3);
 
 			const remaining = readdirSync(tempDir);
 			expect(remaining).toHaveLength(3);
-			expect(remaining).toContain("dream-backup-2026-04-05T00-00-00-000Z_abc");
-			expect(remaining).toContain("dream-backup-2026-04-04T00-00-00-000Z_abc");
-			expect(remaining).toContain("dream-backup-2026-04-03T00-00-00-000Z_abc");
+			expect(remaining).toContain("dream-backup-2026-04-05T00-00-00-000Z_abc.tar.gz");
+			expect(remaining).toContain("dream-backup-2026-04-04T00-00-00-000Z_abc.tar.gz");
+			expect(remaining).toContain("dream-backup-2026-04-03T00-00-00-000Z_abc.tar.gz");
 		});
 
 		it("handles fewer than keepCount backups", async () => {
-			mkdirSync(join(tempDir, "dream-backup-2026-04-01T00-00-00-000Z_abc"));
+			writeFileSync(join(tempDir, "dream-backup-2026-04-01T00-00-00-000Z_abc.tar.gz"), "fake archive");
 			await pruneOldBackups(tempDir, 10);
 			expect(readdirSync(tempDir)).toHaveLength(1);
 		});
@@ -352,6 +431,70 @@ describe("dream", () => {
 		it("returns an array", () => {
 			const result = discoverAllProjectMemoryDirs();
 			expect(Array.isArray(result)).toBe(true);
+		});
+
+		it("returns directories that end with .dreb/memory and exist", () => {
+			const result = discoverAllProjectMemoryDirs();
+			for (const dir of result) {
+				expect(dir).toMatch(/\.dreb\/memory$/);
+				expect(existsSync(dir)).toBe(true);
+			}
+		});
+	});
+
+	describe("safeDirName", () => {
+		it("strips leading slash and replaces separators", () => {
+			expect(safeDirName("/home/user/.dreb/memory")).toBe("home-user-.dreb-memory");
+		});
+
+		it("replaces colons and backslashes", () => {
+			expect(safeDirName("C:\\Users\\test")).toBe("C--Users-test");
+		});
+
+		it("handles paths without leading slash", () => {
+			expect(safeDirName("relative/path")).toBe("relative-path");
+		});
+	});
+
+	describe("resolveDreamContext", () => {
+		it("returns a DreamContext with the archive path from settings manager", async () => {
+			const mockSettingsManager = {
+				getDreamArchivePath: () => "/tmp/test-archive",
+			} as unknown as SettingsManager;
+
+			const ctx = await resolveDreamContext(mockSettingsManager);
+			expect(ctx.archivePath).toBe("/tmp/test-archive");
+		});
+
+		it("sets globalMemoryDir to ~/.dreb/memory", async () => {
+			const { homedir } = await import("node:os");
+			const mockSettingsManager = {
+				getDreamArchivePath: () => "/tmp/test-archive",
+			} as unknown as SettingsManager;
+
+			const ctx = await resolveDreamContext(mockSettingsManager);
+			expect(ctx.globalMemoryDir).toBe(join(homedir(), ".dreb", "memory"));
+		});
+
+		it("lastRunTimestamp is null when no marker file exists", async () => {
+			const mockSettingsManager = {
+				getDreamArchivePath: () => "/tmp/test-archive-no-marker",
+			} as unknown as SettingsManager;
+
+			// This relies on there being no .dream-last-run in a fresh/test ~/.dreb/memory,
+			// or the test environment not having one. We verify it's either null or a string.
+			const ctx = await resolveDreamContext(mockSettingsManager);
+			expect(ctx.lastRunTimestamp === null || typeof ctx.lastRunTimestamp === "string").toBe(true);
+		});
+
+		it("sessionsDir is a string", async () => {
+			const mockSettingsManager = {
+				getDreamArchivePath: () => "/tmp/test-archive",
+			} as unknown as SettingsManager;
+
+			const ctx = await resolveDreamContext(mockSettingsManager);
+			expect(typeof ctx.sessionsDir).toBe("string");
+			expect(ctx.sessionsDir.length).toBeGreaterThan(0);
 		});
 	});
 });

--- a/packages/coding-agent/test/core/dream.test.ts
+++ b/packages/coding-agent/test/core/dream.test.ts
@@ -1,0 +1,343 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	acquireDreamLock,
+	type BackupResult,
+	buildDreamPrompt,
+	cleanupDreamTmpDirs,
+	type DreamContext,
+	discoverAllProjectMemoryDirs,
+	parseDreamCommand,
+	performDreamBackup,
+	pruneOldBackups,
+	validateArchivePath,
+	validateMemoryLinks,
+} from "../../src/core/dream.js";
+
+describe("dream", () => {
+	describe("parseDreamCommand", () => {
+		it("parses /dream as run command", () => {
+			expect(parseDreamCommand("/dream")).toEqual({ type: "run" });
+		});
+
+		it("parses /dream backup as showBackup", () => {
+			expect(parseDreamCommand("/dream backup")).toEqual({ type: "showBackup" });
+		});
+
+		it("parses /dream backup /path as setBackup", () => {
+			expect(parseDreamCommand("/dream backup /some/path")).toEqual({ type: "setBackup", path: "/some/path" });
+		});
+
+		it("parses /dream backup ~/path with tilde", () => {
+			expect(parseDreamCommand("/dream backup ~/backups")).toEqual({ type: "setBackup", path: "~/backups" });
+		});
+
+		it("trims whitespace", () => {
+			expect(parseDreamCommand("/dream  ")).toEqual({ type: "run" });
+			expect(parseDreamCommand("/dream  backup  ")).toEqual({ type: "showBackup" });
+		});
+	});
+
+	describe("validateArchivePath", () => {
+		it("accepts valid absolute path", () => {
+			expect(() => validateArchivePath("/tmp/archive", ["/home/user/.dreb/memory"])).not.toThrow();
+		});
+
+		it("rejects empty path", () => {
+			expect(() => validateArchivePath("", ["/home/user/.dreb/memory"])).toThrow();
+		});
+
+		it("rejects relative path", () => {
+			expect(() => validateArchivePath("relative/path", ["/home/user/.dreb/memory"])).toThrow();
+		});
+
+		it("rejects path that is child of memory dir", () => {
+			expect(() => validateArchivePath("/home/user/.dreb/memory/archive", ["/home/user/.dreb/memory"])).toThrow();
+		});
+
+		it("rejects path where memory dir is child of archive", () => {
+			expect(() => validateArchivePath("/home/user/.dreb", ["/home/user/.dreb/memory"])).toThrow();
+		});
+	});
+
+	describe("validateMemoryLinks", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it("returns valid when all links exist", () => {
+			writeFileSync(join(tempDir, "entry.md"), "---\nname: test\n---\nContent");
+			writeFileSync(join(tempDir, "MEMORY.md"), "- [Test](entry.md) — test entry\n");
+			const result = validateMemoryLinks([tempDir]);
+			expect(result.valid).toBe(true);
+			expect(result.brokenLinks).toHaveLength(0);
+		});
+
+		it("detects broken links", () => {
+			writeFileSync(join(tempDir, "MEMORY.md"), "- [Missing](missing.md) — gone\n");
+			const result = validateMemoryLinks([tempDir]);
+			expect(result.valid).toBe(false);
+			expect(result.brokenLinks).toHaveLength(1);
+			expect(result.brokenLinks[0].target).toBe("missing.md");
+		});
+
+		it("handles missing MEMORY.md gracefully", () => {
+			const result = validateMemoryLinks([tempDir]);
+			expect(result.valid).toBe(true);
+		});
+
+		it("handles non-existent directory gracefully", () => {
+			const result = validateMemoryLinks(["/nonexistent/path"]);
+			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe("performDreamBackup", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-backup-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it("creates backup with correct structure", async () => {
+			const memDir = join(tempDir, "memory");
+			const archiveDir = join(tempDir, "archive");
+			mkdirSync(memDir, { recursive: true });
+			writeFileSync(join(memDir, "MEMORY.md"), "# Memory");
+			writeFileSync(join(memDir, "entry.md"), "content");
+
+			const context: DreamContext = {
+				archivePath: archiveDir,
+				lastRunTimestamp: null,
+				globalMemoryDir: memDir,
+				projectMemoryDirs: [],
+				claudeMemoryDirs: [],
+				sessionsDir: join(tempDir, "sessions"),
+			};
+
+			const result = await performDreamBackup(context);
+			expect(result.verified).toBe(true);
+			expect(result.fileCount).toBe(2);
+			expect(existsSync(result.backupDir)).toBe(true);
+		});
+
+		it("copies project memory dirs", async () => {
+			const globalDir = join(tempDir, "global");
+			const projectDir = join(tempDir, "project", ".dreb", "memory");
+			const archiveDir = join(tempDir, "archive");
+			mkdirSync(globalDir, { recursive: true });
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(globalDir, "MEMORY.md"), "# Global");
+			writeFileSync(join(projectDir, "MEMORY.md"), "# Project");
+
+			const context: DreamContext = {
+				archivePath: archiveDir,
+				lastRunTimestamp: null,
+				globalMemoryDir: globalDir,
+				projectMemoryDirs: [projectDir],
+				claudeMemoryDirs: [],
+				sessionsDir: join(tempDir, "sessions"),
+			};
+
+			const result = await performDreamBackup(context);
+			expect(result.verified).toBe(true);
+			expect(result.fileCount).toBe(2);
+		});
+
+		it("handles missing source dirs gracefully", async () => {
+			const archiveDir = join(tempDir, "archive");
+			const context: DreamContext = {
+				archivePath: archiveDir,
+				lastRunTimestamp: null,
+				globalMemoryDir: join(tempDir, "nonexistent"),
+				projectMemoryDirs: [],
+				claudeMemoryDirs: [],
+				sessionsDir: join(tempDir, "sessions"),
+			};
+
+			const result = await performDreamBackup(context);
+			expect(result.fileCount).toBe(0);
+			expect(existsSync(result.backupDir)).toBe(true);
+		});
+	});
+
+	describe("buildDreamPrompt", () => {
+		it("includes all pipeline steps", () => {
+			const context: DreamContext = {
+				archivePath: "/tmp/archive",
+				lastRunTimestamp: null,
+				globalMemoryDir: "/home/user/.dreb/memory",
+				projectMemoryDirs: ["/home/user/project/.dreb/memory"],
+				claudeMemoryDirs: [],
+				sessionsDir: "/home/user/.dreb/agent/sessions",
+			};
+			const backup: BackupResult = {
+				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				timestamp: "2026-04-15T13-29-13-106Z",
+				fileCount: 5,
+				totalSize: 1024,
+				verified: true,
+			};
+
+			const prompt = buildDreamPrompt(context, backup);
+			expect(prompt).toContain("Step 1");
+			expect(prompt).toContain("Step 10");
+			expect(prompt).toContain("read-only");
+			expect(prompt).toContain("STOP AND WAIT");
+			expect(prompt).toContain(".dream-last-run");
+			expect(prompt).toContain(context.globalMemoryDir);
+			expect(prompt).toContain("Never (first run)");
+		});
+
+		it("includes last run timestamp when provided", () => {
+			const context: DreamContext = {
+				archivePath: "/tmp/archive",
+				lastRunTimestamp: "2026-04-10T12:00:00.000Z",
+				globalMemoryDir: "/home/user/.dreb/memory",
+				projectMemoryDirs: [],
+				claudeMemoryDirs: [],
+				sessionsDir: "/home/user/.dreb/agent/sessions",
+			};
+			const backup: BackupResult = {
+				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				timestamp: "2026-04-15T00-00-00-000Z",
+				fileCount: 3,
+				totalSize: 512,
+				verified: true,
+			};
+
+			const prompt = buildDreamPrompt(context, backup);
+			expect(prompt).toContain("2026-04-10T12:00:00.000Z");
+			expect(prompt).not.toContain("Never (first run)");
+		});
+
+		it("marks claude dirs as read-only", () => {
+			const context: DreamContext = {
+				archivePath: "/tmp/archive",
+				lastRunTimestamp: null,
+				globalMemoryDir: "/home/user/.dreb/memory",
+				projectMemoryDirs: [],
+				claudeMemoryDirs: ["/home/user/.claude/projects/memory"],
+				sessionsDir: "/home/user/.dreb/agent/sessions",
+			};
+			const backup: BackupResult = {
+				backupDir: "/tmp/archive/dream-backup-2026-04-15",
+				timestamp: "2026-04-15T00-00-00-000Z",
+				fileCount: 1,
+				totalSize: 256,
+				verified: true,
+			};
+
+			const prompt = buildDreamPrompt(context, backup);
+			expect(prompt).toContain(".claude/");
+			expect(prompt).toContain("READ-ONLY");
+		});
+	});
+
+	describe("acquireDreamLock", () => {
+		it("acquires and releases lock", async () => {
+			const release = await acquireDreamLock();
+			expect(typeof release).toBe("function");
+			release();
+		});
+
+		it("prevents concurrent acquisition", async () => {
+			const release = await acquireDreamLock();
+			try {
+				await expect(acquireDreamLock()).rejects.toThrow();
+			} finally {
+				release();
+			}
+		});
+	});
+
+	describe("pruneOldBackups", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-prune-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it("keeps last N backups and removes older ones", async () => {
+			for (let i = 1; i <= 5; i++) {
+				const dir = join(tempDir, `dream-backup-2026-04-${String(i).padStart(2, "0")}T00-00-00-000Z_abc`);
+				mkdirSync(dir);
+			}
+
+			await pruneOldBackups(tempDir, 3);
+
+			const remaining = readdirSync(tempDir);
+			expect(remaining).toHaveLength(3);
+			expect(remaining).toContain("dream-backup-2026-04-05T00-00-00-000Z_abc");
+			expect(remaining).toContain("dream-backup-2026-04-04T00-00-00-000Z_abc");
+			expect(remaining).toContain("dream-backup-2026-04-03T00-00-00-000Z_abc");
+		});
+
+		it("handles fewer than keepCount backups", async () => {
+			mkdirSync(join(tempDir, "dream-backup-2026-04-01T00-00-00-000Z_abc"));
+			await pruneOldBackups(tempDir, 10);
+			expect(readdirSync(tempDir)).toHaveLength(1);
+		});
+
+		it("handles empty archive dir", async () => {
+			await pruneOldBackups(tempDir, 10);
+			expect(readdirSync(tempDir)).toHaveLength(0);
+		});
+
+		it("handles non-existent archive dir", async () => {
+			await expect(pruneOldBackups(join(tempDir, "nonexistent"), 10)).resolves.not.toThrow();
+		});
+	});
+
+	describe("cleanupDreamTmpDirs", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "dreb-dream-cleanup-test-"));
+		});
+
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		it("removes .dream-tmp directories", () => {
+			const tmpDreamDir = join(tempDir, ".dream-tmp");
+			mkdirSync(tmpDreamDir);
+			writeFileSync(join(tmpDreamDir, "temp.md"), "temp");
+
+			cleanupDreamTmpDirs([tempDir]);
+			expect(existsSync(tmpDreamDir)).toBe(false);
+		});
+
+		it("handles missing .dream-tmp gracefully", () => {
+			expect(() => cleanupDreamTmpDirs([tempDir])).not.toThrow();
+		});
+
+		it("handles non-existent dirs gracefully", () => {
+			expect(() => cleanupDreamTmpDirs(["/nonexistent/path"])).not.toThrow();
+		});
+	});
+
+	describe("discoverAllProjectMemoryDirs", () => {
+		it("returns an array", () => {
+			const result = discoverAllProjectMemoryDirs();
+			expect(Array.isArray(result)).toBe(true);
+		});
+	});
+});

--- a/packages/coding-agent/test/core/dream.test.ts
+++ b/packages/coding-agent/test/core/dream.test.ts
@@ -38,6 +38,20 @@ describe("dream", () => {
 			expect(parseDreamCommand("/dream  ")).toEqual({ type: "run" });
 			expect(parseDreamCommand("/dream  backup  ")).toEqual({ type: "showBackup" });
 		});
+
+		it("preserves paths with spaces (quote stripping is expandPath's job)", () => {
+			expect(parseDreamCommand("/dream backup /mnt/c/path with spaces/backups")).toEqual({
+				type: "setBackup",
+				path: "/mnt/c/path with spaces/backups",
+			});
+		});
+
+		it("preserves quoted paths as-is (expandPath strips quotes downstream)", () => {
+			expect(parseDreamCommand('/dream backup "/mnt/c/path with spaces"')).toEqual({
+				type: "setBackup",
+				path: '"/mnt/c/path with spaces"',
+			});
+		});
 	});
 
 	describe("validateArchivePath", () => {

--- a/packages/coding-agent/test/core/dream.test.ts
+++ b/packages/coding-agent/test/core/dream.test.ts
@@ -592,16 +592,22 @@ describe("dream", () => {
 	});
 
 	describe("safeDirName", () => {
-		it("strips leading slash and replaces separators", () => {
-			expect(safeDirName("/home/user/.dreb/memory")).toBe("home-user-.dreb-memory");
+		it("encodes path separators collision-free", () => {
+			expect(safeDirName("/home/user/.dreb/memory")).toBe("_home_user_.dreb_memory");
 		});
 
-		it("replaces colons and backslashes", () => {
-			expect(safeDirName("C:\\Users\\test")).toBe("C--Users-test");
+		it("produces different names for paths differing only in dash vs slash", () => {
+			const a = safeDirName("/home/user/my-project/.dreb/memory");
+			const b = safeDirName("/home/user/my/project/.dreb/memory");
+			expect(a).not.toBe(b);
+		});
+
+		it("encodes colons and backslashes", () => {
+			expect(safeDirName("C:\\Users\\test")).toBe("C%3A%5CUsers%5Ctest");
 		});
 
 		it("handles paths without leading slash", () => {
-			expect(safeDirName("relative/path")).toBe("relative-path");
+			expect(safeDirName("relative/path")).toBe("relative_path");
 		});
 	});
 
@@ -625,37 +631,48 @@ describe("dream", () => {
 			expect(ctx.globalMemoryDir).toBe(join(homedir(), ".dreb", "memory"));
 		});
 
-		it("lastRunTimestamp is null when no marker file exists", async () => {
-			// resolveDreamContext reads ~/.dreb/memory/.dream-last-run — we can't
-			// easily redirect that without env var overrides. But we can verify the
-			// type contract and that it returns null OR a valid ISO timestamp string.
-			const mockSettingsManager = {
-				getDreamArchivePath: () => "/tmp/test-archive-no-marker",
-			} as unknown as SettingsManager;
+		it("lastRunTimestamp is null when marker file is absent (via override)", async () => {
+			const tempMemDir = mkdtempSync(join(tmpdir(), "dreb-dream-no-marker-ctx-"));
+			try {
+				const mockSettingsManager = {
+					getDreamArchivePath: () => "/tmp/test-archive-no-marker",
+				} as unknown as SettingsManager;
 
-			const ctx = await resolveDreamContext(mockSettingsManager);
-			if (ctx.lastRunTimestamp !== null) {
-				// If a marker file exists on this machine, it should be a valid timestamp
-				expect(new Date(ctx.lastRunTimestamp).toISOString()).toBe(ctx.lastRunTimestamp);
-			} else {
+				const ctx = await resolveDreamContext(mockSettingsManager, tempMemDir);
 				expect(ctx.lastRunTimestamp).toBeNull();
+			} finally {
+				rmSync(tempMemDir, { recursive: true, force: true });
 			}
 		});
 
-		it("reads lastRunTimestamp from marker file in temp dir", async () => {
-			// Create a temp dir with a known marker file to verify reading logic.
-			// resolveDreamContext hardcodes ~/.dreb/memory — so we test the underlying
-			// logic by writing a marker and reading it directly.
+		it("reads lastRunTimestamp from marker file via overrideGlobalMemDir", async () => {
 			const tempMemDir = mkdtempSync(join(tmpdir(), "dreb-dream-marker-test-"));
 			try {
 				const markerPath = join(tempMemDir, ".dream-last-run");
 				const knownTimestamp = "2026-04-10T12:00:00.000Z";
 				writeFileSync(markerPath, knownTimestamp, "utf-8");
 
-				// Verify readFileSync on the marker produces the expected content
-				const { readFileSync } = await import("node:fs");
-				const content = readFileSync(markerPath, "utf-8").trim();
-				expect(content).toBe(knownTimestamp);
+				const mockSettingsManager = {
+					getDreamArchivePath: () => "/tmp/test-archive",
+				} as unknown as SettingsManager;
+
+				const ctx = await resolveDreamContext(mockSettingsManager, tempMemDir);
+				expect(ctx.lastRunTimestamp).toBe(knownTimestamp);
+				expect(ctx.globalMemoryDir).toBe(tempMemDir);
+			} finally {
+				rmSync(tempMemDir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns null lastRunTimestamp when no marker file exists", async () => {
+			const tempMemDir = mkdtempSync(join(tmpdir(), "dreb-dream-no-marker-test-"));
+			try {
+				const mockSettingsManager = {
+					getDreamArchivePath: () => "/tmp/test-archive",
+				} as unknown as SettingsManager;
+
+				const ctx = await resolveDreamContext(mockSettingsManager, tempMemDir);
+				expect(ctx.lastRunTimestamp).toBeNull();
 			} finally {
 				rmSync(tempMemDir, { recursive: true, force: true });
 			}

--- a/packages/coding-agent/test/path-utils.test.ts
+++ b/packages/coding-agent/test/path-utils.test.ts
@@ -22,6 +22,28 @@ describe("path-utils", () => {
 			const result = expandPath(withNBSP);
 			expect(result).toBe("file name.txt");
 		});
+
+		it("should strip surrounding double quotes", () => {
+			const result = expandPath('"/mnt/c/path with spaces/file.txt"');
+			expect(result).toBe("/mnt/c/path with spaces/file.txt");
+		});
+
+		it("should strip surrounding single quotes", () => {
+			const result = expandPath("'/mnt/c/path with spaces/file.txt'");
+			expect(result).toBe("/mnt/c/path with spaces/file.txt");
+		});
+
+		it("should not strip mismatched quotes", () => {
+			const result = expandPath("'/mnt/c/path\"");
+			expect(result).toBe("'/mnt/c/path\"");
+		});
+
+		it("should handle quoted tilde paths", () => {
+			const result = expandPath('"~/Documents/my file.txt"');
+			expect(result).toContain("Documents/my file.txt");
+			expect(result).not.toContain('"');
+			expect(result).not.toContain("~");
+		});
 	});
 
 	describe("resolveToCwd", () => {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.5.2",
+	"version": "2.6.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #99

Add a `/dream` command that runs memory consolidation on the parent agent session. Programmatically backs up all memory files before modifications, then guides the agent through consolidation, pruning, session log scanning, and reporting.

Implementation plan posted as a comment below.