### PR TITLE
Secret scrubbing: prevent credential leaks in tool output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Secret scrubbing and sensitive file access guards — two layers of defense against accidental credential leaks through the tool pipeline. Output scrubbing detects and redacts known secret patterns (AWS, GitHub, OpenAI, Anthropic, Slack, Stripe, PEM/SSH keys, URL credentials) in tool output before it enters the LLM conversation. Sensitive file guard blocks read access to credential files (`~/.ssh/id_*`, `~/.aws/credentials`, `~/.dreb/secrets/`, etc.) via both the `read` tool and bash commands. Both layers configurable via `sensitiveFilePaths` and `secretOutputPatterns` settings. ([#171](https://github.com/aebrer/dreb/issues/171))
+
 - Expanded forbidden-commands guard with destructive operation patterns: `rm -rf /` and variants, `dd` to block devices, `mkfs`, fork bomb `:(){ :|:& };:`, and block device redirects (`> /dev/sda`). Guard now also checks quoted content (catches `echo "rm -rf /" | bash`) and inspects script files before execution (`bash script.sh`). ([#170](https://github.com/aebrer/dreb/issues/170))
 
 - Subagent parallel/chain tasks now inherit the top-level `agent` and `model` parameters when not overridden per-item. Precedence: per-task > top-level > default (`"Explore"`). ([#167](https://github.com/aebrer/dreb/issues/167))

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -128,6 +128,36 @@ When a provider requests a retry delay longer than `maxDelayMs` (e.g., Google's 
 
 `npmCommand` is used for all npm package-manager operations, including `npm root -g`, installs, uninstalls, and `npm install` inside git packages. Use argv-style entries exactly as the process should be launched.
 
+### Security
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `sensitiveFilePaths` | string[] | `[]` | Additional glob patterns for sensitive file paths blocked by the read/bash guard (appended to built-in defaults) |
+| `secretOutputPatterns` | `{ name, pattern }[]` | `[]` | Additional regex patterns for secret scrubbing in tool output (appended to built-in defaults) |
+
+dreb includes two built-in layers of protection against accidental credential exposure through the tool pipeline:
+
+**Output scrubbing** — Tool output is scanned for known secret patterns before it enters the LLM conversation. Detected secrets are replaced with `<REDACTED:pattern_name>` markers. Built-in patterns cover AWS access keys, GitHub tokens (classic and fine-grained PATs), GitLab tokens, OpenAI keys, Anthropic keys, Slack tokens, Stripe keys, URL credentials, PEM private key blocks, and OpenSSH private key blocks. Add custom patterns via `secretOutputPatterns`:
+
+```json
+{
+  "secretOutputPatterns": [
+    { "name": "internal_api_key", "pattern": "INTERNAL_[A-Z0-9]{32,}" }
+  ]
+}
+```
+
+**Sensitive file access guard** — The `read` tool and common bash file-reading commands (`cat`, `head`, `tail`, `grep`, `sed`, `base64`, etc.) are blocked from accessing known credential files. Built-in protected paths: `~/.ssh/id_*` (not `.pub`), `~/.gnupg/private-keys-v1.d/*`, `~/.dreb/secrets/*`, `~/.dreb/agent/auth.json`, `~/.aws/credentials`, `~/.config/gcloud/credentials.db`. Add custom paths via `sensitiveFilePaths` — only trailing wildcards (`*`, `/**`) are supported:
+
+```json
+{
+  "sensitiveFilePaths": [
+    "~/.vault/token",
+    "~/.config/hub"
+  ]
+}
+```
+
 ### Sessions
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -435,10 +435,16 @@ export class AgentSession {
 			let scrubbedContent = result.content;
 			const extraSecretPatterns = this.settingsManager?.getSecretOutputPatterns();
 			const compiledExtras: SecretPattern[] | undefined = extraSecretPatterns?.flatMap((p) => {
+				if (!p.pattern || typeof p.pattern !== "string" || p.pattern.trim() === "") {
+					console.warn(`[secret-scrubber] Skipping empty or invalid pattern in secretOutputPatterns: "${p.name}"`);
+					return [];
+				}
 				try {
 					return [{ name: p.name, pattern: new RegExp(p.pattern, "g") }];
-				} catch {
-					// Invalid regex in settings — skip silently rather than crashing the session
+				} catch (err) {
+					console.warn(
+						`[secret-scrubber] Skipping invalid regex in secretOutputPatterns "${p.name}": ${p.pattern} — ${err instanceof Error ? err.message : String(err)}`,
+					);
 					return [];
 				}
 			});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -66,6 +66,8 @@ import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
+import { type SecretPattern, scrubSecrets } from "./secret-scrubber.js";
+import { isSensitivePath } from "./sensitive-paths.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
 import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
@@ -391,6 +393,21 @@ export class AgentSession {
 				}
 			}
 
+			// Check sensitive file paths — blocks read tool access to credential files
+			if (toolCall.name === "read") {
+				const filePath = (args as Record<string, unknown>)?.path;
+				if (typeof filePath === "string") {
+					const extraSensitivePaths = this.settingsManager?.getSensitiveFilePaths();
+					const sensitiveResult = isSensitivePath(filePath, extraSensitivePaths);
+					if (sensitiveResult.blocked) {
+						return {
+							block: true as const,
+							reason: `File blocked by sensitive-path guard: "${sensitiveResult.pattern}". This file contains credentials that should not be sent to the model.`,
+						};
+					}
+				}
+			}
+
 			const runner = this._extensionRunner;
 			if (!runner?.hasHandlers("tool_call")) {
 				return undefined;
@@ -414,9 +431,34 @@ export class AgentSession {
 		});
 
 		this.agent.setAfterToolCall(async ({ toolCall, args, result, isError }) => {
+			// Scrub secrets from tool output — runs before extensions, cannot be bypassed
+			let scrubbedContent = result.content;
+			const extraSecretPatterns = this.settingsManager?.getSecretOutputPatterns();
+			const compiledExtras: SecretPattern[] | undefined = extraSecretPatterns?.map((p) => ({
+				name: p.name,
+				pattern: new RegExp(p.pattern, "g"),
+			}));
+			let totalRedactions = 0;
+			scrubbedContent = scrubbedContent.map((item) => {
+				if (item.type === "text" && item.text) {
+					const { scrubbed, redactionCount } = scrubSecrets(item.text, compiledExtras);
+					totalRedactions += redactionCount;
+					if (redactionCount > 0) {
+						return { ...item, text: scrubbed };
+					}
+				}
+				return item;
+			});
+
+			// Build override result if secrets were scrubbed
+			let scrubOverride: { content?: typeof scrubbedContent; details?: unknown } | undefined;
+			if (totalRedactions > 0) {
+				scrubOverride = { content: scrubbedContent };
+			}
+
 			const runner = this._extensionRunner;
 			if (!runner?.hasHandlers("tool_result")) {
-				return undefined;
+				return scrubOverride;
 			}
 
 			const hookResult = await runner.emitToolResult({
@@ -424,17 +466,17 @@ export class AgentSession {
 				toolName: toolCall.name,
 				toolCallId: toolCall.id,
 				input: args as Record<string, unknown>,
-				content: result.content,
+				content: scrubbedContent,
 				details: isError ? undefined : result.details,
 				isError,
 			});
 
 			if (!hookResult || isError) {
-				return undefined;
+				return scrubOverride;
 			}
 
 			return {
-				content: hookResult.content,
+				content: hookResult.content ?? scrubOverride?.content,
 				details: hookResult.details,
 			};
 		});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -434,10 +434,14 @@ export class AgentSession {
 			// Scrub secrets from tool output — runs before extensions, cannot be bypassed
 			let scrubbedContent = result.content;
 			const extraSecretPatterns = this.settingsManager?.getSecretOutputPatterns();
-			const compiledExtras: SecretPattern[] | undefined = extraSecretPatterns?.map((p) => ({
-				name: p.name,
-				pattern: new RegExp(p.pattern, "g"),
-			}));
+			const compiledExtras: SecretPattern[] | undefined = extraSecretPatterns?.flatMap((p) => {
+				try {
+					return [{ name: p.name, pattern: new RegExp(p.pattern, "g") }];
+				} catch {
+					// Invalid regex in settings — skip silently rather than crashing the session
+					return [];
+				}
+			});
 			let totalRedactions = 0;
 			scrubbedContent = scrubbedContent.map((item) => {
 				if (item.type === "text" && item.text) {

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -30,6 +30,13 @@ const DEFAULT_FORBIDDEN_PATTERNS: string[] = [
 	"^dd\\s+.*of=/dev/(sd|hd|vd|nvme|xvd|loop|mmcblk|disk)", // dd writing to block devices
 	"^mkfs", // format filesystem (mkfs.ext4, mkfs.xfs, etc.)
 	"^>>?\\s*/dev/(sd|hd|vd|nvme|xvd|loop|mmcblk|disk)", // redirect to block device (> and >>)
+	// Sensitive file access — block reading credential files via bash
+	"^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)", // SSH private keys (not .pub)
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/", // dreb credential store
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json", // dreb auth storage
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials", // AWS credentials
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys", // GPG private keys
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db", // GCloud credentials
 ];
 
 /**
@@ -67,6 +74,13 @@ const QUOTED_CONTENT_PATTERNS: string[] = [
 	"^gh api.*bypass",
 	"^git\\s+commit.*--no-verify",
 	":\\(\\)\\s*\\{", // fork bomb
+	// Sensitive file access in quoted content
+	"^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)",
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/",
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json",
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials",
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys",
+	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db",
 ];
 
 /**

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -31,12 +31,13 @@ const DEFAULT_FORBIDDEN_PATTERNS: string[] = [
 	"^mkfs", // format filesystem (mkfs.ext4, mkfs.xfs, etc.)
 	"^>>?\\s*/dev/(sd|hd|vd|nvme|xvd|loop|mmcblk|disk)", // redirect to block device (> and >>)
 	// Sensitive file access — block reading credential files via bash
-	"^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)", // SSH private keys (not .pub)
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/", // dreb credential store
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json", // dreb auth storage
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials", // AWS credentials
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys", // GPG private keys
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db", // GCloud credentials
+	// Matches bare commands AND absolute-path invocations (/bin/cat, /usr/bin/cat, etc.)
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)", // SSH private keys (not .pub)
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/secrets/", // dreb credential store
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/agent/auth\\.json", // dreb auth storage
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.aws/credentials", // AWS credentials
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.gnupg/private-keys", // GPG private keys
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.config/gcloud/credentials\\.db", // GCloud credentials
 ];
 
 /**
@@ -75,12 +76,12 @@ const QUOTED_CONTENT_PATTERNS: string[] = [
 	"^git\\s+commit.*--no-verify",
 	":\\(\\)\\s*\\{", // fork bomb
 	// Sensitive file access in quoted content
-	"^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)",
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/",
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json",
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials",
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys",
-	"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/secrets/",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/agent/auth\\.json",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.aws/credentials",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.gnupg/private-keys",
+	"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.config/gcloud/credentials\\.db",
 ];
 
 /**

--- a/packages/coding-agent/src/core/secret-scrubber.ts
+++ b/packages/coding-agent/src/core/secret-scrubber.ts
@@ -1,0 +1,84 @@
+export interface SecretPattern {
+	name: string;
+	pattern: RegExp;
+}
+
+export interface ScrubResult {
+	scrubbed: string;
+	redactionCount: number;
+}
+
+// Multi-line patterns (processed first)
+const pemPrivateKey =
+	/-----BEGIN (?:RSA |EC |DSA |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |ENCRYPTED )?PRIVATE KEY-----/g;
+const opensshPrivateKey = /-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]*?-----END OPENSSH PRIVATE KEY-----/g;
+
+// Single-line patterns
+const awsAccessKey = /\bAKIA[0-9A-Z]{16}\b/g;
+const githubToken =
+	/ghp_[A-Za-z0-9_]{36,}|gho_[A-Za-z0-9_]{36,}|ghu_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9_]{36,}|ghr_[A-Za-z0-9_]{36,}/g;
+const gitlabToken = /glpat-[0-9a-zA-Z_-]{20,}/g;
+const anthropicKey = /sk-ant-[a-zA-Z0-9_-]{90,}/g;
+const openaiKey = /sk-(?!ant-)[a-zA-Z0-9_-]{20,}/g;
+const slackToken = /xox[baprs]-[0-9a-zA-Z-]{10,}/g;
+const stripeKey = /[sr]k_(?:test|live)_[0-9a-zA-Z]{24,}/g;
+const urlCredentials = /(https?:\/\/)([^\s:]+):([^\s@]+)@/g;
+
+const MULTILINE_PATTERNS: SecretPattern[] = [
+	{ name: "pem_private_key", pattern: pemPrivateKey },
+	{ name: "openssh_private_key", pattern: opensshPrivateKey },
+];
+
+const SINGLELINE_PATTERNS: SecretPattern[] = [
+	{ name: "aws_access_key", pattern: awsAccessKey },
+	{ name: "github_token", pattern: githubToken },
+	{ name: "gitlab_token", pattern: gitlabToken },
+	{ name: "anthropic_key", pattern: anthropicKey },
+	{ name: "openai_key", pattern: openaiKey },
+	{ name: "slack_token", pattern: slackToken },
+	{ name: "stripe_key", pattern: stripeKey },
+	{ name: "url_credentials", pattern: urlCredentials },
+];
+
+export const DEFAULT_SECRET_PATTERNS: SecretPattern[] = [...MULTILINE_PATTERNS, ...SINGLELINE_PATTERNS];
+
+export function scrubSecrets(text: string, extraPatterns?: SecretPattern[]): ScrubResult {
+	let scrubbed = text;
+	let redactionCount = 0;
+
+	function applyPattern(sp: SecretPattern): void {
+		// Reset lastIndex since we reuse compiled regexes
+		sp.pattern.lastIndex = 0;
+
+		if (sp.name === "url_credentials") {
+			scrubbed = scrubbed.replace(sp.pattern, (_match, protocol, user, _password) => {
+				redactionCount++;
+				return `${protocol}${user}:<REDACTED:url_credentials>@`;
+			});
+		} else {
+			scrubbed = scrubbed.replace(sp.pattern, () => {
+				redactionCount++;
+				return `<REDACTED:${sp.name}>`;
+			});
+		}
+	}
+
+	// Multi-line patterns first
+	for (const sp of MULTILINE_PATTERNS) {
+		applyPattern(sp);
+	}
+
+	// Single-line patterns
+	for (const sp of SINGLELINE_PATTERNS) {
+		applyPattern(sp);
+	}
+
+	// Extra patterns last
+	if (extraPatterns) {
+		for (const sp of extraPatterns) {
+			applyPattern(sp);
+		}
+	}
+
+	return { scrubbed, redactionCount };
+}

--- a/packages/coding-agent/src/core/secret-scrubber.ts
+++ b/packages/coding-agent/src/core/secret-scrubber.ts
@@ -16,7 +16,7 @@ const opensshPrivateKey = /-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]*?-----END O
 // Single-line patterns
 const awsAccessKey = /\bAKIA[0-9A-Z]{16}\b/g;
 const githubToken =
-	/ghp_[A-Za-z0-9_]{36,}|gho_[A-Za-z0-9_]{36,}|ghu_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9_]{36,}|ghr_[A-Za-z0-9_]{36,}/g;
+	/ghp_[A-Za-z0-9_]{36,}|gho_[A-Za-z0-9_]{36,}|ghu_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9_]{36,}|ghr_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}/g;
 const gitlabToken = /glpat-[0-9a-zA-Z_-]{20,}/g;
 const anthropicKey = /sk-ant-[a-zA-Z0-9_-]{90,}/g;
 const openaiKey = /sk-(?!ant-)[a-zA-Z0-9_-]{20,}/g;

--- a/packages/coding-agent/src/core/sensitive-paths.ts
+++ b/packages/coding-agent/src/core/sensitive-paths.ts
@@ -35,6 +35,16 @@ function resolvePath(filepath: string): string {
 }
 
 /**
+ * Check whether a pattern contains unsupported mid-path wildcards.
+ * Only trailing wildcards are supported. Mid-path wildcards silently fail.
+ */
+function hasMidPathWildcard(pattern: string): boolean {
+	// Strip trailing wildcard(s), then check if any wildcards remain
+	const withoutTrailing = pattern.replace(/\/?\*{1,2}$/, "");
+	return withoutTrailing.includes("*");
+}
+
+/**
  * Check whether a single pattern matches a resolved absolute path.
  * Returns true if the path matches the pattern.
  *
@@ -42,33 +52,27 @@ function resolvePath(filepath: string): string {
  *   - Ends with `/*` or `/**` → directory prefix match
  *   - Ends with `*` (but not `/*`) → prefix match on the literal prefix
  *   - Otherwise → exact match
+ *
+ * Mid-path wildcards are NOT supported and will not match anything.
+ * Use hasMidPathWildcard() to detect and warn about these before calling.
  */
-function matchesPattern(resolvedPath: string, pattern: string): { matches: boolean; allowlisted?: boolean } {
+function matchesPattern(resolvedPath: string, pattern: string): boolean {
 	const expandedPattern = resolvePath(pattern.replace(/\/?\*{1,2}$/, ""));
 
 	// Directory match: pattern ends with /* or /**
 	if (pattern.endsWith("/**") || pattern.endsWith("/*")) {
 		const dirPrefix = expandedPattern.endsWith("/") ? expandedPattern : `${expandedPattern}/`;
 		// Match the directory itself or anything under it
-		if (resolvedPath === expandedPattern || resolvedPath.startsWith(dirPrefix)) {
-			return { matches: true };
-		}
-		return { matches: false };
+		return resolvedPath === expandedPattern || resolvedPath.startsWith(dirPrefix);
 	}
 
 	// Prefix match: pattern ends with * (e.g. ~/.ssh/id_*)
 	if (pattern.endsWith("*")) {
-		if (resolvedPath.startsWith(expandedPattern)) {
-			return { matches: true };
-		}
-		return { matches: false };
+		return resolvedPath.startsWith(expandedPattern);
 	}
 
 	// Exact match
-	if (resolvedPath === resolvePath(pattern)) {
-		return { matches: true };
-	}
-	return { matches: false };
+	return resolvedPath === resolvePath(pattern);
 }
 
 /**
@@ -85,8 +89,7 @@ export function isSensitivePath(filepath: string, extraPatterns?: string[]): Sen
 
 	// Check default patterns
 	for (const pattern of DEFAULT_SENSITIVE_PATTERNS) {
-		const result = matchesPattern(resolved, pattern);
-		if (result.matches) {
+		if (matchesPattern(resolved, pattern)) {
 			// Special case: SSH id_* pattern — allowlist .pub files
 			if (pattern === "~/.ssh/id_*" && resolved.endsWith(SSH_PUB_SUFFIX)) {
 				continue;
@@ -98,8 +101,15 @@ export function isSensitivePath(filepath: string, extraPatterns?: string[]): Sen
 	// Check extra patterns
 	if (extraPatterns) {
 		for (const pattern of extraPatterns) {
-			const result = matchesPattern(resolved, pattern);
-			if (result.matches) {
+			if (hasMidPathWildcard(pattern)) {
+				// Mid-path wildcards like ~/vaults/*/key.pem are not supported.
+				// Skip with a console warning so misconfigurations are visible.
+				console.warn(
+					`[sensitive-paths] Skipping unsupported mid-path wildcard pattern: "${pattern}". Only trailing wildcards (e.g. "~/.ssh/id_*", "~/.secrets/*") are supported.`,
+				);
+				continue;
+			}
+			if (matchesPattern(resolved, pattern)) {
 				return { blocked: true, pattern };
 			}
 		}

--- a/packages/coding-agent/src/core/sensitive-paths.ts
+++ b/packages/coding-agent/src/core/sensitive-paths.ts
@@ -1,0 +1,109 @@
+import { homedir } from "node:os";
+import { normalize, resolve } from "node:path";
+
+export interface SensitivePathResult {
+	blocked: boolean;
+	pattern?: string;
+}
+
+export const DEFAULT_SENSITIVE_PATTERNS: string[] = [
+	"~/.ssh/id_*",
+	"~/.gnupg/private-keys-v1.d/*",
+	"~/.dreb/secrets/*",
+	"~/.dreb/agent/auth.json",
+	"~/.aws/credentials",
+	"~/.config/gcloud/credentials.db",
+];
+
+const SSH_PUB_SUFFIX = ".pub";
+
+/**
+ * Expand `~` or `~/` prefix to the user's home directory.
+ */
+function expandHome(filepath: string): string {
+	if (filepath === "~") return homedir();
+	if (filepath.startsWith("~/")) return `${homedir()}/${filepath.slice(2)}`;
+	return filepath;
+}
+
+/**
+ * Resolve and normalize a path, expanding `~` to the real home directory.
+ * This defeats traversal attacks like `../../.ssh/id_rsa`.
+ */
+function resolvePath(filepath: string): string {
+	return normalize(resolve(expandHome(filepath)));
+}
+
+/**
+ * Check whether a single pattern matches a resolved absolute path.
+ * Returns true if the path matches the pattern.
+ *
+ * Pattern types:
+ *   - Ends with `/*` or `/**` → directory prefix match
+ *   - Ends with `*` (but not `/*`) → prefix match on the literal prefix
+ *   - Otherwise → exact match
+ */
+function matchesPattern(resolvedPath: string, pattern: string): { matches: boolean; allowlisted?: boolean } {
+	const expandedPattern = resolvePath(pattern.replace(/\/?\*{1,2}$/, ""));
+
+	// Directory match: pattern ends with /* or /**
+	if (pattern.endsWith("/**") || pattern.endsWith("/*")) {
+		const dirPrefix = expandedPattern.endsWith("/") ? expandedPattern : `${expandedPattern}/`;
+		// Match the directory itself or anything under it
+		if (resolvedPath === expandedPattern || resolvedPath.startsWith(dirPrefix)) {
+			return { matches: true };
+		}
+		return { matches: false };
+	}
+
+	// Prefix match: pattern ends with * (e.g. ~/.ssh/id_*)
+	if (pattern.endsWith("*")) {
+		if (resolvedPath.startsWith(expandedPattern)) {
+			return { matches: true };
+		}
+		return { matches: false };
+	}
+
+	// Exact match
+	if (resolvedPath === resolvePath(pattern)) {
+		return { matches: true };
+	}
+	return { matches: false };
+}
+
+/**
+ * Check whether a file path points to a sensitive credential file.
+ *
+ * Resolves the input to an absolute, normalized path (expanding `~`),
+ * then checks against built-in and optional extra patterns.
+ *
+ * SSH public keys (`*.pub`) are explicitly allowlisted even though
+ * they match the `~/.ssh/id_*` pattern.
+ */
+export function isSensitivePath(filepath: string, extraPatterns?: string[]): SensitivePathResult {
+	const resolved = resolvePath(filepath);
+
+	// Check default patterns
+	for (const pattern of DEFAULT_SENSITIVE_PATTERNS) {
+		const result = matchesPattern(resolved, pattern);
+		if (result.matches) {
+			// Special case: SSH id_* pattern — allowlist .pub files
+			if (pattern === "~/.ssh/id_*" && resolved.endsWith(SSH_PUB_SUFFIX)) {
+				continue;
+			}
+			return { blocked: true, pattern };
+		}
+	}
+
+	// Check extra patterns
+	if (extraPatterns) {
+		for (const pattern of extraPatterns) {
+			const result = matchesPattern(resolved, pattern);
+			if (result.matches) {
+				return { blocked: true, pattern };
+			}
+		}
+	}
+
+	return { blocked: false };
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -97,6 +97,8 @@ export interface Settings {
 	markdown?: MarkdownSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
 	forbiddenCommands?: string[]; // Regex patterns for commands blocked by the forbidden-commands guard
+	sensitiveFilePaths?: string[]; // Additional glob patterns for sensitive file paths blocked by the read/bash guard
+	secretOutputPatterns?: { name: string; pattern: string }[]; // Additional regex patterns for secret scrubbing in tool output
 	dream?: {
 		archivePath?: string; // Custom archive location for dream backups (default: ~/.dreb/memory-archive/)
 	};
@@ -946,6 +948,14 @@ export class SettingsManager {
 
 	getForbiddenCommands(): string[] | undefined {
 		return this.settings.forbiddenCommands;
+	}
+
+	getSensitiveFilePaths(): string[] | undefined {
+		return this.settings.sensitiveFilePaths;
+	}
+
+	getSecretOutputPatterns(): { name: string; pattern: string }[] | undefined {
+		return this.settings.secretOutputPatterns;
 	}
 
 	getDreamArchivePath(): string {

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -666,6 +666,113 @@ describe("isForbiddenCommand", () => {
 			expect(isForbiddenCommand('echo "rm --no-preserve-root -rf /"')).toBe("^rm\\s+.*--no-preserve-root");
 		});
 	});
+
+	describe("sensitive file access via bash commands", () => {
+		const SSH_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)";
+		const DREB_SECRETS_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/";
+		const DREB_AUTH_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json";
+		const AWS_CREDS_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials";
+
+		it("blocks cat ~/.ssh/id_rsa", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks cat ~/.ssh/id_ed25519", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/id_ed25519")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks head -5 ~/.ssh/id_rsa", () => {
+			expect(isForbiddenCommand("head -5 ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks tail ~/.ssh/id_ecdsa", () => {
+			expect(isForbiddenCommand("tail ~/.ssh/id_ecdsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks less ~/.ssh/id_dsa", () => {
+			expect(isForbiddenCommand("less ~/.ssh/id_dsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks more ~/.ssh/id_rsa", () => {
+			expect(isForbiddenCommand("more ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks strings ~/.ssh/id_rsa", () => {
+			expect(isForbiddenCommand("strings ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("allows cat ~/.ssh/id_rsa.pub", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/id_rsa.pub")).toBeUndefined();
+		});
+
+		it("allows cat ~/.ssh/id_ed25519.pub", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/id_ed25519.pub")).toBeUndefined();
+		});
+
+		it("allows cat ~/.ssh/known_hosts", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/known_hosts")).toBeUndefined();
+		});
+
+		it("allows cat ~/.ssh/config", () => {
+			expect(isForbiddenCommand("cat ~/.ssh/config")).toBeUndefined();
+		});
+
+		it("blocks cat on absolute path with .ssh", () => {
+			expect(isForbiddenCommand("cat /home/user/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks cat ~/.dreb/secrets/providers.env", () => {
+			expect(isForbiddenCommand("cat ~/.dreb/secrets/providers.env")).toBe(DREB_SECRETS_PATTERN);
+		});
+
+		it("blocks head ~/.dreb/secrets/anything", () => {
+			expect(isForbiddenCommand("head ~/.dreb/secrets/anything")).toBe(DREB_SECRETS_PATTERN);
+		});
+
+		it("blocks cat ~/.dreb/agent/auth.json", () => {
+			expect(isForbiddenCommand("cat ~/.dreb/agent/auth.json")).toBe(DREB_AUTH_PATTERN);
+		});
+
+		it("blocks cat ~/.aws/credentials", () => {
+			expect(isForbiddenCommand("cat ~/.aws/credentials")).toBe(AWS_CREDS_PATTERN);
+		});
+
+		it("blocks head -5 ~/.aws/credentials", () => {
+			expect(isForbiddenCommand("head -5 ~/.aws/credentials")).toBe(AWS_CREDS_PATTERN);
+		});
+
+		it("allows cat /tmp/normal-file", () => {
+			expect(isForbiddenCommand("cat /tmp/normal-file")).toBeUndefined();
+		});
+
+		it("allows cat ./src/index.ts", () => {
+			expect(isForbiddenCommand("cat ./src/index.ts")).toBeUndefined();
+		});
+
+		it("blocks sensitive file after chaining", () => {
+			expect(isForbiddenCommand("cd /tmp && cat ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks sensitive file inside subshell", () => {
+			expect(isForbiddenCommand("$(cat ~/.ssh/id_rsa)")).toBe(SSH_PATTERN);
+		});
+
+		it('blocks echo "cat ~/.ssh/id_rsa" (quoted content check)', () => {
+			expect(isForbiddenCommand('echo "cat ~/.ssh/id_rsa"')).toBe(SSH_PATTERN);
+		});
+
+		it("blocks cat ~/.gnupg/private-keys path", () => {
+			expect(isForbiddenCommand("cat ~/.gnupg/private-keys-v1.d/abc")).toBe(
+				"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys",
+			);
+		});
+
+		it("blocks cat ~/.config/gcloud/credentials.db", () => {
+			expect(isForbiddenCommand("cat ~/.config/gcloud/credentials.db")).toBe(
+				"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db",
+			);
+		});
+	});
 });
 
 describe("extractScriptPaths", () => {

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -668,10 +668,14 @@ describe("isForbiddenCommand", () => {
 	});
 
 	describe("sensitive file access via bash commands", () => {
-		const SSH_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)";
-		const DREB_SECRETS_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/secrets/";
-		const DREB_AUTH_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.dreb/agent/auth\\.json";
-		const AWS_CREDS_PATTERN = "^(?:cat|head|tail|less|more|strings)\\s+.*\\.aws/credentials";
+		const SSH_PATTERN =
+			"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*(?:~|\\.ssh)/id_(?!.*\\.pub\\b)";
+		const DREB_SECRETS_PATTERN =
+			"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/secrets/";
+		const DREB_AUTH_PATTERN =
+			"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.dreb/agent/auth\\.json";
+		const AWS_CREDS_PATTERN =
+			"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.aws/credentials";
 
 		it("blocks cat ~/.ssh/id_rsa", () => {
 			expect(isForbiddenCommand("cat ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
@@ -763,14 +767,55 @@ describe("isForbiddenCommand", () => {
 
 		it("blocks cat ~/.gnupg/private-keys path", () => {
 			expect(isForbiddenCommand("cat ~/.gnupg/private-keys-v1.d/abc")).toBe(
-				"^(?:cat|head|tail|less|more|strings)\\s+.*\\.gnupg/private-keys",
+				"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.gnupg/private-keys",
 			);
 		});
 
 		it("blocks cat ~/.config/gcloud/credentials.db", () => {
 			expect(isForbiddenCommand("cat ~/.config/gcloud/credentials.db")).toBe(
-				"^(?:cat|head|tail|less|more|strings)\\s+.*\\.config/gcloud/credentials\\.db",
+				"^(?:/\\S+/)?(?:cat|head|tail|less|more|strings|grep|sed|awk|base64|xxd)\\s+.*\\.config/gcloud/credentials\\.db",
 			);
+		});
+
+		// Finding 3 fixes: absolute paths and additional commands
+		it("blocks /bin/cat ~/.ssh/id_rsa (absolute path)", () => {
+			expect(isForbiddenCommand("/bin/cat ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks /usr/bin/cat ~/.ssh/id_rsa (absolute path)", () => {
+			expect(isForbiddenCommand("/usr/bin/cat ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks grep on SSH private key", () => {
+			expect(isForbiddenCommand('grep "" ~/.ssh/id_rsa')).toBe(SSH_PATTERN);
+		});
+
+		it("blocks sed on SSH private key", () => {
+			expect(isForbiddenCommand("sed '' ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks base64 on SSH private key", () => {
+			expect(isForbiddenCommand("base64 ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks xxd on SSH private key", () => {
+			expect(isForbiddenCommand("xxd ~/.ssh/id_rsa")).toBe(SSH_PATTERN);
+		});
+
+		it("blocks awk on AWS credentials", () => {
+			expect(isForbiddenCommand("awk '{print}' ~/.aws/credentials")).toBe(AWS_CREDS_PATTERN);
+		});
+
+		it("blocks /usr/bin/base64 on AWS credentials (absolute path)", () => {
+			expect(isForbiddenCommand("/usr/bin/base64 ~/.aws/credentials")).toBe(AWS_CREDS_PATTERN);
+		});
+
+		it("still allows grep on normal files", () => {
+			expect(isForbiddenCommand("grep pattern ./src/index.ts")).toBeUndefined();
+		});
+
+		it("still allows base64 on normal files", () => {
+			expect(isForbiddenCommand("base64 /tmp/safe-file")).toBeUndefined();
 		});
 	});
 });

--- a/packages/coding-agent/test/secret-scrubbing.test.ts
+++ b/packages/coding-agent/test/secret-scrubbing.test.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_SECRET_PATTERNS, type SecretPattern, scrubSecrets } from "../src/core/secret-scrubber.js";
 import { DEFAULT_SENSITIVE_PATTERNS, isSensitivePath } from "../src/core/sensitive-paths.js";
 
@@ -88,6 +88,22 @@ describe("scrubSecrets", () => {
 
 		it("does not redact ghp_ with insufficient length", () => {
 			const input = "ghp_short";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("GitHub fine-grained PATs", () => {
+		it("redacts github_pat_ token", () => {
+			const token = `github_pat_${"A".repeat(82)}`;
+			const { scrubbed, redactionCount } = scrubSecrets(`GITHUB_TOKEN=${token}`);
+			expect(scrubbed).toBe("GITHUB_TOKEN=<REDACTED:github_token>");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("does not redact github_pat_ with insufficient length", () => {
+			const input = "github_pat_short";
 			const { scrubbed, redactionCount } = scrubSecrets(input);
 			expect(scrubbed).toBe(input);
 			expect(redactionCount).toBe(0);
@@ -577,6 +593,23 @@ describe("isSensitivePath", () => {
 		it("extra patterns do not override default allowlists", () => {
 			// .pub files are still allowed even with extra patterns
 			expect(isSensitivePath("~/.ssh/id_rsa.pub", ["~/.extra/*"]).blocked).toBe(false);
+		});
+
+		it("warns and skips mid-path wildcard patterns", () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const result = isSensitivePath("~/vaults/myteam/key.pem", ["~/vaults/*/key.pem"]);
+			expect(result.blocked).toBe(false);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Skipping unsupported mid-path wildcard pattern"),
+			);
+			warnSpy.mockRestore();
+		});
+
+		it("does not warn for trailing wildcard patterns", () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			isSensitivePath("~/.vault/token", ["~/.vault/*"]);
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
 		});
 	});
 });

--- a/packages/coding-agent/test/secret-scrubbing.test.ts
+++ b/packages/coding-agent/test/secret-scrubbing.test.ts
@@ -613,3 +613,21 @@ describe("isSensitivePath", () => {
 		});
 	});
 });
+
+// ============================================================================
+// Empty/Invalid Pattern Guards (agent-session.ts wiring validation)
+// ============================================================================
+
+describe("empty-string regex behavior", () => {
+	it("empty-string regex pattern mangles output (documents why caller must guard)", () => {
+		// An empty-string regex matches every zero-width position between characters.
+		// This is why agent-session.ts guards against empty patterns before calling scrubSecrets.
+		const emptyPattern: SecretPattern[] = [{ name: "bad", pattern: /(?:)/g }];
+		const input = "hello";
+		const { scrubbed, redactionCount } = scrubSecrets(input, emptyPattern);
+		// Inserts <REDACTED:bad> between every character + at start/end
+		expect(redactionCount).toBe(6); // h-e-l-l-o = 5 chars, 6 zero-width positions
+		expect(scrubbed).toContain("<REDACTED:bad>");
+		expect(scrubbed.length).toBeGreaterThan(input.length * 5);
+	});
+});

--- a/packages/coding-agent/test/secret-scrubbing.test.ts
+++ b/packages/coding-agent/test/secret-scrubbing.test.ts
@@ -1,0 +1,582 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SECRET_PATTERNS, type SecretPattern, scrubSecrets } from "../src/core/secret-scrubber.js";
+import { DEFAULT_SENSITIVE_PATTERNS, isSensitivePath } from "../src/core/sensitive-paths.js";
+
+// ============================================================================
+// Layer 1: Output Scrubbing (secret-scrubber.ts)
+// ============================================================================
+
+describe("scrubSecrets", () => {
+	describe("pattern registry", () => {
+		it("exports DEFAULT_SECRET_PATTERNS with all expected patterns", () => {
+			const names = DEFAULT_SECRET_PATTERNS.map((p) => p.name);
+			expect(names).toContain("aws_access_key");
+			expect(names).toContain("github_token");
+			expect(names).toContain("gitlab_token");
+			expect(names).toContain("anthropic_key");
+			expect(names).toContain("openai_key");
+			expect(names).toContain("slack_token");
+			expect(names).toContain("stripe_key");
+			expect(names).toContain("url_credentials");
+			expect(names).toContain("pem_private_key");
+			expect(names).toContain("openssh_private_key");
+		});
+	});
+
+	describe("AWS access key", () => {
+		it("redacts AWS access key", () => {
+			const input = "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe("AWS_ACCESS_KEY_ID=<REDACTED:aws_access_key>");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("redacts AWS key embedded in text", () => {
+			const input = "Found key AKIAIOSFODNN7EXAMPLE in config";
+			const { scrubbed } = scrubSecrets(input);
+			expect(scrubbed).toContain("<REDACTED:aws_access_key>");
+			expect(scrubbed).not.toContain("AKIAIOSFODNN7EXAMPLE");
+		});
+
+		it("does not redact MD5 hash", () => {
+			const input = "hash: d41d8cd98f00b204e9800998ecf8427e";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact short strings that happen to start with AKIA", () => {
+			const input = "AKIA1234"; // only 4 chars after AKIA, need 16
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("GitHub tokens", () => {
+		it("redacts ghp_ personal access token", () => {
+			const token = "ghp_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed, redactionCount } = scrubSecrets(`token=${token}`);
+			expect(scrubbed).toBe("token=<REDACTED:github_token>");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("redacts ghs_ service token", () => {
+			const token = "ghs_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:github_token>");
+		});
+
+		it("redacts gho_ OAuth token", () => {
+			const token = "gho_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:github_token>");
+		});
+
+		it("redacts ghu_ user token", () => {
+			const token = "ghu_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:github_token>");
+		});
+
+		it("redacts ghr_ refresh token", () => {
+			const token = "ghr_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:github_token>");
+		});
+
+		it("does not redact ghp_ with insufficient length", () => {
+			const input = "ghp_short";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("GitLab tokens", () => {
+		it("redacts glpat- token", () => {
+			const token = "glpat-ABCDEFghijklmnop12345";
+			const { scrubbed } = scrubSecrets(`GITLAB_TOKEN=${token}`);
+			expect(scrubbed).toBe("GITLAB_TOKEN=<REDACTED:gitlab_token>");
+		});
+
+		it("does not redact glpat- with insufficient length", () => {
+			const input = "glpat-short";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("OpenAI keys", () => {
+		it("redacts sk-proj- style key", () => {
+			const key = "sk-proj-abc123def456ghi789jkl";
+			const { scrubbed } = scrubSecrets(`OPENAI_API_KEY=${key}`);
+			expect(scrubbed).toBe("OPENAI_API_KEY=<REDACTED:openai_key>");
+		});
+
+		it("redacts sk- key with sufficient length", () => {
+			const key = "sk-abcdefghijklmnopqrstuvwx";
+			const { scrubbed } = scrubSecrets(key);
+			expect(scrubbed).toBe("<REDACTED:openai_key>");
+		});
+
+		it("does not redact short sk- prefix", () => {
+			const input = "sk-abc";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact sk-ant- (handled by anthropic pattern)", () => {
+			const key = `sk-ant-${"a".repeat(95)}`;
+			const { scrubbed } = scrubSecrets(key);
+			expect(scrubbed).toBe("<REDACTED:anthropic_key>");
+			expect(scrubbed).not.toContain("openai_key");
+		});
+	});
+
+	describe("Anthropic keys", () => {
+		it("redacts sk-ant- key", () => {
+			const key = `sk-ant-api03-${"A".repeat(90)}`;
+			const { scrubbed } = scrubSecrets(`key=${key}`);
+			expect(scrubbed).toBe("key=<REDACTED:anthropic_key>");
+		});
+
+		it("does not redact sk-ant- with insufficient length", () => {
+			const input = "sk-ant-short";
+			const { redactionCount } = scrubSecrets(input);
+			// This is too short for anthropic (needs 90+ after sk-ant-), but might match openai
+			// sk-ant-short is 12 chars after sk- which is < 20, so no match for either
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("Slack tokens", () => {
+		it("redacts xoxb- bot token", () => {
+			const token = "xoxb-1234567890-abcdefghij";
+			const { scrubbed } = scrubSecrets(`SLACK_TOKEN=${token}`);
+			expect(scrubbed).toBe("SLACK_TOKEN=<REDACTED:slack_token>");
+		});
+
+		it("redacts xoxp- user token", () => {
+			const token = "xoxp-1234567890-abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:slack_token>");
+		});
+
+		it("redacts xoxa- app token", () => {
+			const token = "xoxa-1234567890-abcdefghij";
+			const { scrubbed } = scrubSecrets(token);
+			expect(scrubbed).toBe("<REDACTED:slack_token>");
+		});
+
+		it("does not redact xoxb- with insufficient length", () => {
+			const input = "xoxb-short";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("Stripe keys", () => {
+		it("redacts sk_live_ key", () => {
+			const key = `sk_live_${"a".repeat(24)}`;
+			const { scrubbed } = scrubSecrets(`STRIPE_KEY=${key}`);
+			expect(scrubbed).toBe("STRIPE_KEY=<REDACTED:stripe_key>");
+		});
+
+		it("redacts sk_test_ key", () => {
+			const key = `sk_test_${"b".repeat(24)}`;
+			const { scrubbed } = scrubSecrets(key);
+			expect(scrubbed).toBe("<REDACTED:stripe_key>");
+		});
+
+		it("redacts rk_live_ restricted key", () => {
+			const key = `rk_live_${"c".repeat(24)}`;
+			const { scrubbed } = scrubSecrets(key);
+			expect(scrubbed).toBe("<REDACTED:stripe_key>");
+		});
+
+		it("does not redact sk_live_ with insufficient length", () => {
+			const input = "sk_live_short";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("URL credentials", () => {
+		it("redacts password in https URL", () => {
+			const input = "https://admin:s3cret@db.example.com:5432/mydb";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe("https://admin:<REDACTED:url_credentials>@db.example.com:5432/mydb");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("redacts password in http URL", () => {
+			const input = "http://user:password123@host.com";
+			const { scrubbed } = scrubSecrets(input);
+			expect(scrubbed).toBe("http://user:<REDACTED:url_credentials>@host.com");
+		});
+
+		it("does not redact URL without credentials", () => {
+			const input = "https://host.com/path";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact URL with only user (no password)", () => {
+			const input = "https://user@host.com";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("PEM private keys", () => {
+		it("redacts RSA private key block", () => {
+			const pem = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA2a2rwplBQLcD2B4VkXqKV++jGz1z7FxCVHZ8h1jFJYBP
+KQEFhBSWFkZjhGk1LZ0qb1FQfr1XQ2v3Oag9N3hb0q7k1Ef
+-----END RSA PRIVATE KEY-----`;
+			const { scrubbed, redactionCount } = scrubSecrets(`cert:\n${pem}\nmore text`);
+			expect(scrubbed).toBe("cert:\n<REDACTED:pem_private_key>\nmore text");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("redacts EC private key block", () => {
+			const pem = `-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIOLwH3zAA1NwDXxBUJkIc0gA8j+7OzQ5Bz6JFnSFYW
+-----END EC PRIVATE KEY-----`;
+			const { scrubbed } = scrubSecrets(pem);
+			expect(scrubbed).toBe("<REDACTED:pem_private_key>");
+		});
+
+		it("redacts ENCRYPTED private key block", () => {
+			const pem = `-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFHDBOBgkqhkiG9w0BBQ0wQTApBgkqhkiG9w0BBQwwHAQI
+-----END ENCRYPTED PRIVATE KEY-----`;
+			const { scrubbed } = scrubSecrets(pem);
+			expect(scrubbed).toBe("<REDACTED:pem_private_key>");
+		});
+
+		it("redacts plain PRIVATE KEY block (PKCS8)", () => {
+			const pem = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEA
+-----END PRIVATE KEY-----`;
+			const { scrubbed } = scrubSecrets(pem);
+			expect(scrubbed).toBe("<REDACTED:pem_private_key>");
+		});
+
+		it("does NOT redact public key block", () => {
+			const pem = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+-----END PUBLIC KEY-----`;
+			const { scrubbed, redactionCount } = scrubSecrets(pem);
+			expect(scrubbed).toBe(pem);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does NOT redact certificate block", () => {
+			const cert = `-----BEGIN CERTIFICATE-----
+MIIDdTCCAl2gAwIBAgIJAOi7KK
+-----END CERTIFICATE-----`;
+			const { scrubbed, redactionCount } = scrubSecrets(cert);
+			expect(scrubbed).toBe(cert);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("OpenSSH private keys", () => {
+		it("redacts OpenSSH private key block", () => {
+			const key = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDd1X+ILZvDDJ6x/VB5oTxqMR
+-----END OPENSSH PRIVATE KEY-----`;
+			const { scrubbed, redactionCount } = scrubSecrets(`key file:\n${key}`);
+			expect(scrubbed).toBe("key file:\n<REDACTED:openssh_private_key>");
+			expect(redactionCount).toBe(1);
+		});
+	});
+
+	describe("false positive avoidance", () => {
+		it("does not redact UUIDs", () => {
+			const input = "id: 550e8400-e29b-41d4-a716-446655440000";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact SHA-256 hashes", () => {
+			const input = "sha256: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact generic base64 data", () => {
+			const input = "data: SGVsbG8gV29ybGQhIFRoaXMgaXMgYSB0ZXN0Lg==";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact git commit hashes", () => {
+			const input = "commit abc123def456789012345678901234567890abcd";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+
+		it("does not redact normal PATH-like environment variables", () => {
+			const input = "PATH=/usr/local/bin:/usr/bin:/bin\nHOME=/home/user\nTERM=xterm-256color";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+
+	describe("multiple secrets", () => {
+		it("redacts multiple different secrets in one output", () => {
+			const input = [
+				`ANTHROPIC_API_KEY=sk-ant-api03-${"B".repeat(90)}`,
+				"GITHUB_TOKEN=ghp_ABCDEFghijklmnop1234567890abcdefghij",
+				"DATABASE_URL=https://admin:password@db.example.com/mydb",
+			].join("\n");
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(redactionCount).toBe(3);
+			expect(scrubbed).toContain("<REDACTED:anthropic_key>");
+			expect(scrubbed).toContain("<REDACTED:github_token>");
+			expect(scrubbed).toContain("<REDACTED:url_credentials>");
+		});
+
+		it("redacts multiple instances of the same pattern", () => {
+			const input = "key1=AKIAIOSFODNN7EXAMPLE key2=AKIAIOSFODNN7EXAMPLF";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(redactionCount).toBe(2);
+			expect(scrubbed).toBe("key1=<REDACTED:aws_access_key> key2=<REDACTED:aws_access_key>");
+		});
+	});
+
+	describe("extra patterns", () => {
+		it("applies extra patterns after defaults", () => {
+			const extra: SecretPattern[] = [{ name: "custom_secret", pattern: /CUSTOM_SECRET_[A-Z0-9]{10,}/g }];
+			const input = "key=CUSTOM_SECRET_ABCDEF1234";
+			const { scrubbed, redactionCount } = scrubSecrets(input, extra);
+			expect(scrubbed).toBe("key=<REDACTED:custom_secret>");
+			expect(redactionCount).toBe(1);
+		});
+
+		it("extra patterns do not interfere with defaults", () => {
+			const extra: SecretPattern[] = [{ name: "custom", pattern: /CUSTOM_[A-Z]+/g }];
+			const input = "ghp_ABCDEFghijklmnop1234567890abcdefghij";
+			const { scrubbed } = scrubSecrets(input, extra);
+			expect(scrubbed).toBe("<REDACTED:github_token>");
+		});
+	});
+
+	describe("idempotency", () => {
+		it("calling scrubSecrets twice produces the same result", () => {
+			const input = "key=AKIAIOSFODNN7EXAMPLE and token=ghp_ABCDEFghijklmnop1234567890abcdefghij";
+			const first = scrubSecrets(input);
+			const second = scrubSecrets(first.scrubbed);
+			expect(second.scrubbed).toBe(first.scrubbed);
+			expect(second.redactionCount).toBe(0);
+		});
+	});
+
+	describe("empty and edge inputs", () => {
+		it("handles empty string", () => {
+			const { scrubbed, redactionCount } = scrubSecrets("");
+			expect(scrubbed).toBe("");
+			expect(redactionCount).toBe(0);
+		});
+
+		it("handles text with no secrets", () => {
+			const input = "Just a normal log line with no secrets.";
+			const { scrubbed, redactionCount } = scrubSecrets(input);
+			expect(scrubbed).toBe(input);
+			expect(redactionCount).toBe(0);
+		});
+	});
+});
+
+// ============================================================================
+// Layer 2: Sensitive File Access Guard (sensitive-paths.ts)
+// ============================================================================
+
+describe("isSensitivePath", () => {
+	const home = homedir();
+
+	describe("pattern registry", () => {
+		it("exports DEFAULT_SENSITIVE_PATTERNS with expected entries", () => {
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.ssh/id_*");
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.gnupg/private-keys-v1.d/*");
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.dreb/secrets/*");
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.dreb/agent/auth.json");
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.aws/credentials");
+			expect(DEFAULT_SENSITIVE_PATTERNS).toContain("~/.config/gcloud/credentials.db");
+		});
+	});
+
+	describe("SSH private keys", () => {
+		it("blocks ~/.ssh/id_rsa", () => {
+			const result = isSensitivePath("~/.ssh/id_rsa");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.ssh/id_*");
+		});
+
+		it("blocks ~/.ssh/id_ed25519", () => {
+			expect(isSensitivePath("~/.ssh/id_ed25519").blocked).toBe(true);
+		});
+
+		it("blocks ~/.ssh/id_ecdsa", () => {
+			expect(isSensitivePath("~/.ssh/id_ecdsa").blocked).toBe(true);
+		});
+
+		it("blocks ~/.ssh/id_dsa", () => {
+			expect(isSensitivePath("~/.ssh/id_dsa").blocked).toBe(true);
+		});
+
+		it("allows ~/.ssh/id_rsa.pub", () => {
+			expect(isSensitivePath("~/.ssh/id_rsa.pub").blocked).toBe(false);
+		});
+
+		it("allows ~/.ssh/id_ed25519.pub", () => {
+			expect(isSensitivePath("~/.ssh/id_ed25519.pub").blocked).toBe(false);
+		});
+
+		it("allows ~/.ssh/known_hosts", () => {
+			expect(isSensitivePath("~/.ssh/known_hosts").blocked).toBe(false);
+		});
+
+		it("allows ~/.ssh/config", () => {
+			expect(isSensitivePath("~/.ssh/config").blocked).toBe(false);
+		});
+
+		it("allows ~/.ssh/authorized_keys", () => {
+			expect(isSensitivePath("~/.ssh/authorized_keys").blocked).toBe(false);
+		});
+
+		it("blocks absolute path to SSH private key", () => {
+			expect(isSensitivePath(`${home}/.ssh/id_rsa`).blocked).toBe(true);
+		});
+
+		it("allows absolute path to SSH public key", () => {
+			expect(isSensitivePath(`${home}/.ssh/id_rsa.pub`).blocked).toBe(false);
+		});
+	});
+
+	describe("dreb secrets", () => {
+		it("blocks ~/.dreb/secrets/providers.env", () => {
+			const result = isSensitivePath("~/.dreb/secrets/providers.env");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.dreb/secrets/*");
+		});
+
+		it("blocks ~/.dreb/secrets/any-file", () => {
+			expect(isSensitivePath("~/.dreb/secrets/any-file").blocked).toBe(true);
+		});
+
+		it("blocks ~/.dreb/agent/auth.json", () => {
+			const result = isSensitivePath("~/.dreb/agent/auth.json");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.dreb/agent/auth.json");
+		});
+
+		it("allows ~/.dreb/memory/something.md", () => {
+			expect(isSensitivePath("~/.dreb/memory/something.md").blocked).toBe(false);
+		});
+
+		it("allows ~/.dreb/agent/sessions/", () => {
+			expect(isSensitivePath("~/.dreb/agent/sessions/abc.json").blocked).toBe(false);
+		});
+	});
+
+	describe("AWS credentials", () => {
+		it("blocks ~/.aws/credentials", () => {
+			const result = isSensitivePath("~/.aws/credentials");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.aws/credentials");
+		});
+
+		it("allows ~/.aws/config", () => {
+			expect(isSensitivePath("~/.aws/config").blocked).toBe(false);
+		});
+	});
+
+	describe("GPG private keys", () => {
+		it("blocks ~/.gnupg/private-keys-v1.d/somefile", () => {
+			const result = isSensitivePath("~/.gnupg/private-keys-v1.d/somefile");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.gnupg/private-keys-v1.d/*");
+		});
+
+		it("allows ~/.gnupg/pubring.kbx", () => {
+			expect(isSensitivePath("~/.gnupg/pubring.kbx").blocked).toBe(false);
+		});
+	});
+
+	describe("Google Cloud credentials", () => {
+		it("blocks ~/.config/gcloud/credentials.db", () => {
+			const result = isSensitivePath("~/.config/gcloud/credentials.db");
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.config/gcloud/credentials.db");
+		});
+
+		it("allows ~/.config/gcloud/properties", () => {
+			expect(isSensitivePath("~/.config/gcloud/properties").blocked).toBe(false);
+		});
+	});
+
+	describe("safe paths", () => {
+		it("allows /tmp/safe-file", () => {
+			expect(isSensitivePath("/tmp/safe-file").blocked).toBe(false);
+		});
+
+		it("allows regular project files", () => {
+			expect(isSensitivePath("./src/index.ts").blocked).toBe(false);
+		});
+
+		it("allows /etc/hosts", () => {
+			expect(isSensitivePath("/etc/hosts").blocked).toBe(false);
+		});
+	});
+
+	describe("path traversal prevention", () => {
+		it("blocks traversal to SSH key via ..", () => {
+			// From a typical cwd, ../../.ssh/id_rsa should resolve to home
+			const traversal = `${home}/projects/myapp/../../.ssh/id_rsa`;
+			expect(isSensitivePath(traversal).blocked).toBe(true);
+		});
+
+		it("blocks absolute path with .. that resolves to sensitive file", () => {
+			expect(isSensitivePath(`${home}/.ssh/../.ssh/id_ed25519`).blocked).toBe(true);
+		});
+	});
+
+	describe("extra patterns", () => {
+		it("blocks paths matching extra exact patterns", () => {
+			const result = isSensitivePath("~/.config/hub", ["~/.config/hub"]);
+			expect(result.blocked).toBe(true);
+			expect(result.pattern).toBe("~/.config/hub");
+		});
+
+		it("blocks paths matching extra prefix patterns", () => {
+			const result = isSensitivePath("~/.vault/token", ["~/.vault/*"]);
+			expect(result.blocked).toBe(true);
+		});
+
+		it("does not block non-matching extra patterns", () => {
+			expect(isSensitivePath("/tmp/file", ["~/.vault/*"]).blocked).toBe(false);
+		});
+
+		it("extra patterns do not override default allowlists", () => {
+			// .pub files are still allowed even with extra patterns
+			expect(isSensitivePath("~/.ssh/id_rsa.pub", ["~/.extra/*"]).blocked).toBe(false);
+		});
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.8.0",
+	"version": "2.9.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #171

Adds two layers of defense against accidental credential exposure through the tool pipeline:
- **Output scrubbing** — detect and redact secrets in tool output before they enter the LLM conversation
- **Sensitive file access guard** — block reads of known secret files (SSH private keys, credential stores)

Implementation plan posted as a comment below.