### PR TITLE
Final fallback to parent model when all subagent fallbacks fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.10.0",
+			"version": "2.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2693,6 +2693,7 @@ export class AgentSession {
 					},
 					subagent: {
 						parentProvider: () => this.model?.provider,
+						parentModel: () => this.model?.id,
 						modelRegistry: this._modelRegistry,
 						onBackgroundStart: (agentId, agentType, taskSummary) => {
 							this._emit({ type: "background_agent_start", agentId, agentType, taskSummary });

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -432,7 +432,8 @@ export function resolveModelWithFallbacks(
 	models: string | string[],
 	parentProvider: string | undefined,
 	registry: ModelRegistry | undefined,
-): { ok: true; modelId: string; provider?: string } | { ok: false; error: string } {
+	parentModel?: string,
+): { ok: true; modelId: string; provider?: string; warning?: string } | { ok: false; error: string } {
 	const modelList = Array.isArray(models) ? models : [models];
 	let lastError = "";
 	for (const modelStr of modelList) {
@@ -440,10 +441,21 @@ export function resolveModelWithFallbacks(
 		if (result.ok) return result;
 		lastError = result.error;
 	}
-	if (modelList.length > 1) {
+	// After all configured fallbacks are exhausted, try the parent model as a last resort
+	if (parentModel) {
+		const result = resolveModelStringSingle(parentModel, parentProvider, registry);
+		if (result.ok) {
+			return {
+				...result,
+				warning: `Agent preferred models were unavailable. Falling back to parent model "${result.modelId}".`,
+			};
+		}
+		lastError = result.error;
+	}
+	if (modelList.length > 1 || parentModel) {
 		return {
 			ok: false,
-			error: `None of the fallback models resolved: ${modelList.join(", ")}. Last error: ${lastError}`,
+			error: `None of the fallback models resolved: ${[...modelList, ...(parentModel ? [parentModel] : [])].join(", ")}. Last error: ${lastError}`,
 		};
 	}
 	return { ok: false, error: lastError };
@@ -553,6 +565,7 @@ async function executeSingle(
 	parentProvider?: string,
 	registry?: ModelRegistry,
 	sessionDir?: string,
+	parentModel?: string,
 ): Promise<SubagentResult> {
 	const name = agentName || DEFAULT_AGENT;
 	const config = agents.get(name);
@@ -582,13 +595,14 @@ async function executeSingle(
 	const modelSpec = modelOverride || config.model;
 	let effectiveConfig: AgentTypeConfig = modelOverride ? { ...config, model: modelOverride } : config;
 	let resolvedProvider = parentProvider;
+	let warning: string | undefined;
 
 	// Resolve and validate the model against the registry before spawning.
 	// This catches typos and invalid model names immediately instead of failing
 	// silently in the child process. Also passes the canonical model ID to the
 	// child, avoiding fuzzy matching entirely.
 	if (modelSpec) {
-		const resolved = resolveModelWithFallbacks(modelSpec, parentProvider, registry);
+		const resolved = resolveModelWithFallbacks(modelSpec, parentProvider, registry, parentModel);
 		if (!resolved.ok) {
 			return {
 				agent: name,
@@ -603,10 +617,15 @@ async function executeSingle(
 		if (resolved.provider) {
 			resolvedProvider = resolved.provider;
 		}
+		warning = resolved.warning;
 	}
 
 	onProgress?.(`Running ${name} agent...`);
-	return spawnSubagent(effectiveConfig, task, cwd, signal, onProgress, resolvedProvider, sessionDir);
+	const result = await spawnSubagent(effectiveConfig, task, cwd, signal, onProgress, resolvedProvider, sessionDir);
+	if (warning) {
+		result.output = `[WARNING: ${warning}]\n\n${result.output}`;
+	}
+	return result;
 }
 
 async function executeChain(
@@ -620,6 +639,7 @@ async function executeChain(
 	sessionBaseDir?: string,
 	defaultAgent?: string,
 	defaultModel?: string,
+	parentModel?: string,
 ): Promise<SubagentResult[]> {
 	const results: SubagentResult[] = [];
 	let previousOutput = "";
@@ -669,6 +689,7 @@ async function executeChain(
 			parentProvider,
 			registry,
 			stepSessionDir,
+			parentModel,
 		);
 		results.push(result);
 
@@ -744,6 +765,8 @@ export interface SubagentToolOptions {
 	onBackgroundComplete?: (agentId: string, result: SubagentResult, cancelled: boolean) => void;
 	/** Parent session's current provider (e.g. "anthropic"). Called at each invocation to get the live value after mid-session model switches. */
 	parentProvider?: () => string | undefined;
+	/** Parent session's current model ID. Used as a final fallback when all subagent-configured models fail to resolve. Called at each invocation for fresh value. */
+	parentModel?: () => string | undefined;
 	/** Model registry for validating model names before spawning child processes. */
 	modelRegistry?: ModelRegistry;
 }
@@ -903,6 +926,7 @@ export function createSubagentToolDefinition(
 	const onBackgroundStart = options?.onBackgroundStart;
 	const onBackgroundComplete = options?.onBackgroundComplete;
 	const getParentProvider = options?.parentProvider ?? (() => undefined);
+	const getParentModel = options?.parentModel ?? (() => undefined);
 	const modelRegistry = options?.modelRegistry;
 
 	// Discover agents at definition time to build the prompt guidelines.
@@ -1093,6 +1117,7 @@ export function createSubagentToolDefinition(
 							getParentProvider(),
 							modelRegistry,
 							sessionDir,
+							getParentModel(),
 						),
 					);
 				};
@@ -1182,6 +1207,7 @@ export function createSubagentToolDefinition(
 							chainSessionDir,
 							params.agent,
 							params.model,
+							getParentModel(),
 						);
 						const resultText = results
 							.map((r, i) => `### Step ${i + 1}\n${formatSingleResult(r)}`)

--- a/packages/coding-agent/test/subagent-model-fallback.test.ts
+++ b/packages/coding-agent/test/subagent-model-fallback.test.ts
@@ -367,4 +367,128 @@ describe("model fallback lists", () => {
 			}
 		});
 	});
+
+	describe("resolveModelWithFallbacks — parent model final fallback (issue 176)", () => {
+		const parentModels: Model<"anthropic-messages">[] = [
+			{
+				id: "claude-sonnet-4-5",
+				name: "Claude Sonnet 4.5",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+				contextWindow: 200000,
+				maxTokens: 8192,
+			},
+			{
+				id: "gpt-4o",
+				name: "GPT-4o",
+				api: "anthropic-messages",
+				provider: "openai",
+				baseUrl: "https://api.openai.com",
+				reasoning: false,
+				input: ["text", "image"],
+				cost: { input: 5, output: 15, cacheRead: 0.5, cacheWrite: 5 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+			},
+		];
+
+		const registry = {
+			getAll: () => parentModels,
+			authStorage: { hasAuth: () => true },
+		} as unknown as Parameters<typeof resolveModelWithFallbacks>[2];
+
+		test("parent model is used when all configured fallbacks fail", () => {
+			// Parent is running openai/gpt-4o; configured fallbacks are anthropic-only unknown models
+			const result = resolveModelWithFallbacks(["nonexistent-a", "nonexistent-b"], "openai", registry, "gpt-4o");
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.modelId).toBe("gpt-4o");
+				expect(result.provider).toBe("openai");
+				expect(result.warning).toContain("Falling back to parent model");
+				expect(result.warning).toContain("gpt-4o");
+			}
+		});
+
+		test("parent model is only tried after configured fallbacks are exhausted", () => {
+			// First configured fallback succeeds — parent model should not be tried
+			const result = resolveModelWithFallbacks(
+				["claude-sonnet-4-5", "nonexistent-b"],
+				"anthropic",
+				registry,
+				"gpt-4o",
+			);
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.modelId).toBe("claude-sonnet-4-5");
+				expect(result.warning).toBeUndefined();
+			}
+		});
+
+		test("if parent model also fails, existing error behavior is preserved", () => {
+			const result = resolveModelWithFallbacks(
+				["nonexistent-a", "nonexistent-b"],
+				"anthropic",
+				registry,
+				"also-nonexistent",
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toContain("None of the fallback models resolved");
+				expect(result.error).toContain("nonexistent-a");
+				expect(result.error).toContain("nonexistent-b");
+				expect(result.error).toContain("also-nonexistent");
+			}
+		});
+
+		test("single configured model fails, parent model succeeds", () => {
+			// Parent is running openai/gpt-4o
+			const result = resolveModelWithFallbacks("nonexistent-model", "openai", registry, "gpt-4o");
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.modelId).toBe("gpt-4o");
+				expect(result.warning).toBeDefined();
+			}
+		});
+
+		test("without parentModel, all failing returns original error", () => {
+			const result = resolveModelWithFallbacks(["nonexistent-a", "nonexistent-b"], "anthropic", registry);
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toContain("None of the fallback models resolved");
+				expect(result.error).not.toContain("also-nonexistent");
+			}
+		});
+
+		test("parent model with provider prefix resolves correctly", () => {
+			const result = resolveModelWithFallbacks(["nonexistent-model"], undefined, registry, "openai/gpt-4o");
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.modelId).toBe("gpt-4o");
+				expect(result.provider).toBe("openai");
+			}
+		});
+
+		test("lazy parentModel getter pattern — fresh value after switch", () => {
+			// Simulate mutable session state
+			let currentModel = "claude-sonnet-4-5";
+			const getParentModel = () => currentModel;
+
+			// First call: parent model is claude
+			const before = resolveModelWithFallbacks(["nonexistent-model"], "anthropic", registry, getParentModel());
+			expect(before.ok).toBe(true);
+			if (before.ok) expect(before.modelId).toBe("claude-sonnet-4-5");
+
+			// Simulate mid-session model switch
+			currentModel = "gpt-4o";
+
+			// Second call: parent model is now gpt-4o
+			const after = resolveModelWithFallbacks(["nonexistent-model"], "openai", registry, getParentModel());
+			expect(after.ok).toBe(true);
+			if (after.ok) expect(after.modelId).toBe("gpt-4o");
+		});
+	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #176

When a subagent's configured model fallback list is exhausted, attempt the parent/orchestrator agent's model as a final fallback with a visible warning.

Implementation plan posted as a comment below.