### PR TITLE
Rename search tool parameters projectDir and path for clarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -333,9 +333,9 @@ Task tracking is prompt-driven: the system prompt includes guidelines for when t
 
 The `search` tool provides natural language queries over the codebase using embeddings and full-text search. It supports identifier queries (e.g., `AuthMiddleware`), natural language (e.g., `where is rate limiting handled`), and path queries (e.g., `src/auth/`).
 
-**Parameters:** `query` (required), `path` (restrict to subdirectory), `limit` (max results, default 20), `projectDir` (index/search a different directory instead of cwd — useful for Telegram sessions where cwd is `~/`), `rebuild` (force a clean re-index when results look stale or corrupt).
+**Parameters:** `query` (required), `searchDir` (directory to index and search — each unique value gets its own independent index; defaults to cwd, but should be set explicitly in Telegram sessions where cwd is `~/`), `restrictToDir` (filter results to files under this subdirectory within the already-built index — does not affect which files are indexed), `limit` (max results, default 20), `rebuild` (force a clean re-index when results look stale or corrupt).
 
-**How it works:** The first query builds a project index (typically 10–60s, longer for very large repos). Subsequent queries use the cached index, with incremental re-indexing for changed files (mtime-based). Each unique `projectDir` gets its own independent index.
+**How it works:** The first query builds a project index (typically 10–60s, longer for very large repos). Subsequent queries use the cached index, with incremental re-indexing for changed files (mtime-based). Each unique `searchDir` gets its own independent index.
 
 **Indexing pipeline:**
 - AST-aware code chunking via tree-sitter (TypeScript, JavaScript, Python, Go, Rust, Java, C, C++, GDScript) — extracts functions, classes, methods, and exports as individual chunks

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/search.ts
+++ b/packages/coding-agent/src/core/tools/search.ts
@@ -24,10 +24,18 @@ import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const searchSchema = Type.Object({
 	query: Type.String({ description: "The search query (natural language, identifier, or path)" }),
-	path: Type.Optional(Type.String({ description: "Restrict search to files under this path (relative to cwd)" })),
+	restrictToDir: Type.Optional(
+		Type.String({
+			description:
+				"Filter results to files under this path (relative to searchDir or cwd). Does not affect indexing — the entire searchDir is still indexed.",
+		}),
+	),
 	limit: Type.Optional(Type.Number({ description: "Maximum number of results to return (default: 20)" })),
-	projectDir: Type.Optional(
-		Type.String({ description: "Directory to index and search instead of cwd (useful when cwd is ~/)" }),
+	searchDir: Type.Optional(
+		Type.String({
+			description:
+				"Directory to index and search instead of cwd (useful when cwd is ~/). The entire contents of this directory are scanned and indexed.",
+		}),
 	),
 	rebuild: Type.Optional(Type.Boolean({ description: "Force a clean rebuild of the search index (default: false)" })),
 });
@@ -50,18 +58,18 @@ export interface SearchToolDetails {
 
 /** @internal Exported for testing. */
 export function formatSearchCall(
-	args: { query?: string; path?: string; limit?: number; projectDir?: string; rebuild?: boolean } | undefined,
+	args: { query?: string; restrictToDir?: string; limit?: number; searchDir?: string; rebuild?: boolean } | undefined,
 	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
 ): string {
 	const query = str(args?.query);
-	const searchPath = str(args?.path);
-	const projectDir = str(args?.projectDir);
+	const restrictToDir = str(args?.restrictToDir);
+	const searchDir = str(args?.searchDir);
 	let text = `${theme.fg("toolTitle", theme.bold("search"))} ${theme.fg("accent", `"${query ?? ""}"`)}`;
-	if (projectDir) {
-		text += theme.fg("toolOutput", ` project ${shortenPath(projectDir)}`);
+	if (searchDir) {
+		text += theme.fg("toolOutput", ` project ${shortenPath(searchDir)}`);
 	}
-	if (searchPath) {
-		text += theme.fg("toolOutput", ` in ${shortenPath(searchPath)}`);
+	if (restrictToDir) {
+		text += theme.fg("toolOutput", ` in ${shortenPath(restrictToDir)}`);
 	}
 	if (args?.rebuild) {
 		text += theme.fg("toolOutput", " [rebuild]");
@@ -156,7 +164,7 @@ export function createSearchToolDefinition(cwd: string): ToolDefinition<typeof s
 				};
 			}
 
-			const { query, path: searchPath, limit, projectDir, rebuild } = params;
+			const { query, restrictToDir, limit, searchDir, rebuild } = params;
 
 			if (!query || query.trim().length === 0) {
 				return {
@@ -165,21 +173,21 @@ export function createSearchToolDefinition(cwd: string): ToolDefinition<typeof s
 				};
 			}
 
-			const resolvedProjectDir = projectDir ? resolveToCwd(projectDir, cwd) : cwd;
+			const resolvedSearchDir = searchDir ? resolveToCwd(searchDir, cwd) : cwd;
 
-			if (projectDir && (!existsSync(resolvedProjectDir) || !statSync(resolvedProjectDir).isDirectory())) {
+			if (searchDir && (!existsSync(resolvedSearchDir) || !statSync(resolvedSearchDir).isDirectory())) {
 				return {
 					content: [
 						{
 							type: "text",
-							text: `projectDir does not exist or is not a directory: ${resolvedProjectDir}`,
+							text: `searchDir does not exist or is not a directory: ${resolvedSearchDir}`,
 						},
 					],
 					details: { resultCount: 0, indexBuilt: false },
 				};
 			}
 
-			const engine = getSearchEngine(resolvedProjectDir);
+			const engine = getSearchEngine(resolvedSearchDir);
 
 			if (rebuild) {
 				await engine.resetIndex();
@@ -188,7 +196,7 @@ export function createSearchToolDefinition(cwd: string): ToolDefinition<typeof s
 			let indexBuilt = false;
 			const results = await engine.search(query, {
 				limit: typeof limit === "number" && limit > 0 ? Math.floor(limit) : 20,
-				pathFilter: searchPath,
+				pathFilter: restrictToDir,
 				onProgress: (phase, current, total) => {
 					if (phase === "indexing" || phase === "scanning" || phase === "loading model" || phase === "embedding") {
 						indexBuilt = true;

--- a/packages/coding-agent/test/search/search-tool.test.ts
+++ b/packages/coding-agent/test/search/search-tool.test.ts
@@ -130,10 +130,10 @@ describe("createSearchToolDefinition", () => {
 			expect(schema.required).toContain("query");
 		});
 
-		it("has path as an optional property", () => {
-			expect(schema.properties.path).toBeDefined();
+		it("has restrictToDir as an optional property", () => {
+			expect(schema.properties.restrictToDir).toBeDefined();
 			// Optional properties are not in the required array
-			expect(schema.required ?? []).not.toContain("path");
+			expect(schema.required ?? []).not.toContain("restrictToDir");
 		});
 
 		it("has limit as an optional property", () => {
@@ -141,10 +141,10 @@ describe("createSearchToolDefinition", () => {
 			expect(schema.required ?? []).not.toContain("limit");
 		});
 
-		it("has projectDir as an optional property", () => {
-			expect(schema.properties.projectDir).toBeDefined();
-			expect(schema.properties.projectDir.type).toBe("string");
-			expect(schema.required ?? []).not.toContain("projectDir");
+		it("has searchDir as an optional property", () => {
+			expect(schema.properties.searchDir).toBeDefined();
+			expect(schema.properties.searchDir.type).toBe("string");
+			expect(schema.required ?? []).not.toContain("searchDir");
 		});
 
 		it("has rebuild as an optional property", () => {
@@ -171,14 +171,14 @@ describe("createSearchToolDefinition", () => {
 			expect(result).toContain('"AuthMiddleware"');
 		});
 
-		it("renders projectDir when provided", () => {
-			const result = formatSearchCall({ query: "test", projectDir: "/home/user/project" }, stubTheme);
+		it("renders searchDir when provided", () => {
+			const result = formatSearchCall({ query: "test", searchDir: "/home/user/project" }, stubTheme);
 			expect(result).toContain("project");
 			expect(result).toContain("/home/user/project"); // shortenPath output
 		});
 
-		it("renders searchPath when provided", () => {
-			const result = formatSearchCall({ query: "test", path: "src/auth" }, stubTheme);
+		it("renders restrictToDir when provided", () => {
+			const result = formatSearchCall({ query: "test", restrictToDir: "src/auth" }, stubTheme);
 			expect(result).toContain("in");
 			expect(result).toContain("src/auth");
 		});
@@ -200,7 +200,7 @@ describe("createSearchToolDefinition", () => {
 
 		it("renders all options together", () => {
 			const result = formatSearchCall(
-				{ query: "auth", projectDir: "/proj", path: "src", rebuild: true, limit: 10 },
+				{ query: "auth", searchDir: "/proj", restrictToDir: "src", rebuild: true, limit: 10 },
 				stubTheme,
 			);
 			expect(result).toContain('"auth"');
@@ -405,10 +405,24 @@ describe("createSearchToolDefinition", () => {
 				expect(typeof details.indexBuilt).toBe("boolean");
 			});
 
+			it("restrictToDir pointing outside searchDir returns no results", async () => {
+				const result = await fixtureTool.execute(
+					"t-restrict-outside",
+					{ query: "AuthMiddleware", restrictToDir: "/tmp/this-path-definitely-does-not-exist-abc123" },
+					undefined,
+					undefined,
+					undefined as any,
+				);
+				const text = (result.content[0] as { type: "text"; text: string }).text;
+
+				expect(text).toBe("No results found.");
+				expect(result.details!.resultCount).toBe(0);
+			});
+
 			it("no results returns 'No results found' message", async () => {
 				const result = await fixtureTool.execute(
 					"t-empty",
-					{ query: "anything", path: "nonexistent/dir" },
+					{ query: "anything", restrictToDir: "nonexistent/dir" },
 					undefined,
 					undefined,
 					undefined as any,
@@ -421,45 +435,45 @@ describe("createSearchToolDefinition", () => {
 		});
 
 		// ============================================================================
-		// Execute — projectDir parameter
+		// Execute — searchDir parameter
 		// ============================================================================
 
-		describe("projectDir parameter", () => {
-			let projectDirFixture: string;
+		describe("searchDir parameter", () => {
+			let searchDirFixture: string;
 			let differentCwdTool: ReturnType<typeof createSearchToolDefinition>;
 
 			beforeAll(() => {
 				// Create a fixture project in a separate directory
-				projectDirFixture = mkdtempSync(path.join(tmpdir(), "search-projectdir-"));
-				createFixtureProject(projectDirFixture);
+				searchDirFixture = mkdtempSync(path.join(tmpdir(), "search-projectdir-"));
+				createFixtureProject(searchDirFixture);
 				// Create the tool with a DIFFERENT cwd (empty temp dir)
 				const emptyCwd = mkdtempSync(path.join(tmpdir(), "search-empty-cwd-"));
 				differentCwdTool = createSearchToolDefinition(emptyCwd);
 			});
 
 			afterAll(() => {
-				rmSync(projectDirFixture, { recursive: true, force: true });
+				rmSync(searchDirFixture, { recursive: true, force: true });
 			});
 
-			it("searches the projectDir instead of cwd when provided", async () => {
+			it("searches the searchDir instead of cwd when provided", async () => {
 				const result = await differentCwdTool.execute(
 					"t-projdir",
-					{ query: "AuthMiddleware", projectDir: projectDirFixture },
+					{ query: "AuthMiddleware", searchDir: searchDirFixture },
 					undefined,
 					undefined,
 					undefined as any,
 				);
 				const text = (result.content[0] as { type: "text"; text: string }).text;
 
-				// Should find results from the projectDir fixture
+				// Should find results from the searchDir fixture
 				expect(text).toContain("AuthMiddleware");
 				expect(result.details!.resultCount).toBeGreaterThan(0);
 			});
 
-			it("returns error when projectDir does not exist", async () => {
+			it("returns error when searchDir does not exist", async () => {
 				const result = await differentCwdTool.execute(
 					"t-projdir-noexist",
-					{ query: "AuthMiddleware", projectDir: "/tmp/this-path-definitely-does-not-exist-abc123" },
+					{ query: "AuthMiddleware", searchDir: "/tmp/this-path-definitely-does-not-exist-abc123" },
 					undefined,
 					undefined,
 					undefined as any,
@@ -471,13 +485,13 @@ describe("createSearchToolDefinition", () => {
 				expect(result.details!.indexBuilt).toBe(false);
 			});
 
-			it("returns error when projectDir is a file, not a directory", async () => {
+			it("returns error when searchDir is a file, not a directory", async () => {
 				const tmpFile = path.join(mkdtempSync(path.join(tmpdir(), "search-file-")), "not-a-dir.txt");
 				writeFileSync(tmpFile, "hello", "utf-8");
 				try {
 					const result = await differentCwdTool.execute(
 						"t-projdir-file",
-						{ query: "AuthMiddleware", projectDir: tmpFile },
+						{ query: "AuthMiddleware", searchDir: tmpFile },
 						undefined,
 						undefined,
 						undefined as any,
@@ -491,12 +505,12 @@ describe("createSearchToolDefinition", () => {
 				}
 			});
 
-			it("does not find project-specific content when projectDir points elsewhere", async () => {
+			it("does not find project-specific content when searchDir points elsewhere", async () => {
 				const emptyProject = mkdtempSync(path.join(tmpdir(), "search-empty-proj-"));
 				try {
 					const result = await differentCwdTool.execute(
 						"t-projdir-empty",
-						{ query: "AuthMiddleware", projectDir: emptyProject },
+						{ query: "AuthMiddleware", searchDir: emptyProject },
 						undefined,
 						undefined,
 						undefined as any,
@@ -600,10 +614,10 @@ describe("createSearchToolDefinition", () => {
 		});
 
 		// ============================================================================
-		// Execute — projectDir + rebuild isolation
+		// Execute — searchDir + rebuild isolation
 		// ============================================================================
 
-		describe("projectDir + rebuild isolation", () => {
+		describe("searchDir + rebuild isolation", () => {
 			let projectA: string;
 			let projectB: string;
 			let isolationTool: ReturnType<typeof createSearchToolDefinition>;
@@ -628,10 +642,10 @@ describe("createSearchToolDefinition", () => {
 				rmSync(projectB, { recursive: true, force: true });
 			});
 
-			it("each projectDir gets its own index", async () => {
+			it("each searchDir gets its own index", async () => {
 				const resultA = await isolationTool.execute(
 					"t-iso-a",
-					{ query: "AuthMiddleware", projectDir: projectA },
+					{ query: "AuthMiddleware", searchDir: projectA },
 					undefined,
 					undefined,
 					undefined as any,
@@ -640,7 +654,7 @@ describe("createSearchToolDefinition", () => {
 
 				const resultB = await isolationTool.execute(
 					"t-iso-b",
-					{ query: "PaymentProcessor", projectDir: projectB },
+					{ query: "PaymentProcessor", searchDir: projectB },
 					undefined,
 					undefined,
 					undefined as any,
@@ -656,7 +670,7 @@ describe("createSearchToolDefinition", () => {
 				// Rebuild project A
 				await isolationTool.execute(
 					"t-iso-rebuild-a",
-					{ query: "AuthMiddleware", projectDir: projectA, rebuild: true },
+					{ query: "AuthMiddleware", searchDir: projectA, rebuild: true },
 					undefined,
 					undefined,
 					undefined as any,
@@ -667,7 +681,7 @@ describe("createSearchToolDefinition", () => {
 
 				const resultB = await isolationTool.execute(
 					"t-iso-b-after",
-					{ query: "PaymentProcessor", projectDir: projectB },
+					{ query: "PaymentProcessor", searchDir: projectB },
 					undefined,
 					undefined,
 					undefined as any,

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/README.md
+++ b/packages/semantic-search/README.md
@@ -47,8 +47,8 @@ The package exposes a `search` tool over the Model Context Protocol (stdio trans
 | Parameter    | Required | Description                                      |
 | ------------ | -------- | ------------------------------------------------ |
 | `query`      | yes      | Natural language, identifier, or path query       |
-| `projectDir` | yes      | Absolute path to the project directory to search  |
-| `path`       | no       | Restrict search to files under this path          |
+| `searchDir` | yes      | Directory to index and search — each unique value gets its own independent index |
+| `restrictToDir` | no       | Filter results to files under this path within the already-built index (does not affect indexing) |
 | `limit`      | no       | Maximum results to return (default: 20)           |
 | `rebuild`    | no       | Force a clean index rebuild (default: false)      |
 

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/semantic-search/skills/search/SKILL.md
+++ b/packages/semantic-search/skills/search/SKILL.md
@@ -24,8 +24,8 @@ The search tool supports three kinds of queries, automatically classified:
 | Parameter    | Required | Description                                                                 |
 | ------------ | -------- | --------------------------------------------------------------------------- |
 | `query`      | Yes      | Search query — natural language, identifier, or path                        |
-| `projectDir` | Yes      | Absolute path to the project directory. Set this to your current working directory |
-| `path`       | No       | Restrict search to files under this subdirectory (relative to project root) |
+| `searchDir` | Yes      | Directory to index and search — each unique value gets its own independent index |
+| `restrictToDir` | No       | Filter results to files under this subdirectory within the already-built index (does not affect which files are indexed) |
 | `limit`      | No       | Maximum number of results to return (default: 20)                           |
 | `rebuild`    | No       | Force a clean index rebuild — use when files have changed significantly     |
 
@@ -53,7 +53,7 @@ Each result includes:
 
 ## Tips
 
-- Start broad, then narrow with `path` if you get too many results from different areas
+- Start broad, then narrow with `restrictToDir` if you get too many results from different areas
 - Use `limit` to get more results when exploring a broad topic (e.g. `limit: 50`)
 - Use `rebuild: true` after major refactors, branch switches, or large file changes
 - Identifier queries work best for finding where something is defined or used

--- a/packages/semantic-search/src/mcp-server.ts
+++ b/packages/semantic-search/src/mcp-server.ts
@@ -4,7 +4,7 @@
  * Exposes the SearchEngine as a single "search" tool over the Model Context Protocol,
  * enabling any MCP-compatible client to run semantic codebase queries.
  *
- * The server defaults to using its CWD as the project directory. Claude Code
+ * The server defaults to using its CWD as the search directory. Claude Code
  * launches MCP servers with CWD set to the project root, so no configuration
  * is needed for typical per-project usage.
  */
@@ -32,15 +32,18 @@ const SEARCH_TOOL = {
 		type: "object" as const,
 		properties: {
 			query: { type: "string", description: "Search query (natural language, identifier, or path)" },
-			projectDir: {
+			searchDir: {
 				type: "string",
-				description: "Absolute path to the project directory to search. Use your current working directory.",
+				description: "Directory to index and search. This controls which directory gets indexed.",
 			},
-			path: { type: "string", description: "Restrict search to files under this path" },
+			restrictToDir: {
+				type: "string",
+				description: "Restrict results to files under this path (filters the already-built index).",
+			},
 			limit: { type: "number", description: "Maximum results to return (default: 20)" },
 			rebuild: { type: "boolean", description: "Force index rebuild (default: false)" },
 		},
-		required: ["query", "projectDir"],
+		required: ["query", "searchDir"],
 	},
 };
 
@@ -67,11 +70,11 @@ function getSearchEngine(projectRoot: string): SearchEngine {
 /**
  * Create an MCP server instance configured with the semantic search tool.
  *
- * @param defaultProjectDir - Default project directory for searches. Used when
- *   the client doesn't specify `projectDir` in the tool call. Typically the
+ * @param defaultSearchDir - Default directory to index and search. Used when
+ *   the client doesn't specify `searchDir` in the tool call. Typically the
  *   server's CWD, which Claude Code sets to the project root.
  */
-export function createMcpServer(defaultProjectDir: string): Server {
+export function createMcpServer(defaultSearchDir: string): Server {
 	const server = new Server(
 		{ name: "semantic-search", version: packageVersion },
 		{ capabilities: { tools: {}, logging: {} } },
@@ -91,15 +94,15 @@ export function createMcpServer(defaultProjectDir: string): Server {
 
 		const args = (request.params.arguments ?? {}) as {
 			query?: string;
-			projectDir?: string;
-			path?: string;
+			searchDir?: string;
+			restrictToDir?: string;
 			limit?: number;
 			rebuild?: boolean;
 		};
-		const { query, path: searchPath, rebuild = false } = args;
+		const { query, restrictToDir: pathFilter, rebuild = false } = args;
 		const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 20;
 
-		const projectDir = args.projectDir ? resolve(args.projectDir) : defaultProjectDir;
+		const searchDir = args.searchDir ? resolve(args.searchDir) : defaultSearchDir;
 
 		if (!SearchEngine.isAvailable()) {
 			return {
@@ -121,7 +124,7 @@ export function createMcpServer(defaultProjectDir: string): Server {
 		}
 
 		try {
-			const engine = getSearchEngine(projectDir);
+			const engine = getSearchEngine(searchDir);
 
 			if (rebuild) {
 				await engine.resetIndex();
@@ -130,7 +133,7 @@ export function createMcpServer(defaultProjectDir: string): Server {
 			// Send progress via logging messages
 			const results = await engine.search(query, {
 				limit,
-				pathFilter: searchPath,
+				pathFilter: pathFilter,
 				onProgress: (phase, current, total) => {
 					server
 						.sendLoggingMessage({
@@ -174,8 +177,8 @@ export function createMcpServer(defaultProjectDir: string): Server {
  * Create and start an MCP server over stdio.
  * This blocks until the transport is closed.
  */
-export async function startServer(projectDir: string): Promise<void> {
-	const server = createMcpServer(projectDir);
+export async function startServer(searchDir: string): Promise<void> {
+	const server = createMcpServer(searchDir);
 	const transport = new StdioServerTransport();
 	await server.connect(transport);
 }

--- a/packages/semantic-search/test/mcp-server.test.ts
+++ b/packages/semantic-search/test/mcp-server.test.ts
@@ -249,12 +249,12 @@ describe("MCP protocol integration", () => {
 
 		expect(tool.inputSchema.type).toBe("object");
 		expect(tool.inputSchema.properties).toHaveProperty("query");
-		expect(tool.inputSchema.properties).toHaveProperty("path");
+		expect(tool.inputSchema.properties).toHaveProperty("restrictToDir");
 		expect(tool.inputSchema.properties).toHaveProperty("limit");
 		expect(tool.inputSchema.properties).toHaveProperty("rebuild");
-		expect(tool.inputSchema.properties).toHaveProperty("projectDir");
+		expect(tool.inputSchema.properties).toHaveProperty("searchDir");
 		expect(tool.inputSchema.required).toContain("query");
-		expect(tool.inputSchema.required).toContain("projectDir");
+		expect(tool.inputSchema.required).toContain("searchDir");
 	});
 
 	it("calls search and returns formatted results", async () => {
@@ -268,7 +268,7 @@ describe("MCP protocol integration", () => {
 
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "server setup", projectDir: "/tmp/test-project" },
+			arguments: { query: "server setup", searchDir: "/tmp/test-project" },
 		});
 
 		expect(result.content).toHaveLength(1);
@@ -283,7 +283,7 @@ describe("MCP protocol integration", () => {
 
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "nonexistent", projectDir: "/tmp/test-project" },
+			arguments: { query: "nonexistent", searchDir: "/tmp/test-project" },
 		});
 
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;
@@ -295,7 +295,7 @@ describe("MCP protocol integration", () => {
 
 		await client.callTool({
 			name: "search",
-			arguments: { query: "handler", projectDir: "/tmp/test-project", path: "src/api" },
+			arguments: { query: "handler", searchDir: "/tmp/test-project", restrictToDir: "src/api" },
 		});
 
 		expect(mockSearch).toHaveBeenCalledWith("handler", expect.objectContaining({ pathFilter: "src/api" }));
@@ -306,7 +306,7 @@ describe("MCP protocol integration", () => {
 
 		await client.callTool({
 			name: "search",
-			arguments: { query: "handler", projectDir: "/tmp/test-project", limit: 5 },
+			arguments: { query: "handler", searchDir: "/tmp/test-project", limit: 5 },
 		});
 
 		expect(mockSearch).toHaveBeenCalledWith("handler", expect.objectContaining({ limit: 5 }));
@@ -317,7 +317,7 @@ describe("MCP protocol integration", () => {
 
 		await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/test-project", rebuild: true },
+			arguments: { query: "test", searchDir: "/tmp/test-project", rebuild: true },
 		});
 
 		expect(mockResetIndex).toHaveBeenCalled();
@@ -328,19 +328,19 @@ describe("MCP protocol integration", () => {
 
 		await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/test-project", rebuild: false },
+			arguments: { query: "test", searchDir: "/tmp/test-project", rebuild: false },
 		});
 
 		expect(mockResetIndex).not.toHaveBeenCalled();
 	});
 
-	it("accepts projectDir as a per-call override", async () => {
+	it("accepts searchDir as a per-call override", async () => {
 		mockSearch.mockResolvedValue([]);
 
-		// Should not throw — projectDir is accepted as a valid parameter
+		// Should not throw — searchDir is accepted as a valid parameter
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/other-project" },
+			arguments: { query: "test", searchDir: "/tmp/other-project" },
 		});
 
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;
@@ -351,7 +351,7 @@ describe("MCP protocol integration", () => {
 	it("returns isError for empty query", async () => {
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "", projectDir: "/tmp/test-project" },
+			arguments: { query: "", searchDir: "/tmp/test-project" },
 		});
 		expect(result.isError).toBe(true);
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;
@@ -361,7 +361,7 @@ describe("MCP protocol integration", () => {
 	it("returns isError for whitespace-only query", async () => {
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "   ", projectDir: "/tmp/test-project" },
+			arguments: { query: "   ", searchDir: "/tmp/test-project" },
 		});
 		expect(result.isError).toBe(true);
 	});
@@ -372,7 +372,7 @@ describe("MCP protocol integration", () => {
 
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/test-project" },
+			arguments: { query: "test", searchDir: "/tmp/test-project" },
 		});
 		expect(result.isError).toBe(true);
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;
@@ -387,7 +387,7 @@ describe("MCP protocol integration", () => {
 
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/test-project" },
+			arguments: { query: "test", searchDir: "/tmp/test-project" },
 		});
 
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;
@@ -400,7 +400,7 @@ describe("MCP protocol integration", () => {
 
 		const result = await client.callTool({
 			name: "search",
-			arguments: { query: "test", projectDir: "/tmp/test-project" },
+			arguments: { query: "test", searchDir: "/tmp/test-project" },
 		});
 		expect(result.isError).toBe(true);
 		const text = (result.content as Array<{ type: string; text: string }>)[0].text;

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #165

Renames search tool directory-related parameters to reduce confusion between the directory that gets indexed/searched and the directory that merely filters results.

Implementation plan posted as a comment below.