### PR TITLE
Fix subagent agent-type metadata propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.6.2",
+			"version": "2.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Claude Opus 4.7 support: `supportsXhigh()` recognizes `opus-4-7` model IDs, and the Anthropic and Amazon Bedrock providers detect Opus 4.7 for adaptive thinking and `xhigh` → `max` effort mapping. ([#167](https://github.com/aebrer/dreb/issues/167))
+
 - Added `onWarning` callback to `StreamOptions` for non-fatal warnings during streaming (e.g., malformed JSON chunks, SSE parse errors). All providers now forward `onWarning` to `parseStreamingJson` so callers can handle parse failures instead of silently swallowing them. ([#115](https://github.com/aebrer/dreb/issues/115))
 - Added `onWarning` callback parameter to `parseStreamingJson()` — called when both `JSON.parse` and `partial-json` fail on input
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -443,7 +443,7 @@ if (model.reasoning) {
 const response = await completeSimple(model, {
   messages: [{ role: 'user', content: 'Solve: 2x + 5 = 13' }]
 }, {
-  reasoning: 'medium'  // 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' (xhigh maps to high on non-OpenAI providers)
+  reasoning: 'medium'  // 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' (xhigh maps to 'max' on Opus 4.6+, 'high' on other Anthropic models)
 });
 
 // Access thinking and text blocks

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -148,14 +148,19 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  *
  * Supported today:
  * - GPT-5.2 / GPT-5.3 / GPT-5.4 model families
- * - Opus 4.6 models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
+ * - Opus 4.6+ models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	if (model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3") || model.id.includes("gpt-5.4")) {
 		return true;
 	}
 
-	if (model.id.includes("opus-4-6") || model.id.includes("opus-4.6")) {
+	if (
+		model.id.includes("opus-4-6") ||
+		model.id.includes("opus-4.6") ||
+		model.id.includes("opus-4-7") ||
+		model.id.includes("opus-4.7")
+	) {
 		return true;
 	}
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -391,12 +391,14 @@ function handleContentBlockStop(
 }
 
 /**
- * Check if the model supports adaptive thinking (Opus 4.6 and Sonnet 4.6).
+ * Check if the model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+).
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
 	return (
 		modelId.includes("opus-4-6") ||
 		modelId.includes("opus-4.6") ||
+		modelId.includes("opus-4-7") ||
+		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
 		modelId.includes("sonnet-4.6")
 	);
@@ -414,8 +416,14 @@ function mapThinkingLevelToEffort(
 			return "medium";
 		case "high":
 			return "high";
-		case "xhigh":
-			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+		case "xhigh": {
+			const isOpus =
+				modelId.includes("opus-4-6") ||
+				modelId.includes("opus-4.6") ||
+				modelId.includes("opus-4-7") ||
+				modelId.includes("opus-4.7");
+			return isOpus ? "max" : "high";
+		}
 		default:
 			return "high";
 	}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -441,13 +441,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6 and Sonnet 4.6)
+ * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	// Opus 4.6 and Sonnet 4.6 model IDs (with or without date suffix)
 	return (
 		modelId.includes("opus-4-6") ||
 		modelId.includes("opus-4.6") ||
+		modelId.includes("opus-4-7") ||
+		modelId.includes("opus-4.7") ||
 		modelId.includes("sonnet-4-6") ||
 		modelId.includes("sonnet-4.6")
 	);
@@ -455,7 +456,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 
 /**
  * Map ThinkingLevel to Anthropic effort levels for adaptive thinking.
- * Note: effort "max" is only valid on Opus 4.6.
+ * Note: effort "max" is only valid on Opus 4.6+.
  */
 function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], modelId: string): AnthropicEffort {
 	switch (level) {
@@ -467,8 +468,14 @@ function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], model
 			return "medium";
 		case "high":
 			return "high";
-		case "xhigh":
-			return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+		case "xhigh": {
+			const isOpus =
+				modelId.includes("opus-4-6") ||
+				modelId.includes("opus-4.6") ||
+				modelId.includes("opus-4-7") ||
+				modelId.includes("opus-4.7");
+			return isOpus ? "max" : "high";
+		}
 		default:
 			return "high";
 	}
@@ -489,7 +496,7 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
 		return streamAnthropic(model, context, { ...base, thinkingEnabled: false } satisfies AnthropicOptions);
 	}
 
-	// For Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort level
+	// For Opus 4.6+, Sonnet 4.6+: use adaptive thinking with effort level
 	// For older models: use budget-based thinking
 	if (supportsAdaptiveThinking(model.id)) {
 		const effort = mapThinkingLevelToEffort(options.reasoning, model.id);
@@ -541,8 +548,8 @@ function createClient(
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
 ): { client: Anthropic; isOAuthToken: boolean } {
-	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
-	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
+	// Adaptive thinking models (Opus 4.6+, Sonnet 4.6+) have interleaved thinking built-in.
+	// The beta header is deprecated on these models, so skip it.
 	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id);
 	const firstParty = isFirstPartyAnthropic(model.baseUrl);
 

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from "vitest";
 import { findModel, getModel, supportsXhigh } from "../src/models.js";
 
 describe("supportsXhigh", () => {
-	it("returns true for Anthropic Opus 4.6 on anthropic-messages API", () => {
+	it("returns true for latest Anthropic Opus on anthropic-messages API", () => {
 		const model = findModel("anthropic", "opus")!;
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
+
+	it("returns true for Opus 4.6 by exact ID", () => {
+		const model = getModel("anthropic", "claude-opus-4-6");
 		expect(model).toBeDefined();
 		expect(supportsXhigh(model!)).toBe(true);
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Subagent parallel/chain tasks now inherit the top-level `agent` and `model` parameters when not overridden per-item. Precedence: per-task > top-level > default (`"Explore"`). ([#167](https://github.com/aebrer/dreb/issues/167))
+- Subagent child session JSONL headers now include an `agentType` field recording which agent definition executed the session, providing an audit trail for post-hoc debugging. ([#167](https://github.com/aebrer/dreb/issues/167))
+- `formatSubagentCall` for parallel and chain modes now displays agent type(s) in the tool call header (e.g. `parallel (3 feature-dev tasks)`, `chain (feature-dev, 2 steps)`). ([#167](https://github.com/aebrer/dreb/issues/167))
+
 - Added `warnInSession()` on `AgentSession` — surfaces warnings in the conversation so both the human and AI agent can see and act on them. Supports `{ informational: true }` for non-interrupting context notes vs. actionable warnings that prompt the agent to inform the user. ([#115](https://github.com/aebrer/dreb/issues/115))
 - Added `warnResourceDiagnostics()` on `AgentSession` — collects all resource loading diagnostics (skills, prompts, themes, context files, extensions) and surfaces them via `warnInSession()`. Called automatically on startup and `/reload`.
 - Added `getContextDiagnostics()` to `ResourceLoader` interface — returns `ResourceDiagnostic[]` for context file loading failures (AGENTS.md, memory indexes, etc.)

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -27,6 +27,7 @@ What you get in exchange: a skill system, an extension API, custom agent definit
 - [Context Files](#context-files)
 - [Memory](#memory)
 - [Task Tracking](#task-tracking)
+- [Subagents](#subagents)
 - [Semantic Search](#semantic-search)
 - [Customization](#customization)
   - [Prompt Templates](#prompt-templates)
@@ -326,6 +327,23 @@ The `tasks_update` tool lets the model maintain a visible task list during multi
 The tool uses a full-replacement model — the model sends the complete task list on each call, no incremental updates. The TUI panel is visible by default and renders when active tasks exist. It auto-hides when the task list is empty or all tasks are completed. Toggle visibility with the `app.tasks.toggle` keybinding (unbound by default, configurable in [keybindings](docs/keybindings.md)). The panel displays up to 10 tasks at a time; overflow shows as "... and N more".
 
 Task tracking is prompt-driven: the system prompt includes guidelines for when to use it (3+ step work), concise titles, and a maximum of 20 tasks.
+
+---
+
+## Subagents
+
+The `subagent` tool delegates tasks to independent child agent processes. Each subagent runs in its own process with its own context window, and notifies the parent when complete.
+
+**Modes:**
+- **Single** (`task`): One background agent
+- **Parallel** (`tasks`): Up to 8 concurrent agents (max 4 at a time)
+- **Chain** (`chain`): Sequential pipeline where each step can reference the previous step's output via `{previous}`
+
+**Agent type inheritance:** The top-level `agent` parameter is inherited by parallel tasks and chain steps that don't specify their own. Precedence: per-task `agent` > top-level `agent` > default (`"Explore"`). The `model` parameter follows the same inheritance.
+
+**Agent definitions** live in `~/.dreb/agents/` (global) and `.dreb/agents/` (project). Each is a markdown file with YAML frontmatter specifying `name`, `model` (with provider fallback list), and optional `systemPrompt`. Built-in agents include `Explore` (read-only codebase exploration), `Sandbox` (restricted to `/tmp`), `feature-dev` (strong-tier coding), and several review agents.
+
+**Session metadata:** Each child process records its agent type in the session JSONL header (`agentType` field), providing an audit trail of which agent definition executed the work.
 
 ---
 

--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -64,10 +64,11 @@ Extended messages from [`packages/coding-agent/src/core/messages.ts`](https://gi
 
 ## Output Format
 
-Each line is a JSON object. The first line is the session header (`version` is the session schema version; increments indicate breaking format changes):
+Each line is a JSON object. The first line is the session header (`version` is the session schema version; increments indicate breaking format changes). Subagent child sessions also include `agentType`:
 
 ```json
 {"type":"session","version":3,"id":"uuid","timestamp":"...","cwd":"/path"}
+{"type":"session","version":3,"id":"uuid","timestamp":"...","cwd":"/path","agentType":"feature-dev"}
 ```
 
 Followed by events as they occur:

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -285,7 +285,7 @@ Set the reasoning/thinking level for models that support it.
 
 Levels: `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`
 
-Note: `"xhigh"` is only supported by OpenAI codex-max models.
+Note: `"xhigh"` is supported by OpenAI codex-max models and Anthropic Opus 4.6+ (maps to adaptive effort `"max"`).
 
 Response:
 ```json

--- a/packages/coding-agent/docs/session.md
+++ b/packages/coding-agent/docs/session.md
@@ -197,6 +197,12 @@ For sessions with a parent (created via `/fork` or `newSession({ parentSession }
 {"type":"session","version":3,"id":"uuid","timestamp":"2024-12-03T14:00:00.000Z","cwd":"/path/to/project","parentSession":"/path/to/original/session.jsonl"}
 ```
 
+For subagent child sessions (set via `--agent-type`):
+
+```json
+{"type":"session","version":3,"id":"uuid","timestamp":"2024-12-03T14:00:00.000Z","cwd":"/path/to/project","agentType":"feature-dev"}
+```
+
 ### SessionMessageEntry
 
 A message in the conversation. The `message` field contains an `AgentMessage`.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -39,6 +39,7 @@ export interface Args {
 	noPromptTemplates?: boolean;
 	themes?: string[];
 	noThemes?: boolean;
+	agentType?: string;
 	listModels?: string | true;
 	offline?: boolean;
 	verbose?: boolean;
@@ -149,6 +150,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.noPromptTemplates = true;
 		} else if (arg === "--no-themes") {
 			result.noThemes = true;
+		} else if (arg === "--agent-type" && i + 1 < args.length) {
+			result.agentType = args[++i];
 		} else if (arg === "--list-models") {
 			// Check if next arg is a search pattern (not a flag or file arg)
 			if (i + 1 < args.length && !args[i + 1].startsWith("-") && !args[i + 1].startsWith("@")) {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -33,6 +33,8 @@ export interface SessionHeader {
 	timestamp: string;
 	cwd: string;
 	parentSession?: string;
+	/** Agent type that executed this session (set for subagent child processes via --agent-type) */
+	agentType?: string;
 }
 
 export interface NewSessionOptions {
@@ -744,6 +746,18 @@ export class SessionManager {
 			this.sessionFile = join(this.getSessionDir(), `${fileTimestamp}_${this.sessionId}.jsonl`);
 		}
 		return this.sessionFile;
+	}
+
+	/**
+	 * Set agent type metadata on the current session header.
+	 * Must be called before the first flush (i.e., before the first assistant message).
+	 * Used by subagent child processes to record which agent definition executed the session.
+	 */
+	setAgentType(agentType: string): void {
+		const header = this.fileEntries[0] as SessionHeader | undefined;
+		if (header?.type === "session") {
+			header.agentType = agentType;
+		}
 	}
 
 	private _buildIndex(): void {

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -826,7 +826,8 @@ function formatSubagentCall(
 		return `${theme.fg("toolTitle", theme.bold("subagent"))} ${theme.fg("accent", `parallel (${typeLabel})`)}`;
 	}
 	if (args?.chain) {
-		return `${theme.fg("toolTitle", theme.bold("subagent"))} ${theme.fg("accent", `chain (${args.chain.length} steps)`)}`;
+		const agentName = str(args.agent) || args.chain[0]?.agent || DEFAULT_AGENT;
+		return `${theme.fg("toolTitle", theme.bold("subagent"))} ${theme.fg("accent", `chain (${agentName}, ${args.chain.length} steps)`)}`;
 	}
 
 	const agent = str(args?.agent) || DEFAULT_AGENT;

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -208,6 +208,8 @@ async function spawnSubagent(
 	if (agentConfig.systemPrompt) {
 		args.push("--append-system-prompt", agentConfig.systemPrompt);
 	}
+	// Pass agent type metadata so the child session can record it in its JSONL header
+	args.push("--agent-type", agentConfig.name);
 	args.push("-p", task);
 
 	// Early abort check — if the signal is already aborted (e.g. queued task whose
@@ -616,6 +618,8 @@ async function executeChain(
 	parentProvider?: string,
 	registry?: ModelRegistry,
 	sessionBaseDir?: string,
+	defaultAgent?: string,
+	defaultModel?: string,
 ): Promise<SubagentResult[]> {
 	const results: SubagentResult[] = [];
 	let previousOutput = "";
@@ -629,7 +633,7 @@ async function executeChain(
 		// Validate task length after {previous} substitution (can compound across steps)
 		if (task.length > MAX_TASK_LENGTH) {
 			results.push({
-				agent: step.agent || DEFAULT_AGENT,
+				agent: step.agent || defaultAgent || DEFAULT_AGENT,
 				task: `${task.slice(0, 200)}...`,
 				exitCode: 1,
 				output: "",
@@ -642,7 +646,7 @@ async function executeChain(
 		const cwdResult = clampCwd(defaultCwd, step.cwd);
 		if (!cwdResult.ok) {
 			results.push({
-				agent: step.agent || DEFAULT_AGENT,
+				agent: step.agent || defaultAgent || DEFAULT_AGENT,
 				task,
 				exitCode: 1,
 				output: "",
@@ -656,12 +660,12 @@ async function executeChain(
 		const stepSessionDir = sessionBaseDir ? join(sessionBaseDir, `step-${i + 1}`) : undefined;
 		const result = await executeSingle(
 			agents,
-			step.agent,
+			step.agent || defaultAgent,
 			task,
 			cwdResult.cwd,
 			signal,
 			onProgress,
-			step.model,
+			step.model || defaultModel,
 			parentProvider,
 			registry,
 			stepSessionDir,
@@ -805,11 +809,21 @@ function formatSubagentCall(
 	const invalidArg = invalidArgText(theme);
 
 	if (args?.tasks) {
-		return (
-			theme.fg("toolTitle", theme.bold("subagent")) +
-			" " +
-			theme.fg("accent", `parallel (${args.tasks.length} tasks)`)
-		);
+		// Show agent type(s) in the parallel label
+		const agentCounts = new Map<string, number>();
+		for (const t of args.tasks) {
+			const name = t.agent || args.agent || DEFAULT_AGENT;
+			agentCounts.set(name, (agentCounts.get(name) || 0) + 1);
+		}
+		let typeLabel: string;
+		if (agentCounts.size === 1) {
+			const [name] = [...agentCounts.keys()];
+			typeLabel = `${args.tasks.length} ${name} tasks`;
+		} else {
+			const parts = [...agentCounts.entries()].map(([name, count]) => `${count} ${name}`);
+			typeLabel = `${args.tasks.length} tasks: ${parts.join(", ")}`;
+		}
+		return `${theme.fg("toolTitle", theme.bold("subagent"))} ${theme.fg("accent", `parallel (${typeLabel})`)}`;
 	}
 	if (args?.chain) {
 		return `${theme.fg("toolTitle", theme.bold("subagent"))} ${theme.fg("accent", `chain (${args.chain.length} steps)`)}`;
@@ -1104,11 +1118,11 @@ export function createSubagentToolDefinition(
 					};
 				} else if (params.tasks) {
 					// Parallel background tasks — each gets its own agent ID and notifies independently
-					const launched: Array<{ id: string; taskText: string }> = [];
+					const launched: Array<{ id: string; agentName: string; taskText: string }> = [];
 					const skipped: Array<{ taskText: string; error: string }> = [];
 					for (let i = 0; i < params.tasks.length; i++) {
 						const item = params.tasks[i];
-						const agentName = item.agent || DEFAULT_AGENT;
+						const agentName = item.agent || params.agent || DEFAULT_AGENT;
 						const cwdResult = clampCwd(cwd, item.cwd);
 						if (!cwdResult.ok) {
 							skipped.push({ taskText: item.task, error: cwdResult.error });
@@ -1119,11 +1133,13 @@ export function createSubagentToolDefinition(
 							item.task,
 							`${agentName} task ${i + 1}/${params.tasks.length}`,
 							cwdResult.cwd,
-							item.model,
+							item.model || params.model,
 						);
-						launched.push({ id: agentId, taskText: item.task });
+						launched.push({ id: agentId, agentName, taskText: item.task });
 					}
-					const listing = launched.map(({ id, taskText }) => `  ${id}: ${taskText.slice(0, 80)}`).join("\n");
+					const listing = launched
+						.map(({ id, agentName, taskText }) => `  ${id} (${agentName}): ${taskText.slice(0, 80)}`)
+						.join("\n");
 					const skippedListing = skipped
 						.map(({ taskText, error }) => `  SKIPPED: ${taskText.slice(0, 60)} — ${error}`)
 						.join("\n");
@@ -1148,7 +1164,7 @@ export function createSubagentToolDefinition(
 					};
 				} else {
 					// Chain mode — sequential, stays as one agent since steps depend on each other
-					const agentName = params.chain![0].agent || DEFAULT_AGENT;
+					const agentName = params.agent || params.chain![0].agent || DEFAULT_AGENT;
 					const taskSummary = `${params.chain!.length}-step chain`;
 					const chainSteps = params.chain!;
 
@@ -1163,6 +1179,8 @@ export function createSubagentToolDefinition(
 							getParentProvider(),
 							modelRegistry,
 							chainSessionDir,
+							params.agent,
+							params.model,
 						);
 						const resultText = results
 							.map((r, i) => `### Step ${i + 1}\n${formatSingleResult(r)}`)
@@ -1170,7 +1188,7 @@ export function createSubagentToolDefinition(
 						const failed = results.filter((r) => r.exitCode !== 0);
 						// Per-step session logs are already embedded in resultText via formatSingleResult
 						return {
-							agent: "chain",
+							agent: agentName,
 							task: taskSummary,
 							exitCode: failed.length > 0 ? 1 : 0,
 							output: resultText,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -796,6 +796,11 @@ export async function main(args: string[]) {
 	let sessionManager = await createSessionManager(parsed, cwd, extensionsResult, settingsManager);
 	time("createSessionManager");
 
+	// Set agent type metadata for subagent child processes (must happen before first flush)
+	if (parsed.agentType && sessionManager) {
+		sessionManager.setAgentType(parsed.agentType);
+	}
+
 	// Handle --resume: show session picker
 	if (parsed.resume) {
 		// Compute effective session dir for resume (same logic as createSessionManager)

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -130,6 +130,16 @@ describe("parseArgs", () => {
 			const result = parseArgs(["--models", "gpt-4o,claude-sonnet,gemini-pro"]);
 			expect(result.models).toEqual(["gpt-4o", "claude-sonnet", "gemini-pro"]);
 		});
+
+		test("parses --agent-type", () => {
+			const result = parseArgs(["--agent-type", "feature-dev"]);
+			expect(result.agentType).toBe("feature-dev");
+		});
+
+		test("--agent-type with no following value does not set agentType", () => {
+			const result = parseArgs(["--agent-type"]);
+			expect(result.agentType).toBeUndefined();
+		});
 	});
 
 	describe("--no-session flag", () => {

--- a/packages/coding-agent/test/subagent-agent-type.test.ts
+++ b/packages/coding-agent/test/subagent-agent-type.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "../src/core/extensions/types.js";
+import { createSubagentToolDefinition, type SubagentResult } from "../src/core/tools/subagent.js";
+
+/**
+ * Tests for agent type propagation — verifies that the top-level `agent` and `model`
+ * parameters are inherited by parallel tasks and chain steps when not overridden per-item.
+ */
+
+const cwd = process.cwd();
+
+function createTool(onComplete?: (agentId: string, result: SubagentResult, cancelled: boolean) => void) {
+	const onBackgroundStart = vi.fn();
+	const onBackgroundComplete = onComplete ?? vi.fn();
+	const tool = createSubagentToolDefinition(cwd, {
+		onBackgroundStart,
+		onBackgroundComplete,
+	});
+	return { tool, onBackgroundStart, onBackgroundComplete };
+}
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find((c) => c.type === "text")?.text ?? "";
+}
+
+// ---------------------------------------------------------------------------
+// Parallel mode — agent inheritance
+// ---------------------------------------------------------------------------
+
+describe("parallel tasks — agent type inheritance", () => {
+	it("inherits top-level agent when task items have no agent field", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		const result = await tool.execute(
+			"call-1",
+			{
+				agent: "feature-dev",
+				tasks: [{ task: "task one" }, { task: "task two" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		const text = getText(result);
+		// Both tasks should be launched as feature-dev
+		expect(text).toContain("2 background agents started");
+		// Each task in the listing should show (feature-dev)
+		expect(text).toContain("(feature-dev):");
+
+		// onBackgroundStart should be called with feature-dev for both
+		expect(onBackgroundStart).toHaveBeenCalledTimes(2);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("feature-dev");
+		expect(onBackgroundStart.mock.calls[1][1]).toBe("feature-dev");
+	});
+
+	it("per-task agent overrides top-level agent", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		await tool.execute(
+			"call-2",
+			{
+				agent: "feature-dev",
+				tasks: [
+					{ task: "task one", agent: "Sandbox" },
+					{ task: "task two" }, // should inherit feature-dev
+				],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		expect(onBackgroundStart).toHaveBeenCalledTimes(2);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("Sandbox");
+		expect(onBackgroundStart.mock.calls[1][1]).toBe("feature-dev");
+	});
+
+	it("defaults to Explore when neither top-level nor per-task agent is set", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		await tool.execute(
+			"call-3",
+			{
+				tasks: [{ task: "task one" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		expect(onBackgroundStart).toHaveBeenCalledTimes(1);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("Explore");
+	});
+
+	it("launch listing includes agent type per task", async () => {
+		const { tool } = createTool();
+		const result = await tool.execute(
+			"call-4",
+			{
+				agent: "feature-dev",
+				tasks: [{ task: "do something" }, { task: "do another thing", agent: "Explore" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		const text = getText(result);
+		// Should have (feature-dev) and (Explore) in the listing
+		expect(text).toContain("(feature-dev):");
+		expect(text).toContain("(Explore):");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Parallel mode — model inheritance
+// ---------------------------------------------------------------------------
+
+describe("parallel tasks — model inheritance", () => {
+	it("inherits top-level model when task items have no model field", async () => {
+		// We can't easily inspect what model was passed to the child process
+		// without spawning, but we can verify the tool doesn't error out
+		// and that the launch listing is correct. The model override flows through
+		// launchBackgroundTask → executeSingle → resolveModelWithFallbacks.
+		// For unit testing, we just verify the tool accepts the configuration.
+		const { tool } = createTool();
+		const result = await tool.execute(
+			"call-5",
+			{
+				model: "some-model",
+				tasks: [{ task: "task one" }, { task: "task two" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		const text = getText(result);
+		// Tasks should launch (model resolution may fail but that's a different concern)
+		expect(text).toContain("background agents started");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Chain mode — agent inheritance
+// ---------------------------------------------------------------------------
+
+describe("chain mode — agent type inheritance", () => {
+	it("inherits top-level agent for chain wrapper and steps", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		const result = await tool.execute(
+			"call-6",
+			{
+				agent: "feature-dev",
+				chain: [{ task: "step one" }, { task: "step two {previous}" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		const text = getText(result);
+		expect(text).toContain("Background chain");
+		expect(text).toContain("2-step chain");
+
+		// onBackgroundStart should be called with feature-dev (the chain wrapper agent)
+		expect(onBackgroundStart).toHaveBeenCalledTimes(1);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("feature-dev");
+	});
+
+	it("uses first step agent when no top-level agent is set", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		await tool.execute(
+			"call-7",
+			{
+				chain: [{ task: "step one", agent: "Sandbox" }, { task: "step two {previous}" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		// Chain wrapper should use first step's agent
+		expect(onBackgroundStart).toHaveBeenCalledTimes(1);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("Sandbox");
+	});
+
+	it("defaults to Explore when no agent specified anywhere", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		await tool.execute(
+			"call-8",
+			{
+				chain: [{ task: "step one" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		expect(onBackgroundStart).toHaveBeenCalledTimes(1);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("Explore");
+	});
+
+	it("top-level agent takes precedence over first step agent for wrapper", async () => {
+		const { tool, onBackgroundStart } = createTool();
+		await tool.execute(
+			"call-9",
+			{
+				agent: "feature-dev",
+				chain: [{ task: "step one", agent: "Sandbox" }, { task: "step two {previous}" }],
+			},
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		// Chain wrapper should use top-level agent, not first step's agent
+		expect(onBackgroundStart).toHaveBeenCalledTimes(1);
+		expect(onBackgroundStart.mock.calls[0][1]).toBe("feature-dev");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatSubagentCall — tested indirectly via renderCall
+// ---------------------------------------------------------------------------
+
+describe("formatSubagentCall — parallel agent types", () => {
+	// formatSubagentCall is not exported, so we test via renderCall which delegates to it.
+	// The Text component stores text privately, so we access it via (component as any).text.
+
+	it("shows single agent type for uniform parallel tasks", () => {
+		const { tool } = createTool();
+		const mockTheme = {
+			fg: (_style: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+		const mockContext = { lastComponent: undefined, argsComplete: true, showImages: false };
+		const component = tool.renderCall?.(
+			{ tasks: [{ task: "a" }, { task: "b" }, { task: "c" }], agent: "feature-dev" } as any,
+			mockTheme,
+			mockContext as any,
+		);
+		const rendered = (component as any)?.text ?? "";
+		expect(rendered).toContain("3 feature-dev tasks");
+	});
+
+	it("shows mixed agent types for heterogeneous parallel tasks", () => {
+		const { tool } = createTool();
+		const mockTheme = {
+			fg: (_style: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+		const mockContext = { lastComponent: undefined, argsComplete: true, showImages: false };
+		const component = tool.renderCall?.(
+			{
+				tasks: [{ task: "a", agent: "Sandbox" }, { task: "b" }, { task: "c" }],
+				agent: "feature-dev",
+			} as any,
+			mockTheme,
+			mockContext as any,
+		);
+		const rendered = (component as any)?.text ?? "";
+		expect(rendered).toContain("3 tasks:");
+		expect(rendered).toContain("1 Sandbox");
+		expect(rendered).toContain("2 feature-dev");
+	});
+});

--- a/packages/coding-agent/test/subagent-agent-type.test.ts
+++ b/packages/coding-agent/test/subagent-agent-type.test.ts
@@ -263,3 +263,60 @@ describe("formatSubagentCall — parallel agent types", () => {
 		expect(rendered).toContain("2 feature-dev");
 	});
 });
+
+describe("formatSubagentCall — chain agent type", () => {
+	it("shows agent type from top-level agent param", () => {
+		const { tool } = createTool();
+		const mockTheme = {
+			fg: (_style: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+		const mockContext = { lastComponent: undefined, argsComplete: true, showImages: false };
+		const component = tool.renderCall?.(
+			{ chain: [{ task: "step1" }, { task: "step2" }], agent: "feature-dev" } as any,
+			mockTheme,
+			mockContext as any,
+		);
+		const rendered = (component as any)?.text ?? "";
+		expect(rendered).toContain("chain");
+		expect(rendered).toContain("feature-dev");
+		expect(rendered).toContain("2 steps");
+	});
+
+	it("shows agent type from first chain step when no top-level agent", () => {
+		const { tool } = createTool();
+		const mockTheme = {
+			fg: (_style: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+		const mockContext = { lastComponent: undefined, argsComplete: true, showImages: false };
+		const component = tool.renderCall?.(
+			{ chain: [{ task: "step1", agent: "Sandbox" }, { task: "step2" }] } as any,
+			mockTheme,
+			mockContext as any,
+		);
+		const rendered = (component as any)?.text ?? "";
+		expect(rendered).toContain("chain");
+		expect(rendered).toContain("Sandbox");
+		expect(rendered).toContain("2 steps");
+	});
+
+	it("falls back to default agent when no agent specified", () => {
+		const { tool } = createTool();
+		const mockTheme = {
+			fg: (_style: string, text: string) => text,
+			bold: (text: string) => text,
+		} as any;
+		const mockContext = { lastComponent: undefined, argsComplete: true, showImages: false };
+		const component = tool.renderCall?.(
+			{ chain: [{ task: "step1" }, { task: "step2" }, { task: "step3" }] } as any,
+			mockTheme,
+			mockContext as any,
+		);
+		const rendered = (component as any)?.text ?? "";
+		expect(rendered).toContain("chain");
+		expect(rendered).toContain("3 steps");
+		// Should contain the default agent name (not be empty)
+		expect(rendered).toMatch(/chain \([^,]+, 3 steps\)/);
+	});
+});

--- a/packages/coding-agent/test/subagent-background-parallel.test.ts
+++ b/packages/coding-agent/test/subagent-background-parallel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ExtensionContext } from "../src/core/extensions/types.js";
-import { createSubagentToolDefinition } from "../src/core/tools/subagent.js";
+import { createSubagentToolDefinition, getBackgroundAgents } from "../src/core/tools/subagent.js";
 
 /**
  * Tests for background parallel mode — specifically the skipped-task path
@@ -98,5 +98,48 @@ describe("subagent background parallel — skipped tasks", () => {
 		expect(text).toContain("SKIPPED");
 		expect(text).toContain("resolves outside parent cwd");
 		expect(text).toContain("No agents were launched");
+	});
+
+	it("should register inherited agent type in background agent registry", async () => {
+		const tool = createTool();
+		const result = await tool.execute(
+			"call-4",
+			{
+				agent: "feature-dev",
+				tasks: [{ task: "valid task with inherited agent" }],
+			},
+			undefined,
+			undefined,
+			dummyCtx,
+		);
+
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(text).toContain("1 background agents started");
+
+		// Check that the background agent registry has the correct agent type
+		const agents = getBackgroundAgents();
+		const ourAgent = agents.find((a) => a.agentType === "feature-dev");
+		expect(ourAgent).toBeDefined();
+		expect(ourAgent!.agentType).toBe("feature-dev");
+	});
+
+	it("should show inherited agent type in launch listing", async () => {
+		const tool = createTool();
+		const result = await tool.execute(
+			"call-5",
+			{
+				agent: "feature-dev",
+				tasks: [{ task: "task one" }, { task: "task two" }],
+			},
+			undefined,
+			undefined,
+			dummyCtx,
+		);
+
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		// Each task line should include (feature-dev)
+		expect(text).toContain("(feature-dev):");
+		// Should NOT contain (Explore) since all tasks inherit feature-dev
+		expect(text).not.toContain("(Explore)");
 	});
 });

--- a/packages/coding-agent/test/subagent-session-persistence.test.ts
+++ b/packages/coding-agent/test/subagent-session-persistence.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-
+import { type SessionHeader, SessionManager } from "../src/core/session-manager.js";
 import { discoverSessionFile, type SubagentResult } from "../src/core/tools/subagent.js";
 
 // ---------------------------------------------------------------------------
@@ -104,5 +104,50 @@ describe("SubagentResult interface", () => {
 
 		expect(withoutSession.sessionFile).toBeUndefined();
 		expect(withSession.sessionFile).toBe("/tmp/test-session.jsonl");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SessionHeader agentType field tests
+// ---------------------------------------------------------------------------
+
+describe("SessionHeader agentType", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = createTempDir();
+	});
+
+	afterEach(() => {
+		if (existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("setAgentType includes agentType in session header", () => {
+		const sm = SessionManager.create("/tmp", tempDir);
+		sm.setAgentType("feature-dev");
+
+		expect(sm.getSessionId()).toBeTruthy();
+
+		// SessionManager stores the header as fileEntries[0]
+		const header = (sm as any).fileEntries[0] as SessionHeader;
+		expect(header.type).toBe("session");
+		expect(header.agentType).toBe("feature-dev");
+	});
+
+	test("session header omits agentType when setAgentType is not called", () => {
+		const sm = SessionManager.create("/tmp", tempDir);
+		const header = (sm as any).fileEntries[0] as SessionHeader;
+		expect(header.type).toBe("session");
+		expect(header.agentType).toBeUndefined();
+	});
+
+	test("setAgentType is safe to call on empty session manager", () => {
+		const sm = SessionManager.inMemory();
+		// Should not throw even though inMemory creates a session
+		sm.setAgentType("test-agent");
+		const header = (sm as any).fileEntries[0] as SessionHeader;
+		expect(header.agentType).toBe("test-agent");
 	});
 });

--- a/packages/coding-agent/test/subagent-session-persistence.test.ts
+++ b/packages/coding-agent/test/subagent-session-persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -149,5 +149,41 @@ describe("SessionHeader agentType", () => {
 		sm.setAgentType("test-agent");
 		const header = (sm as any).fileEntries[0] as SessionHeader;
 		expect(header.agentType).toBe("test-agent");
+	});
+
+	test("setAgentType persists agentType to disk in session header", () => {
+		const sm = SessionManager.create("/tmp", tempDir);
+		sm.setAgentType("feature-dev");
+
+		// Add a user message then an assistant message to trigger flush to disk
+		sm.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+		sm.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hi" }],
+			api: "anthropic-messages",
+			model: "test-model",
+			provider: "test",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 15,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+
+		// Read back the JSONL file from disk
+		const sessionFile = sm.getSessionFile();
+		expect(sessionFile).toBeDefined();
+		expect(existsSync(sessionFile!)).toBe(true);
+
+		const content = readFileSync(sessionFile!, "utf8");
+		const firstLine = content.trim().split("\n")[0];
+		const diskHeader = JSON.parse(firstLine) as SessionHeader;
+		expect(diskHeader.type).toBe("session");
+		expect(diskHeader.agentType).toBe("feature-dev");
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.6.2",
+	"version": "2.6.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #167

Subagent result metadata does not reliably record the resolved agent type. Top-level `agent` parameter is ignored for parallel/chain tasks, session files have no agent metadata, and user-visible messages show wrong agent types.

Implementation plan posted as a comment below.