### PR TITLE
Add Kimi For Coding OAuth provider for K2.6-code-preview access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -3873,9 +3873,9 @@
 			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -5526,9 +5526,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.12",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-			"integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+			"version": "4.12.14",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -6607,9 +6607,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1459,7 +1459,7 @@ async function generateModels() {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 262144,
 			maxTokens: 32768,
-			compat: { thinkingFormat: "kimi" },
+			compat: { thinkingFormat: "kimi", supportsDeveloperRole: false },
 		},
 	];
 	for (const model of kimiCodingOAuthModels) {

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1445,6 +1445,29 @@ async function generateModels() {
 		}
 	}
 
+	// Kimi For Coding OAuth models (OpenAI Completions API at api.kimi.com/coding/v1)
+	const KIMI_CODING_OAUTH_BASE_URL = "https://api.kimi.com/coding/v1";
+	const kimiCodingOAuthModels: Model<"openai-completions">[] = [
+		{
+			id: "kimi-for-coding",
+			name: "Kimi For Coding",
+			api: "openai-completions",
+			provider: "kimi-coding-oauth",
+			baseUrl: KIMI_CODING_OAUTH_BASE_URL,
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 262144,
+			maxTokens: 32768,
+			compat: { thinkingFormat: "kimi" },
+		},
+	];
+	for (const model of kimiCodingOAuthModels) {
+		if (!allModels.some(m => m.provider === "kimi-coding-oauth" && m.id === model.id)) {
+			allModels.push(model);
+		}
+	}
+
 	const azureOpenAiModels: Model<Api>[] = allModels
 		.filter((model) => model.provider === "openai" && model.api === "openai-responses")
 		.map((model) => ({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -420,6 +420,27 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		} else {
 			openRouterParams.reasoning = { effort: "none" };
 		}
+	} else if (compat.thinkingFormat === "kimi" && model.reasoning) {
+		// Kimi uses thinking: { type: "enabled" | "disabled" } + reasoning_effort + prompt_cache_key.
+		const kimiParams = params as typeof params & {
+			thinking?: { type: "enabled" | "disabled" };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		if (options?.reasoningEffort) {
+			const effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
+			if (effort === "off") {
+				kimiParams.thinking = { type: "disabled" };
+			} else if (effort !== "auto") {
+				(kimiParams as any).reasoning_effort = effort;
+				kimiParams.thinking = { type: "enabled" };
+			}
+			// "auto" → omit both thinking and reasoning_effort
+		}
+		// No reasoningEffort → omit both (default behaviour)
+		if (options?.sessionId) {
+			kimiParams.prompt_cache_key = options.sessionId;
+		}
 	} else if (options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
 		// OpenAI-style reasoning_effort
 		(params as any).reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -422,7 +422,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 		}
 	} else if (compat.thinkingFormat === "kimi" && model.reasoning) {
 		// Kimi uses thinking: { type: "enabled" | "disabled" } + reasoning_effort + prompt_cache_key.
-		const kimiParams = params as typeof params & {
+		const kimiParams = params as Omit<typeof params, "reasoning_effort"> & {
 			thinking?: { type: "enabled" | "disabled" };
 			reasoning_effort?: string;
 			prompt_cache_key?: string;
@@ -432,7 +432,7 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 			if (effort === "off") {
 				kimiParams.thinking = { type: "disabled" };
 			} else if (effort !== "auto") {
-				(kimiParams as any).reasoning_effort = effort;
+				kimiParams.reasoning_effort = effort;
 				kimiParams.thinking = { type: "enabled" };
 			}
 			// "auto" → omit both thinking and reasoning_effort

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -38,7 +38,8 @@ export type KnownProvider =
 	| "huggingface"
 	| "opencode"
 	| "opencode-go"
-	| "kimi-coding";
+	| "kimi-coding"
+	| "kimi-coding-oauth";
 export type Provider = KnownProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -276,8 +277,8 @@ export interface OpenAICompletionsCompat {
 	requiresAssistantAfterToolResult?: boolean;
 	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
 	requiresThinkingAsText?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
-	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template";
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking, and "kimi" uses thinking: { type } + reasoning_effort + prompt_cache_key. Default: "openai". */
+	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "kimi";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -24,6 +24,15 @@ export {
 export { antigravityOAuthProvider, loginAntigravity, refreshAntigravityToken } from "./google-antigravity.js";
 // Google Gemini CLI
 export { geminiCliOAuthProvider, loginGeminiCli, refreshGoogleCloudToken } from "./google-gemini-cli.js";
+export type { KimiModelInfo } from "./kimi-coding.js";
+// Kimi For Coding
+export {
+	buildKimiHeaders,
+	kimiCodingOAuthProvider,
+	listModels,
+	loginKimiCoding,
+	refreshKimiCodingToken,
+} from "./kimi-coding.js";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.js";
 
@@ -36,6 +45,7 @@ export * from "./types.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { antigravityOAuthProvider } from "./google-antigravity.js";
 import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
+import { kimiCodingOAuthProvider } from "./kimi-coding.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
 
@@ -44,6 +54,7 @@ const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	geminiCliOAuthProvider,
 	antigravityOAuthProvider,
 	openaiCodexOAuthProvider,
+	kimiCodingOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/kimi-coding.ts
+++ b/packages/ai/src/utils/oauth/kimi-coding.ts
@@ -318,6 +318,9 @@ async function pollForAccessToken(
 				const descriptionSuffix = description ? `: ${description}` : "";
 				throw new Error(`Device flow failed: ${error}${descriptionSuffix}`);
 			}
+
+			// Unexpected response: valid object but no access_token or error field
+			throw new Error(`Unexpected token response: ${JSON.stringify(resp)}`);
 		}
 	}
 
@@ -335,6 +338,19 @@ class RetriableError extends Error {
 		super(message);
 		this.name = "RetriableError";
 	}
+}
+
+/**
+ * Heuristic to detect network-level errors that should be retried.
+ * Fetch throws TypeError on network failures; some runtimes include
+ * recognizable substrings in the message.
+ */
+function isNetworkError(error: Error): boolean {
+	if (error instanceof TypeError) return true;
+	const msg = error.message.toLowerCase();
+	return ["fetch failed", "econnrefused", "etimedout", "enotfound", "econnreset", "socket hang up"].some((s) =>
+		msg.includes(s),
+	);
 }
 
 async function refreshWithRetry(refreshToken: string, signal?: AbortSignal): Promise<TokenSuccessResponse> {
@@ -378,10 +394,15 @@ async function refreshWithRetry(refreshToken: string, signal?: AbortSignal): Pro
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 
-			// Only retry on retriable errors (network failures or retriable HTTP status codes)
+			// Wrap network errors (TypeError from fetch, or common network failure indicators) as retriable
+			if (!(lastError instanceof RetriableError) && isNetworkError(lastError)) {
+				lastError = new RetriableError(lastError.message);
+			}
+
+			// Retry on retriable errors (network failures or retriable HTTP status codes)
 			if (lastError instanceof RetriableError && attempt < MAX_REFRESH_RETRIES - 1) {
 				const backoffMs = Math.min(1000 * 2 ** attempt, 10000);
-				await new Promise((resolve) => setTimeout(resolve, backoffMs));
+				await abortableSleep(backoffMs, signal);
 				continue;
 			}
 
@@ -411,7 +432,12 @@ export async function loginKimiCoding(options: {
 
 	// Discover model entitlement
 	options.onProgress?.("Discovering available models...");
-	const models = await listModels(tokenResp.access_token);
+	let models: KimiModelInfo[] = [];
+	try {
+		models = await listModels(tokenResp.access_token);
+	} catch {
+		// Proceed without model enrichment if the models endpoint fails
+	}
 
 	const credentials: KimiCredentials = {
 		refresh: tokenResp.refresh_token,
@@ -433,11 +459,19 @@ export async function loginKimiCoding(options: {
 // Refresh
 // ============================================================================
 
-export async function refreshKimiCodingToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-	const tokenResp = await refreshWithRetry(credentials.refresh);
+export async function refreshKimiCodingToken(
+	credentials: OAuthCredentials,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	const tokenResp = await refreshWithRetry(credentials.refresh, signal);
 
 	// Re-discover model entitlement
-	const models = await listModels(tokenResp.access_token);
+	let models: KimiModelInfo[] = [];
+	try {
+		models = await listModels(tokenResp.access_token);
+	} catch {
+		// Proceed without model enrichment if the models endpoint fails
+	}
 
 	const fresh: KimiCredentials = {
 		refresh: tokenResp.refresh_token ?? credentials.refresh,

--- a/packages/ai/src/utils/oauth/kimi-coding.ts
+++ b/packages/ai/src/utils/oauth/kimi-coding.ts
@@ -480,6 +480,9 @@ export async function refreshKimiCodingToken(
 		refresh: tokenResp.refresh_token ?? credentials.refresh,
 		access: tokenResp.access_token,
 		expires: Date.now() + tokenResp.expires_in * 1000,
+		modelId: (credentials as KimiCredentials).modelId,
+		contextLength: (credentials as KimiCredentials).contextLength,
+		modelDisplay: (credentials as KimiCredentials).modelDisplay,
 	};
 
 	if (models.length > 0) {

--- a/packages/ai/src/utils/oauth/kimi-coding.ts
+++ b/packages/ai/src/utils/oauth/kimi-coding.ts
@@ -272,7 +272,7 @@ async function pollForAccessToken(
 		const waitMs = Math.min(intervalMs, remainingMs);
 		await abortableSleep(waitMs, signal);
 
-		const raw = await fetchJson(OAUTH_TOKEN_URL, {
+		const tokenResponse = await fetch(OAUTH_TOKEN_URL, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded",
@@ -285,43 +285,43 @@ async function pollForAccessToken(
 			}),
 		});
 
-		if (raw && typeof raw === "object") {
-			const resp = raw as Record<string, unknown>;
+		// The token endpoint returns 400 for authorization_pending / slow_down / expired_token.
+		// We must read the body regardless of status to handle the OAuth error codes.
+		const resp = (await tokenResponse.json()) as Record<string, unknown>;
 
-			// Success: has access_token
-			if (typeof resp.access_token === "string") {
-				return resp as unknown as TokenSuccessResponse;
-			}
-
-			// Error response
-			if (typeof resp.error === "string") {
-				const error = resp.error;
-				const description = resp.error_description as string | undefined;
-				const newInterval = resp.interval as number | undefined;
-
-				if (error === "authorization_pending") {
-					continue;
-				}
-
-				if (error === "slow_down") {
-					intervalMs =
-						typeof newInterval === "number" && newInterval > 0
-							? newInterval * 1000
-							: Math.max(1000, intervalMs + 5000);
-					continue;
-				}
-
-				if (error === "expired_token") {
-					throw new Error("Device code expired. Please try logging in again.");
-				}
-
-				const descriptionSuffix = description ? `: ${description}` : "";
-				throw new Error(`Device flow failed: ${error}${descriptionSuffix}`);
-			}
-
-			// Unexpected response: valid object but no access_token or error field
-			throw new Error(`Unexpected token response: ${JSON.stringify(resp)}`);
+		// Success: has access_token
+		if (typeof resp.access_token === "string") {
+			return resp as unknown as TokenSuccessResponse;
 		}
+
+		// Error response (RFC 8628 §3.5)
+		if (typeof resp.error === "string") {
+			const error = resp.error;
+			const description = resp.error_description as string | undefined;
+			const newInterval = resp.interval as number | undefined;
+
+			if (error === "authorization_pending") {
+				continue;
+			}
+
+			if (error === "slow_down") {
+				intervalMs =
+					typeof newInterval === "number" && newInterval > 0
+						? newInterval * 1000
+						: Math.max(1000, intervalMs + 5000);
+				continue;
+			}
+
+			if (error === "expired_token") {
+				throw new Error("Device code expired. Please try logging in again.");
+			}
+
+			const descriptionSuffix = description ? `: ${description}` : "";
+			throw new Error(`Device flow failed: ${error}${descriptionSuffix}`);
+		}
+
+		// Unexpected response: valid object but no access_token or error field
+		throw new Error(`Unexpected token response: ${JSON.stringify(resp)}`);
 	}
 
 	throw new Error("Device flow timed out");
@@ -423,8 +423,11 @@ export async function loginKimiCoding(options: {
 	signal?: AbortSignal;
 }): Promise<OAuthCredentials> {
 	const device = await startDeviceFlow();
+	// Kimi's device page expects user_code as a query parameter
+	const authUrl = new URL(device.verification_uri);
+	authUrl.searchParams.set("user_code", device.user_code);
 	options.onAuth({
-		url: device.verification_uri,
+		url: authUrl.toString(),
 		instructions: `Enter code: ${device.user_code}`,
 	});
 

--- a/packages/ai/src/utils/oauth/kimi-coding.ts
+++ b/packages/ai/src/utils/oauth/kimi-coding.ts
@@ -1,0 +1,505 @@
+/**
+ * Kimi For Coding OAuth flow (device code)
+ *
+ * Authenticates against Moonshot's Kimi API (auth.kimi.com) with scope "kimi-code".
+ * Uses the device authorization grant flow to obtain access/refresh tokens,
+ * then discovers the user's model entitlement via the /models endpoint.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Api, Model } from "../../types.js";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.js";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const KIMI_CLI_VERSION = "1.35.0";
+const USER_AGENT = `KimiCLI/${KIMI_CLI_VERSION}`;
+const OAUTH_HOST = "https://auth.kimi.com";
+const OAUTH_DEVICE_AUTH_URL = `${OAUTH_HOST}/api/oauth/device_authorization`;
+const OAUTH_TOKEN_URL = `${OAUTH_HOST}/api/oauth/token`;
+const OAUTH_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
+const OAUTH_SCOPE = "kimi-code";
+const OAUTH_DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const OAUTH_REFRESH_GRANT = "refresh_token";
+const API_BASE_URL = "https://api.kimi.com/coding/v1";
+
+const DEVICE_ID_PATH = path.join(os.homedir(), ".kimi", "device_id");
+
+const MAX_REFRESH_RETRIES = 3;
+
+// ============================================================================
+// Device ID
+// ============================================================================
+
+function generateDeviceId(): string {
+	// UUID v4 without dashes (hex only, 32 chars)
+	return "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".replace(/x/g, () => Math.floor(Math.random() * 16).toString(16));
+}
+
+function getDeviceId(): string {
+	try {
+		if (fs.existsSync(DEVICE_ID_PATH)) {
+			const id = fs.readFileSync(DEVICE_ID_PATH, "utf-8").trim();
+			if (/^[0-9a-f]{32}$/i.test(id)) {
+				return id;
+			}
+		}
+	} catch {
+		// Fall through to generate
+	}
+
+	const id = generateDeviceId();
+	try {
+		fs.mkdirSync(path.dirname(DEVICE_ID_PATH), { recursive: true });
+		fs.writeFileSync(DEVICE_ID_PATH, id, "utf-8");
+	} catch {
+		// If we can't persist, just use the generated ID for this session
+	}
+	return id;
+}
+
+// ============================================================================
+// Header helpers
+// ============================================================================
+
+/**
+ * Strip non-ASCII characters from a string for use in HTTP header values.
+ */
+function asciiHeaderValue(value: string): string {
+	return value.replace(/[^\x20-\x7E]/g, "");
+}
+
+/**
+ * Determine the device model string, mirroring kimi-cli logic.
+ */
+function kimiDeviceModel(): string {
+	const platform = os.platform();
+	const machine = os.machine?.() || process.arch;
+
+	if (platform === "darwin") {
+		let version: string;
+		try {
+			version = execFileSync("sw_vers", ["-productVersion"], { encoding: "utf-8", timeout: 3000 }).trim();
+		} catch {
+			version = os.release();
+		}
+		return `macOS ${version} ${machine}`;
+	}
+
+	if (platform === "win32") {
+		const release = os.release();
+		const buildNumber = Number.parseInt(release.split(".").pop() || "0", 10);
+		const label = buildNumber >= 22000 ? "11" : "10";
+		return `Windows ${label} ${machine}`;
+	}
+
+	// Linux and other
+	return `${os.type()} ${os.release()} ${machine}`;
+}
+
+/**
+ * Build the standard set of headers required on every Kimi API request.
+ */
+export function buildKimiHeaders(): Record<string, string> {
+	return {
+		"User-Agent": USER_AGENT,
+		"X-Msh-Platform": "kimi_cli",
+		"X-Msh-Version": KIMI_CLI_VERSION,
+		"X-Msh-Device-Name": asciiHeaderValue(os.hostname()),
+		"X-Msh-Device-Model": asciiHeaderValue(kimiDeviceModel()),
+		"X-Msh-Device-Id": getDeviceId(),
+		"X-Msh-Os-Version": asciiHeaderValue(os.version?.() || `${os.type()} ${os.release()}`),
+	};
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type DeviceCodeResponse = {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	interval: number;
+	expires_in: number;
+};
+
+type TokenSuccessResponse = {
+	access_token: string;
+	refresh_token: string;
+	expires_in: number;
+};
+
+export type KimiModelInfo = {
+	id: string;
+	display_name: string;
+	context_length: number;
+	supports_reasoning?: boolean;
+	[key: string]: unknown;
+};
+
+type KimiCredentials = OAuthCredentials & {
+	modelId?: string;
+	contextLength?: number;
+	modelDisplay?: string;
+};
+
+// ============================================================================
+// Network helpers
+// ============================================================================
+
+async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
+	const response = await fetch(url, init);
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`${response.status} ${response.statusText}: ${text}`);
+	}
+	return response.json();
+}
+
+/**
+ * Sleep that can be interrupted by an AbortSignal.
+ */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+
+		const timeout = setTimeout(resolve, ms);
+
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+// ============================================================================
+// Model discovery
+// ============================================================================
+
+/**
+ * List available models from the Kimi API.
+ * Returns the model info array from the response's `data` field.
+ */
+export async function listModels(accessToken: string): Promise<KimiModelInfo[]> {
+	const raw = await fetchJson(`${API_BASE_URL}/models`, {
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			...buildKimiHeaders(),
+		},
+	});
+
+	if (!raw || typeof raw !== "object") {
+		throw new Error("Invalid models response");
+	}
+
+	const data = (raw as Record<string, unknown>).data;
+	if (!Array.isArray(data)) {
+		throw new Error("Invalid models response: expected data array");
+	}
+
+	return data as KimiModelInfo[];
+}
+
+// ============================================================================
+// Device flow
+// ============================================================================
+
+async function startDeviceFlow(): Promise<DeviceCodeResponse> {
+	const data = await fetchJson(OAUTH_DEVICE_AUTH_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			...buildKimiHeaders(),
+		},
+		body: new URLSearchParams({
+			client_id: OAUTH_CLIENT_ID,
+			scope: OAUTH_SCOPE,
+		}),
+	});
+
+	if (!data || typeof data !== "object") {
+		throw new Error("Invalid device code response");
+	}
+
+	const d = data as Record<string, unknown>;
+	const device_code = d.device_code;
+	const user_code = d.user_code;
+	const verification_uri = d.verification_uri;
+	const interval = d.interval;
+	const expires_in = d.expires_in;
+
+	if (
+		typeof device_code !== "string" ||
+		typeof user_code !== "string" ||
+		typeof verification_uri !== "string" ||
+		typeof interval !== "number" ||
+		typeof expires_in !== "number"
+	) {
+		throw new Error("Invalid device code response fields");
+	}
+
+	return { device_code, user_code, verification_uri, interval, expires_in };
+}
+
+async function pollForAccessToken(
+	deviceCode: string,
+	intervalSeconds: number,
+	expiresIn: number,
+	signal?: AbortSignal,
+): Promise<TokenSuccessResponse> {
+	const deadline = Date.now() + expiresIn * 1000;
+	let intervalMs = Math.max(1000, Math.floor(intervalSeconds * 1000));
+
+	while (Date.now() < deadline) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+
+		const remainingMs = deadline - Date.now();
+		const waitMs = Math.min(intervalMs, remainingMs);
+		await abortableSleep(waitMs, signal);
+
+		const raw = await fetchJson(OAUTH_TOKEN_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				...buildKimiHeaders(),
+			},
+			body: new URLSearchParams({
+				client_id: OAUTH_CLIENT_ID,
+				device_code: deviceCode,
+				grant_type: OAUTH_DEVICE_GRANT,
+			}),
+		});
+
+		if (raw && typeof raw === "object") {
+			const resp = raw as Record<string, unknown>;
+
+			// Success: has access_token
+			if (typeof resp.access_token === "string") {
+				return resp as unknown as TokenSuccessResponse;
+			}
+
+			// Error response
+			if (typeof resp.error === "string") {
+				const error = resp.error;
+				const description = resp.error_description as string | undefined;
+				const newInterval = resp.interval as number | undefined;
+
+				if (error === "authorization_pending") {
+					continue;
+				}
+
+				if (error === "slow_down") {
+					intervalMs =
+						typeof newInterval === "number" && newInterval > 0
+							? newInterval * 1000
+							: Math.max(1000, intervalMs + 5000);
+					continue;
+				}
+
+				if (error === "expired_token") {
+					throw new Error("Device code expired. Please try logging in again.");
+				}
+
+				const descriptionSuffix = description ? `: ${description}` : "";
+				throw new Error(`Device flow failed: ${error}${descriptionSuffix}`);
+			}
+		}
+	}
+
+	throw new Error("Device flow timed out");
+}
+
+// ============================================================================
+// Refresh with retry
+// ============================================================================
+
+const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
+
+class RetriableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RetriableError";
+	}
+}
+
+async function refreshWithRetry(refreshToken: string, signal?: AbortSignal): Promise<TokenSuccessResponse> {
+	let lastError: Error | undefined;
+
+	for (let attempt = 0; attempt < MAX_REFRESH_RETRIES; attempt++) {
+		if (signal?.aborted) {
+			throw new Error("Refresh cancelled");
+		}
+
+		try {
+			const response = await fetch(OAUTH_TOKEN_URL, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					...buildKimiHeaders(),
+				},
+				body: new URLSearchParams({
+					client_id: OAUTH_CLIENT_ID,
+					refresh_token: refreshToken,
+					grant_type: OAUTH_REFRESH_GRANT,
+				}),
+			});
+
+			// Retry on retriable status codes
+			if (RETRYABLE_STATUS_CODES.includes(response.status)) {
+				throw new RetriableError(`Token refresh failed with status ${response.status}`);
+			}
+
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`Token refresh failed: ${response.status} ${response.statusText}: ${text}`);
+			}
+
+			const raw = await response.json();
+			if (!raw || typeof raw !== "object" || typeof (raw as Record<string, unknown>).access_token !== "string") {
+				throw new Error("Invalid token refresh response");
+			}
+
+			return raw as unknown as TokenSuccessResponse;
+		} catch (error) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+
+			// Only retry on retriable errors (network failures or retriable HTTP status codes)
+			if (lastError instanceof RetriableError && attempt < MAX_REFRESH_RETRIES - 1) {
+				const backoffMs = Math.min(1000 * 2 ** attempt, 10000);
+				await new Promise((resolve) => setTimeout(resolve, backoffMs));
+				continue;
+			}
+
+			throw lastError;
+		}
+	}
+
+	throw lastError ?? new Error("Token refresh failed after retries");
+}
+
+// ============================================================================
+// Login flow
+// ============================================================================
+
+export async function loginKimiCoding(options: {
+	onAuth: (info: { url: string; instructions?: string }) => void;
+	onProgress?: (message: string) => void;
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	const device = await startDeviceFlow();
+	options.onAuth({
+		url: device.verification_uri,
+		instructions: `Enter code: ${device.user_code}`,
+	});
+
+	const tokenResp = await pollForAccessToken(device.device_code, device.interval, device.expires_in, options.signal);
+
+	// Discover model entitlement
+	options.onProgress?.("Discovering available models...");
+	const models = await listModels(tokenResp.access_token);
+
+	const credentials: KimiCredentials = {
+		refresh: tokenResp.refresh_token,
+		access: tokenResp.access_token,
+		expires: Date.now() + tokenResp.expires_in * 1000,
+	};
+
+	if (models.length > 0) {
+		const primary = models[0];
+		credentials.modelId = primary.id;
+		credentials.contextLength = primary.context_length;
+		credentials.modelDisplay = primary.display_name;
+	}
+
+	return credentials;
+}
+
+// ============================================================================
+// Refresh
+// ============================================================================
+
+export async function refreshKimiCodingToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+	const tokenResp = await refreshWithRetry(credentials.refresh);
+
+	// Re-discover model entitlement
+	const models = await listModels(tokenResp.access_token);
+
+	const fresh: KimiCredentials = {
+		refresh: tokenResp.refresh_token ?? credentials.refresh,
+		access: tokenResp.access_token,
+		expires: Date.now() + tokenResp.expires_in * 1000,
+	};
+
+	if (models.length > 0) {
+		const primary = models[0];
+		fresh.modelId = primary.id;
+		fresh.contextLength = primary.context_length;
+		fresh.modelDisplay = primary.display_name;
+	}
+
+	return fresh;
+}
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export const kimiCodingOAuthProvider: OAuthProviderInterface = {
+	id: "kimi-coding-oauth",
+	name: "Kimi For Coding",
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginKimiCoding({
+			onAuth: callbacks.onAuth,
+			onProgress: callbacks.onProgress,
+			signal: callbacks.signal,
+		});
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshKimiCodingToken(credentials);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+
+	modifyModels(models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[] {
+		const creds = credentials as KimiCredentials;
+		const headers = buildKimiHeaders();
+
+		return models.map((m) => {
+			if (m.provider !== "kimi-coding-oauth") return m;
+
+			const updated = {
+				...m,
+				headers: { ...headers, ...(m.headers || {}) },
+			};
+
+			if (creds.modelId) {
+				updated.id = creds.modelId;
+			}
+
+			if (creds.contextLength) {
+				updated.contextWindow = creds.contextLength;
+			}
+
+			return updated;
+		});
+	},
+};

--- a/packages/ai/test/kimi-coding-oauth.test.ts
+++ b/packages/ai/test/kimi-coding-oauth.test.ts
@@ -130,7 +130,7 @@ describe("Kimi For Coding OAuth", () => {
 							(c) => getUrl(c[0]) === TOKEN_URL && String(c[1]?.body).includes("grant_type=urn"),
 						).length;
 						if (callCount === 1) {
-							return jsonResponse({ error: "authorization_pending" });
+							return jsonResponse({ error: "authorization_pending" }, 400);
 						}
 						return jsonResponse(MOCK_TOKEN_SUCCESS);
 					}
@@ -155,9 +155,11 @@ describe("Kimi For Coding OAuth", () => {
 				},
 			});
 
-			// Auth callback was called with the verification URI and user code
+			// Auth callback was called with the verification URI including user_code
 			expect(authCalls).toHaveLength(1);
-			expect(authCalls[0].url).toBe("https://auth.kimi.com/device");
+			const authUrl = new URL(authCalls[0].url);
+			expect(authUrl.origin + authUrl.pathname).toBe("https://auth.kimi.com/device");
+			expect(authUrl.searchParams.get("user_code")).toBe("WXYZ-1234");
 			expect(authCalls[0].instructions).toContain("WXYZ-1234");
 
 			// Credentials include model discovery extras
@@ -179,8 +181,8 @@ describe("Kimi For Coding OAuth", () => {
 
 			const pollTimes: number[] = [];
 			const tokenResponses = [
-				jsonResponse({ error: "authorization_pending" }),
-				jsonResponse({ error: "authorization_pending" }),
+				jsonResponse({ error: "authorization_pending" }, 400),
+				jsonResponse({ error: "authorization_pending" }, 400),
 				jsonResponse(MOCK_TOKEN_SUCCESS),
 			];
 
@@ -234,8 +236,8 @@ describe("Kimi For Coding OAuth", () => {
 
 			const pollTimes: number[] = [];
 			const tokenResponses = [
-				jsonResponse({ error: "authorization_pending" }),
-				jsonResponse({ error: "slow_down", interval: 10 }),
+				jsonResponse({ error: "authorization_pending" }, 400),
+				jsonResponse({ error: "slow_down", interval: 10 }, 400),
 				jsonResponse(MOCK_TOKEN_SUCCESS),
 			];
 
@@ -300,7 +302,7 @@ describe("Kimi For Coding OAuth", () => {
 				}
 
 				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
-					return jsonResponse({ error: "expired_token", error_description: "code expired" });
+					return jsonResponse({ error: "expired_token", error_description: "code expired" }, 400);
 				}
 
 				throw new Error(`Unexpected URL: ${url}`);
@@ -338,7 +340,7 @@ describe("Kimi For Coding OAuth", () => {
 				}
 
 				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
-					return jsonResponse({ error: "authorization_pending" });
+					return jsonResponse({ error: "authorization_pending" }, 400);
 				}
 
 				throw new Error(`Unexpected URL: ${url}`);
@@ -376,7 +378,7 @@ describe("Kimi For Coding OAuth", () => {
 				}
 
 				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
-					return jsonResponse({ error: "authorization_pending" });
+					return jsonResponse({ error: "authorization_pending" }, 400);
 				}
 
 				throw new Error(`Unexpected URL: ${url}`);
@@ -408,7 +410,7 @@ describe("Kimi For Coding OAuth", () => {
 
 				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
 					pollCount++;
-					return jsonResponse({ error: "authorization_pending" });
+					return jsonResponse({ error: "authorization_pending" }, 400);
 				}
 
 				throw new Error(`Unexpected URL: ${url}`);

--- a/packages/ai/test/kimi-coding-oauth.test.ts
+++ b/packages/ai/test/kimi-coding-oauth.test.ts
@@ -361,6 +361,297 @@ describe("Kimi For Coding OAuth", () => {
 	});
 
 	// ------------------------------------------------------------------------
+	// Abort signal
+	// ------------------------------------------------------------------------
+	describe("abort signal", () => {
+		it("loginKimiCoding rejects with 'Login cancelled' when signal is aborted before polling", async () => {
+			const controller = new AbortController();
+			controller.abort();
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					return jsonResponse({ error: "authorization_pending" });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			await expect(
+				loginKimiCoding({
+					onAuth: () => {},
+					signal: controller.signal,
+				}),
+			).rejects.toThrow("Login cancelled");
+		});
+
+		it("loginKimiCoding rejects with 'Login cancelled' when signal is aborted during polling", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-04-17T00:00:00Z"));
+
+			const controller = new AbortController();
+			let pollCount = 0;
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					pollCount++;
+					return jsonResponse({ error: "authorization_pending" });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+				signal: controller.signal,
+			});
+
+			// First poll at interval (5s)
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(pollCount).toBe(1);
+
+			// Abort during the wait before the next poll
+			controller.abort();
+
+			await expect(loginPromise).rejects.toThrow("Login cancelled");
+		});
+
+		it("refreshWithRetry rejects with 'Refresh cancelled' when signal is aborted", async () => {
+			const controller = new AbortController();
+			controller.abort();
+
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+				if (url === TOKEN_URL) {
+					return new Response("service unavailable", { status: 503 });
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			// Call refreshKimiCodingToken with signal to test the underlying refreshWithRetry
+			await expect(
+				refreshKimiCodingToken(
+					{
+						refresh: "old-refresh",
+						access: "old-access",
+						expires: 0,
+					},
+					controller.signal,
+				),
+			).rejects.toThrow("Refresh cancelled");
+
+			// Should not have made any fetch calls
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// Network error retry
+	// ------------------------------------------------------------------------
+	describe("network error retry in refresh", () => {
+		it("retries on TypeError (network failure) and then succeeds", async () => {
+			let tokenCall = 0;
+
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					tokenCall++;
+					if (tokenCall === 1) {
+						throw new TypeError("fetch failed");
+					}
+					return jsonResponse({
+						access_token: "retried-access",
+						refresh_token: "retried-refresh",
+						expires_in: 3600,
+					});
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const fresh = await refreshKimiCodingToken({
+				refresh: "old-refresh",
+				access: "old-access",
+				expires: 0,
+			});
+
+			expect(fresh.access).toBe("retried-access");
+			expect(tokenCall).toBe(2);
+		});
+
+		it("retries on ECONNREFUSED and then succeeds", async () => {
+			let tokenCall = 0;
+
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					tokenCall++;
+					if (tokenCall === 1) {
+						throw new Error("connect ECONNREFUSED 127.0.0.1:443");
+					}
+					return jsonResponse({
+						access_token: "retried-access",
+						refresh_token: "retried-refresh",
+						expires_in: 3600,
+					});
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const fresh = await refreshKimiCodingToken({
+				refresh: "old-refresh",
+				access: "old-access",
+				expires: 0,
+			});
+
+			expect(fresh.access).toBe("retried-access");
+			expect(tokenCall).toBe(2);
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// Unexpected poll response
+	// ------------------------------------------------------------------------
+	describe("unexpected poll response", () => {
+		it("throws on response object with neither access_token nor error", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-04-17T00:00:00Z"));
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					return jsonResponse({ foo: "bar", baz: 42 });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+			});
+
+			const rejection = expect(loginPromise).rejects.toThrow("Unexpected token response");
+
+			await vi.advanceTimersByTimeAsync(5000);
+
+			await rejection;
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// listModels failure resilience
+	// ------------------------------------------------------------------------
+	describe("listModels failure resilience", () => {
+		it("loginKimiCoding proceeds without model enrichment when listModels fails", async () => {
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL) {
+					if (String(init?.body).includes("grant_type=urn")) {
+						return jsonResponse(MOCK_TOKEN_SUCCESS);
+					}
+					throw new Error(`Unexpected TOKEN_URL call`);
+				}
+
+				if (url === MODELS_URL) {
+					throw new Error("Models endpoint is down");
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const creds = await loginKimiCoding({
+				onAuth: () => {},
+				onProgress: () => {},
+			});
+
+			expect(creds.access).toBe("kimi-access-token-123");
+			expect(creds.refresh).toBe("kimi-refresh-token-456");
+			expect(creds.modelId).toBeUndefined();
+			expect(creds.contextLength).toBeUndefined();
+			expect(creds.modelDisplay).toBeUndefined();
+		});
+
+		it("refreshKimiCodingToken proceeds without model enrichment when listModels fails", async () => {
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					return jsonResponse({
+						access_token: "new-access",
+						refresh_token: "new-refresh",
+						expires_in: 3600,
+					});
+				}
+
+				if (url === MODELS_URL) {
+					throw new Error("Models endpoint is down");
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const fresh = await refreshKimiCodingToken({
+				refresh: "old-refresh",
+				access: "old-access",
+				expires: 0,
+			});
+
+			expect(fresh.access).toBe("new-access");
+			expect(fresh.refresh).toBe("new-refresh");
+			expect(fresh.modelId).toBeUndefined();
+			expect(fresh.contextLength).toBeUndefined();
+		});
+	});
+
+	// ------------------------------------------------------------------------
 	// Token refresh
 	// ------------------------------------------------------------------------
 	describe("refreshKimiCodingToken", () => {

--- a/packages/ai/test/kimi-coding-oauth.test.ts
+++ b/packages/ai/test/kimi-coding-oauth.test.ts
@@ -1,0 +1,613 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	buildKimiHeaders,
+	kimiCodingOAuthProvider,
+	loginKimiCoding,
+	refreshKimiCodingToken,
+} from "../src/utils/oauth/kimi-coding.js";
+import type { OAuthCredentials } from "../src/utils/oauth/types.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+const DEVICE_AUTH_URL = "https://auth.kimi.com/api/oauth/device_authorization";
+const TOKEN_URL = "https://auth.kimi.com/api/oauth/token";
+const MODELS_URL = "https://api.kimi.com/coding/v1/models";
+
+const MOCK_DEVICE_CODE_RESPONSE = {
+	device_code: "test-device-code",
+	user_code: "WXYZ-1234",
+	verification_uri: "https://auth.kimi.com/device",
+	interval: 5,
+	expires_in: 900,
+};
+
+const MOCK_TOKEN_SUCCESS = {
+	access_token: "kimi-access-token-123",
+	refresh_token: "kimi-refresh-token-456",
+	expires_in: 3600,
+};
+
+const MOCK_MODELS_RESPONSE = {
+	data: [
+		{
+			id: "kimi-k2-0715-chat",
+			display_name: "Kimi K2",
+			context_length: 131072,
+			supports_reasoning: true,
+		},
+	],
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Kimi For Coding OAuth", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	// ------------------------------------------------------------------------
+	// buildKimiHeaders
+	// ------------------------------------------------------------------------
+	describe("buildKimiHeaders", () => {
+		it("returns all required headers", () => {
+			const headers = buildKimiHeaders();
+			expect(headers["User-Agent"]).toBe("KimiCLI/1.35.0");
+			expect(headers["X-Msh-Platform"]).toBe("kimi_cli");
+			expect(headers["X-Msh-Version"]).toBe("1.35.0");
+			expect(headers["X-Msh-Device-Name"]).toBeTruthy();
+			expect(headers["X-Msh-Device-Model"]).toBeTruthy();
+			expect(headers["X-Msh-Device-Id"]).toBeTruthy();
+			expect(headers["X-Msh-Os-Version"]).toBeTruthy();
+		});
+
+		it("produces a valid hex device ID", () => {
+			const headers = buildKimiHeaders();
+			const deviceId = headers["X-Msh-Device-Id"];
+			expect(deviceId).toMatch(/^[0-9a-f]{32}$/);
+		});
+
+		it("strips non-ASCII from header values", () => {
+			// If hostname had non-ASCII, it would be stripped.
+			// We can't easily control os.hostname(), but we can verify the result is ASCII.
+			const headers = buildKimiHeaders();
+			for (const value of Object.values(headers)) {
+				expect(value).toMatch(/^[\x20-\x7E]*$/);
+			}
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// Device flow login
+	// ------------------------------------------------------------------------
+	describe("loginKimiCoding", () => {
+		it("completes device flow and discovers models", async () => {
+			const authCalls: { url: string; instructions?: string }[] = [];
+			const progressCalls: string[] = [];
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					expect(init?.method).toBe("POST");
+					expect(String(init?.body)).toContain("client_id=17e5f671-d194-4dfb-9706-5516cb48c098");
+					expect(String(init?.body)).toContain("scope=kimi-code");
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL) {
+					// First poll returns pending, second returns success
+					if (init?.body && String(init.body).includes("grant_type=urn")) {
+						// It's a device code token poll
+						const callCount = fetchMock.mock.calls.filter(
+							(c) => getUrl(c[0]) === TOKEN_URL && String(c[1]?.body).includes("grant_type=urn"),
+						).length;
+						if (callCount === 1) {
+							return jsonResponse({ error: "authorization_pending" });
+						}
+						return jsonResponse(MOCK_TOKEN_SUCCESS);
+					}
+					throw new Error(`Unexpected TOKEN_URL call: ${String(init?.body)}`);
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const creds = await loginKimiCoding({
+				onAuth: (info) => {
+					authCalls.push(info);
+				},
+				onProgress: (msg) => {
+					progressCalls.push(msg);
+				},
+			});
+
+			// Auth callback was called with the verification URI and user code
+			expect(authCalls).toHaveLength(1);
+			expect(authCalls[0].url).toBe("https://auth.kimi.com/device");
+			expect(authCalls[0].instructions).toContain("WXYZ-1234");
+
+			// Credentials include model discovery extras
+			expect(creds.refresh).toBe("kimi-refresh-token-456");
+			expect(creds.access).toBe("kimi-access-token-123");
+			expect(creds.expires).toBeGreaterThan(Date.now());
+			expect(creds.modelId).toBe("kimi-k2-0715-chat");
+			expect(creds.contextLength).toBe(131072);
+			expect(creds.modelDisplay).toBe("Kimi K2");
+
+			// Progress was reported
+			expect(progressCalls).toContain("Discovering available models...");
+		});
+
+		it("polls with authorization_pending then succeeds", async () => {
+			vi.useFakeTimers();
+			const startTime = new Date("2026-04-17T00:00:00Z");
+			vi.setSystemTime(startTime);
+
+			const pollTimes: number[] = [];
+			const tokenResponses = [
+				jsonResponse({ error: "authorization_pending" }),
+				jsonResponse({ error: "authorization_pending" }),
+				jsonResponse(MOCK_TOKEN_SUCCESS),
+			];
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					pollTimes.push(Date.now());
+					const resp = tokenResponses.shift();
+					if (!resp) throw new Error("Unexpected extra poll");
+					return resp;
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+			});
+
+			// First poll at interval (5s)
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(pollTimes).toHaveLength(1);
+
+			// Second poll at +5s
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(pollTimes).toHaveLength(2);
+
+			// Third poll at +5s — success
+			await vi.advanceTimersByTimeAsync(5000);
+			const creds = await loginPromise;
+
+			expect(pollTimes).toHaveLength(3);
+			expect(creds.access).toBe("kimi-access-token-123");
+		});
+
+		it("increases interval on slow_down", async () => {
+			vi.useFakeTimers();
+			const startTime = new Date("2026-04-17T00:00:00Z");
+			vi.setSystemTime(startTime);
+
+			const pollTimes: number[] = [];
+			const tokenResponses = [
+				jsonResponse({ error: "authorization_pending" }),
+				jsonResponse({ error: "slow_down", interval: 10 }),
+				jsonResponse(MOCK_TOKEN_SUCCESS),
+			];
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					pollTimes.push(Date.now());
+					const resp = tokenResponses.shift();
+					if (!resp) throw new Error("Unexpected extra poll");
+					return resp;
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+			});
+
+			// First poll at 5s
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(pollTimes).toHaveLength(1);
+			expect(pollTimes[0]).toBe(startTime.getTime() + 5000);
+
+			// Second poll at +5s (still on original interval)
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(pollTimes).toHaveLength(2);
+			expect(pollTimes[1]).toBe(startTime.getTime() + 10000);
+
+			// After slow_down with interval=10, next poll should be at +10s
+			await vi.advanceTimersByTimeAsync(9999);
+			expect(pollTimes).toHaveLength(2);
+
+			await vi.advanceTimersByTimeAsync(1);
+			const creds = await loginPromise;
+
+			expect(pollTimes).toHaveLength(3);
+			expect(pollTimes[2]).toBe(startTime.getTime() + 20000);
+			expect(creds.access).toBe("kimi-access-token-123");
+		});
+
+		it("throws on expired_token", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-04-17T00:00:00Z"));
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					return jsonResponse(MOCK_DEVICE_CODE_RESPONSE);
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					return jsonResponse({ error: "expired_token", error_description: "code expired" });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+			});
+
+			// Attach rejection handler before advancing timers
+			const rejection = expect(loginPromise).rejects.toThrow("Device code expired");
+
+			// Advance to trigger first poll
+			await vi.advanceTimersByTimeAsync(5000);
+
+			await rejection;
+		});
+
+		it("throws on timeout when deadline passes", async () => {
+			vi.useFakeTimers();
+			const startTime = new Date("2026-04-17T00:00:00Z");
+			vi.setSystemTime(startTime);
+
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === DEVICE_AUTH_URL) {
+					// Very short expiry (1 second)
+					return jsonResponse({
+						...MOCK_DEVICE_CODE_RESPONSE,
+						expires_in: 1,
+					});
+				}
+
+				if (url === TOKEN_URL && String(init?.body).includes("grant_type=urn")) {
+					return jsonResponse({ error: "authorization_pending" });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const loginPromise = loginKimiCoding({
+				onAuth: () => {},
+			});
+
+			// Attach rejection handler before advancing timers
+			const rejection = expect(loginPromise).rejects.toThrow("Device flow timed out");
+
+			// Advance past the 1-second deadline
+			await vi.advanceTimersByTimeAsync(2000);
+
+			await rejection;
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// Token refresh
+	// ------------------------------------------------------------------------
+	describe("refreshKimiCodingToken", () => {
+		it("refreshes token and rediscovers models", async () => {
+			const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					expect(String(init?.body)).toContain("grant_type=refresh_token");
+					expect(String(init?.body)).toContain("refresh_token=old-refresh");
+					return jsonResponse({
+						access_token: "new-access",
+						refresh_token: "new-refresh",
+						expires_in: 3600,
+					});
+				}
+
+				if (url === MODELS_URL) {
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const oldCreds: OAuthCredentials = {
+				refresh: "old-refresh",
+				access: "old-access",
+				expires: Date.now() - 1000,
+			};
+
+			const fresh = await refreshKimiCodingToken(oldCreds);
+
+			expect(fresh.access).toBe("new-access");
+			expect(fresh.refresh).toBe("new-refresh");
+			expect(fresh.expires).toBeGreaterThan(Date.now());
+			expect(fresh.modelId).toBe("kimi-k2-0715-chat");
+			expect(fresh.contextLength).toBe(131072);
+		});
+
+		it("retries on 429 and then succeeds", async () => {
+			const callOrder: string[] = [];
+			let tokenCall = 0;
+
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					tokenCall++;
+					callOrder.push(`token-${tokenCall}`);
+					if (tokenCall === 1) {
+						return new Response("rate limited", { status: 429 });
+					}
+					return jsonResponse({
+						access_token: "retried-access",
+						refresh_token: "retried-refresh",
+						expires_in: 3600,
+					});
+				}
+
+				if (url === MODELS_URL) {
+					callOrder.push("models");
+					return jsonResponse(MOCK_MODELS_RESPONSE);
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			const fresh = await refreshKimiCodingToken({
+				refresh: "old-refresh",
+				access: "old-access",
+				expires: 0,
+			});
+
+			expect(fresh.access).toBe("retried-access");
+			expect(callOrder).toEqual(["token-1", "token-2", "models"]);
+		});
+
+		it("retries on 503 with exponential backoff and eventually fails", async () => {
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					return new Response("service unavailable", { status: 503 });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			await expect(
+				refreshKimiCodingToken({
+					refresh: "old-refresh",
+					access: "old-access",
+					expires: 0,
+				}),
+			).rejects.toThrow("503");
+
+			// Should have been called 3 times (MAX_REFRESH_RETRIES)
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+
+		it("fails immediately on non-retriable errors", async () => {
+			const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+
+				if (url === TOKEN_URL) {
+					return new Response("bad request", { status: 400 });
+				}
+
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			vi.stubGlobal("fetch", fetchMock);
+
+			await expect(
+				refreshKimiCodingToken({
+					refresh: "old-refresh",
+					access: "old-access",
+					expires: 0,
+				}),
+			).rejects.toThrow("400");
+
+			// Should NOT retry on 400
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// getApiKey
+	// ------------------------------------------------------------------------
+	describe("getApiKey", () => {
+		it("returns the access token", () => {
+			const creds: OAuthCredentials = {
+				refresh: "r",
+				access: "my-access-token",
+				expires: Date.now() + 1000,
+			};
+			expect(kimiCodingOAuthProvider.getApiKey(creds)).toBe("my-access-token");
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// modifyModels
+	// ------------------------------------------------------------------------
+	describe("modifyModels", () => {
+		it("injects Kimi headers and updates model id and contextWindow", () => {
+			const creds: OAuthCredentials & {
+				modelId?: string;
+				contextLength?: number;
+			} = {
+				refresh: "r",
+				access: "a",
+				expires: Date.now() + 1000,
+				modelId: "kimi-k2-0715-chat",
+				contextLength: 131072,
+			};
+
+			const models = [
+				{
+					id: "kimi-default",
+					name: "Kimi",
+					api: "openai-completions" as const,
+					provider: "kimi-coding-oauth",
+					baseUrl: "https://api.kimi.com/coding/v1",
+					reasoning: false,
+					input: ["text"] as ("text" | "image")[],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 32768,
+					maxTokens: 4096,
+				},
+				{
+					id: "other-model",
+					name: "Other",
+					api: "openai-completions" as const,
+					provider: "other-provider",
+					baseUrl: "https://other.example.com",
+					reasoning: false,
+					input: ["text"] as ("text" | "image")[],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 8192,
+					maxTokens: 2048,
+				},
+			];
+
+			const result = kimiCodingOAuthProvider.modifyModels!(models, creds);
+
+			// First model should be updated
+			expect(result[0].id).toBe("kimi-k2-0715-chat");
+			expect(result[0].contextWindow).toBe(131072);
+			expect(result[0].headers).toMatchObject({
+				"User-Agent": "KimiCLI/1.35.0",
+				"X-Msh-Platform": "kimi_cli",
+				"X-Msh-Version": "1.35.0",
+			});
+
+			// Second model should be unchanged
+			expect(result[1].id).toBe("other-model");
+			expect(result[1].contextWindow).toBe(8192);
+			expect(result[1].headers).toBeUndefined();
+		});
+
+		it("does not modify model id when credentials lack modelId", () => {
+			const creds: OAuthCredentials = {
+				refresh: "r",
+				access: "a",
+				expires: Date.now() + 1000,
+			};
+
+			const models = [
+				{
+					id: "kimi-default",
+					name: "Kimi",
+					api: "openai-completions" as const,
+					provider: "kimi-coding-oauth",
+					baseUrl: "https://api.kimi.com/coding/v1",
+					reasoning: false,
+					input: ["text"] as ("text" | "image")[],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 32768,
+					maxTokens: 4096,
+				},
+			];
+
+			const result = kimiCodingOAuthProvider.modifyModels!(models, creds);
+
+			// Headers still injected
+			expect(result[0].headers).toMatchObject({
+				"X-Msh-Platform": "kimi_cli",
+			});
+			// But id and contextWindow unchanged
+			expect(result[0].id).toBe("kimi-default");
+			expect(result[0].contextWindow).toBe(32768);
+		});
+	});
+
+	// ------------------------------------------------------------------------
+	// Provider metadata
+	// ------------------------------------------------------------------------
+	describe("provider metadata", () => {
+		it("has correct id and name", () => {
+			expect(kimiCodingOAuthProvider.id).toBe("kimi-coding-oauth");
+			expect(kimiCodingOAuthProvider.name).toBe("Kimi For Coding");
+		});
+	});
+});

--- a/packages/ai/test/openai-completions-kimi.test.ts
+++ b/packages/ai/test/openai-completions-kimi.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { streamSimple } from "../src/stream.js";
+import type { Model } from "../src/types.js";
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: async (params: unknown) => {
+					mockState.lastParams = params;
+					return {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								choices: [{ delta: {}, finish_reason: "stop" }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							};
+						},
+					};
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+const KIMI_MODEL: Model<"openai-completions"> = {
+	api: "openai-completions",
+	provider: "kimi-coding",
+	id: "kimi-k2-0711",
+	name: "Kimi K2",
+	baseUrl: "https://api.kimi.com/v1",
+	input: ["text"],
+	reasoning: true,
+	contextWindow: 131072,
+	maxTokens: 16384,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	compat: { thinkingFormat: "kimi" },
+};
+
+describe("openai-completions kimi thinkingFormat", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("sets thinking enabled + reasoning_effort when reasoning is specified", async () => {
+		let payload: unknown;
+
+		await streamSimple(
+			KIMI_MODEL,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				reasoning: "medium",
+				sessionId: "sess-123",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toEqual({ type: "enabled" });
+		expect(params.reasoning_effort).toBe("medium");
+		expect(params.prompt_cache_key).toBe("sess-123");
+	});
+
+	it("sets thinking disabled when mapped effort is 'off'", async () => {
+		const model: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			compat: {
+				thinkingFormat: "kimi",
+				reasoningEffortMap: { minimal: "off" },
+			},
+		};
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				reasoning: "minimal",
+				sessionId: "sess-456",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toEqual({ type: "disabled" });
+		expect(params.reasoning_effort).toBeUndefined();
+		expect(params.prompt_cache_key).toBe("sess-456");
+	});
+
+	it("omits thinking and reasoning_effort when mapped effort is 'auto'", async () => {
+		const model: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			compat: {
+				thinkingFormat: "kimi",
+				reasoningEffortMap: { low: "auto" },
+			},
+		};
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				reasoning: "low",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
+		expect(params.prompt_cache_key).toBeUndefined();
+	});
+
+	it("omits thinking/reasoning fields when no reasoning is specified", async () => {
+		let payload: unknown;
+
+		await streamSimple(
+			KIMI_MODEL,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				sessionId: "sess-789",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
+		expect(params.prompt_cache_key).toBe("sess-789");
+	});
+
+	it("omits prompt_cache_key when no sessionId is provided", async () => {
+		let payload: unknown;
+
+		await streamSimple(
+			KIMI_MODEL,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				reasoning: "high",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toEqual({ type: "enabled" });
+		expect(params.reasoning_effort).toBe("high");
+		expect(params.prompt_cache_key).toBeUndefined();
+	});
+
+	it("does not set thinking fields when model has reasoning: false", async () => {
+		const nonReasoningModel: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			reasoning: false,
+		};
+		let payload: unknown;
+
+		await streamSimple(
+			nonReasoningModel,
+			{
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				reasoning: "medium",
+				sessionId: "sess-noreason",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = (payload ?? mockState.lastParams) as {
+			thinking?: { type: string };
+			reasoning_effort?: string;
+			prompt_cache_key?: string;
+		};
+		expect(params.thinking).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
+		// prompt_cache_key is set inside the kimi branch which requires model.reasoning
+		expect(params.prompt_cache_key).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -91,6 +91,7 @@ For each built-in provider, dreb maintains a list of tool-capable models, update
 - GitHub Copilot
 - Google Gemini CLI
 - Google Antigravity
+- Kimi For Coding
 
 **API keys:**
 - Anthropic

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -19,6 +19,7 @@ Use `/login` in interactive mode, then select a provider:
 - GitHub Copilot
 - Google Gemini CLI
 - Google Antigravity
+- Kimi For Coding (requires active Kimi For Coding subscription)
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.dreb/agent/auth.json` and auto-refresh when expired.
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -34,6 +34,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	opencode: "claude-opus-4-6",
 	"opencode-go": "kimi-k2.5",
 	"kimi-coding": "kimi-k2-thinking",
+	"kimi-coding-oauth": "kimi-for-coding",
 };
 
 export interface ScopedModel {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #174

Add a new built-in OAuth provider `kimi-coding-oauth` that uses device flow against auth.kimi.com to access the K2.6-code-preview model via api.kimi.com/coding/v1.

Implementation plan posted as a comment below.