### PR TITLE
Tighten gh CLI instructions across mach6 skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -515,8 +515,8 @@ describe("Context overflow error handling", () => {
 		}, 120000);
 
 		// Meta/Llama backend
-		it("meta-llama/llama-4-maverick via OpenRouter - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("openrouter", "meta-llama/llama-4-maverick");
+		it("meta-llama/llama-4-scout via OpenRouter - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("openrouter", "meta-llama/llama-4-scout");
 			const result = await testContextOverflow(model, process.env.OPENROUTER_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -491,10 +491,10 @@ describe("totalTokens field", () => {
 		);
 
 		it(
-			"meta-llama/llama-4-maverick - should return totalTokens equal to sum of components",
+			"meta-llama/llama-4-scout - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openrouter", "meta-llama/llama-4-maverick");
+				const llm = getModel("openrouter", "meta-llama/llama-4-scout");
 
 				console.log(`\nOpenRouter / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.OPENROUTER_API_KEY });

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/skills/mach6-implement/SKILL.md
+++ b/packages/coding-agent/skills/mach6-implement/SKILL.md
@@ -18,6 +18,7 @@ This skill has two modes:
 2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
 3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 ## Step 1: Parse input
 
@@ -120,6 +121,8 @@ tasks_update([
 gh pr checks <pr-number>
 gh run view <run-id> --log-failed
 ```
+
+**Note:** `gh pr checks` returns exit code 8 while checks are still pending — this is expected, not a failure. Wait and re-run if needed.
 
 Read the failed CI logs and identify issues. Extract test failures, stack traces, error messages. If all checks pass, report this and stop.
 

--- a/packages/coding-agent/skills/mach6-issue/SKILL.md
+++ b/packages/coding-agent/skills/mach6-issue/SKILL.md
@@ -16,6 +16,7 @@ argument-hint: "[issue-number | description]"
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
 5. **Task tracking** — Use the `tasks_update` tool to show progress through multi-step commands.
 6. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning or implementing.
+7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 ## Determine Mode
 
@@ -75,13 +76,16 @@ Present to the user:
 Post as an issue comment:
 
 ```bash
-gh issue comment <number> --body "<!-- mach6-assessment -->
+cat > /tmp/gh-comment.md << 'EOF'
+<!-- mach6-assessment -->
 ## Issue Assessment
 
 <assessment content>
 
 ---
-*Automated assessment by mach6*"
+*Automated assessment by mach6*
+EOF
+gh issue comment <number> --body-file /tmp/gh-comment.md
 ```
 
 Update task: post → completed.
@@ -123,7 +127,10 @@ Present the draft to the user for approval.
 ### Step 3: Create the issue
 
 ```bash
-gh issue create --title "<title>" --body "<body>" [--label "<labels>"]
+cat > /tmp/gh-body.md << 'EOF'
+<body>
+EOF
+gh issue create --title "<title>" --body-file /tmp/gh-body.md [--label "<labels>"]
 ```
 
 Report the issue number and URL. Suggest next step: `/skill:mach6-plan <number>`

--- a/packages/coding-agent/skills/mach6-issue/SKILL.md
+++ b/packages/coding-agent/skills/mach6-issue/SKILL.md
@@ -76,7 +76,7 @@ Present to the user:
 Post as an issue comment:
 
 ```bash
-cat > /tmp/gh-comment.md << 'EOF'
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-assessment -->
 ## Issue Assessment
 
@@ -84,7 +84,7 @@ cat > /tmp/gh-comment.md << 'EOF'
 
 ---
 *Automated assessment by mach6*
-EOF
+MACH6_EOF
 gh issue comment <number> --body-file /tmp/gh-comment.md
 ```
 
@@ -127,9 +127,9 @@ Present the draft to the user for approval.
 ### Step 3: Create the issue
 
 ```bash
-cat > /tmp/gh-body.md << 'EOF'
+cat > /tmp/gh-body.md << 'MACH6_EOF'
 <body>
-EOF
+MACH6_EOF
 gh issue create --title "<title>" --body-file /tmp/gh-body.md [--label "<labels>"]
 ```
 

--- a/packages/coding-agent/skills/mach6-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6-plan/SKILL.md
@@ -18,6 +18,7 @@ This command is strictly for **planning**. Do NOT implement any code changes —
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 5. **Task tracking** — Use the `tasks_update` tool to show progress through multi-step commands.
 6. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning.
+7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 ## Step 1: Set up task tracking
 
@@ -97,11 +98,14 @@ git commit --allow-empty -m "chore: open PR for issue <N>"
 git push -u origin feature/issue-<N>-<slug>
 
 # Open draft PR
-gh pr create --draft --title "<title>" --body "Closes #<N>
+cat > /tmp/gh-body.md << 'EOF'
+Closes #<N>
 
 <brief description>
 
-Implementation plan posted as a comment below."
+Implementation plan posted as a comment below.
+EOF
+gh pr create --draft --title "<title>" --body-file /tmp/gh-body.md
 ```
 
 Update task: branch → completed, post → in_progress.
@@ -109,13 +113,16 @@ Update task: branch → completed, post → in_progress.
 ## Step 7: Post plan to PR
 
 ```bash
-gh pr comment <pr-number> --body "<!-- mach6-plan -->
+cat > /tmp/gh-comment.md << 'EOF'
+<!-- mach6-plan -->
 ## Implementation Plan
 
 <full plan content>
 
 ---
-*Plan created by mach6*"
+*Plan created by mach6*
+EOF
+gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 
 Update task: post → completed.

--- a/packages/coding-agent/skills/mach6-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6-plan/SKILL.md
@@ -98,13 +98,13 @@ git commit --allow-empty -m "chore: open PR for issue <N>"
 git push -u origin feature/issue-<N>-<slug>
 
 # Open draft PR
-cat > /tmp/gh-body.md << 'EOF'
+cat > /tmp/gh-body.md << 'MACH6_EOF'
 Closes #<N>
 
 <brief description>
 
 Implementation plan posted as a comment below.
-EOF
+MACH6_EOF
 gh pr create --draft --title "<title>" --body-file /tmp/gh-body.md
 ```
 
@@ -113,7 +113,7 @@ Update task: branch → completed, post → in_progress.
 ## Step 7: Post plan to PR
 
 ```bash
-cat > /tmp/gh-comment.md << 'EOF'
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-plan -->
 ## Implementation Plan
 
@@ -121,7 +121,7 @@ cat > /tmp/gh-comment.md << 'EOF'
 
 ---
 *Plan created by mach6*
-EOF
+MACH6_EOF
 gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 

--- a/packages/coding-agent/skills/mach6-publish/SKILL.md
+++ b/packages/coding-agent/skills/mach6-publish/SKILL.md
@@ -181,7 +181,10 @@ git push --tags
 
 3. Present draft to user for approval, then create:
    ```bash
-   gh release create v<version> --title "v<version>" --notes "<release-notes>"
+   cat > /tmp/gh-release-notes.md << 'MACH6_EOF'
+   <release-notes>
+   MACH6_EOF
+   gh release create v<version> --title "v<version>" --notes-file /tmp/gh-release-notes.md
    ```
 
 Update task: release → completed.

--- a/packages/coding-agent/skills/mach6-publish/SKILL.md
+++ b/packages/coding-agent/skills/mach6-publish/SKILL.md
@@ -14,6 +14,7 @@ argument-hint: "<pr-number>"
 2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
 3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 ## Step 1: Set up task tracking
 
@@ -35,6 +36,8 @@ git pull
 gh pr view <pr-number> --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,comments,body
 gh pr checks <pr-number>
 ```
+
+**Note:** `gh pr checks` returns exit code 8 while checks are still pending — this is expected, not a failure. Wait and re-run if needed.
 
 Read ALL PR comments to understand the full history — plans, reviews, assessments, progress updates, and discussion.
 

--- a/packages/coding-agent/skills/mach6-push/SKILL.md
+++ b/packages/coding-agent/skills/mach6-push/SKILL.md
@@ -81,7 +81,7 @@ If session context points to an issue but a PR also exists on the current branch
 
 Post a progress comment:
 ```bash
-cat > /tmp/gh-comment.md << 'EOF'
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-progress -->
 ## Progress Update
 
@@ -91,7 +91,7 @@ cat > /tmp/gh-comment.md << 'EOF'
 
 ---
 *Progress tracked by mach6*
-EOF
+MACH6_EOF
 gh pr comment <number> --body-file /tmp/gh-comment.md
 ```
 

--- a/packages/coding-agent/skills/mach6-push/SKILL.md
+++ b/packages/coding-agent/skills/mach6-push/SKILL.md
@@ -15,6 +15,7 @@ argument-hint: "[commit message]"
 3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
 5. **Task tracking** — Use the `tasks_update` tool to show progress.
+6. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 ## Step 1: Set up task tracking
 
@@ -80,7 +81,8 @@ If session context points to an issue but a PR also exists on the current branch
 
 Post a progress comment:
 ```bash
-gh pr comment <number> --body "<!-- mach6-progress -->
+cat > /tmp/gh-comment.md << 'EOF'
+<!-- mach6-progress -->
 ## Progress Update
 
 <summary of changes in this batch>
@@ -88,7 +90,9 @@ gh pr comment <number> --body "<!-- mach6-progress -->
 **Commit:** \`<hash>\`
 
 ---
-*Progress tracked by mach6*"
+*Progress tracked by mach6*
+EOF
+gh pr comment <number> --body-file /tmp/gh-comment.md
 ```
 
 Update task: comment → completed.

--- a/packages/coding-agent/skills/mach6-review/SKILL.md
+++ b/packages/coding-agent/skills/mach6-review/SKILL.md
@@ -14,6 +14,7 @@ argument-hint: "<pr-number> [code|errors|tests|completeness|simplify]"
 2. **HTML markers** — Use `<!-- mach6-review -->` and `<!-- mach6-assessment -->` as the first line of comment bodies.
 3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
 
 **Important: Do NOT fix any issues in this session. Fixes happen via `/skill:mach6-implement`.**
 
@@ -95,7 +96,8 @@ Update task: review → completed, post-review → in_progress.
 Compile all findings from all agents into a single structured comment:
 
 ```bash
-gh pr comment <pr-number> --body "<!-- mach6-review -->
+cat > /tmp/gh-comment.md << 'EOF'
+<!-- mach6-review -->
 ## Code Review
 
 ### Critical
@@ -113,7 +115,9 @@ gh pr comment <pr-number> --body "<!-- mach6-review -->
 **Agents run:** <list of agents>
 
 ---
-*Reviewed by mach6*"
+*Reviewed by mach6*
+EOF
+gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 
 Save the review comment URL:
@@ -152,7 +156,8 @@ Update task: assess → completed, post-assess → in_progress.
 ## Step 7: Post assessment
 
 ```bash
-gh pr comment <pr-number> --body "<!-- mach6-assessment -->
+cat > /tmp/gh-comment.md << 'EOF'
+<!-- mach6-assessment -->
 ## Review Assessment
 
 <link to review comment>
@@ -168,7 +173,9 @@ gh pr comment <pr-number> --body "<!-- mach6-assessment -->
 <numbered list of what to fix, ordered by priority>
 
 ---
-*Assessment by mach6*"
+*Assessment by mach6*
+EOF
+gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 
 Update task: post-assess → completed, summary → in_progress.
@@ -182,7 +189,10 @@ Present to the user:
 
 If any findings were classified as **deferred**, ask the user if they want to create issues for them:
 ```bash
-gh issue create --title "<title>" --body "<body referencing PR and finding>"
+cat > /tmp/gh-body.md << 'EOF'
+<body referencing PR and finding>
+EOF
+gh issue create --title "<title>" --body-file /tmp/gh-body.md
 ```
 
 Update task: summary → completed.

--- a/packages/coding-agent/skills/mach6-review/SKILL.md
+++ b/packages/coding-agent/skills/mach6-review/SKILL.md
@@ -96,7 +96,7 @@ Update task: review → completed, post-review → in_progress.
 Compile all findings from all agents into a single structured comment:
 
 ```bash
-cat > /tmp/gh-comment.md << 'EOF'
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-review -->
 ## Code Review
 
@@ -116,7 +116,7 @@ cat > /tmp/gh-comment.md << 'EOF'
 
 ---
 *Reviewed by mach6*
-EOF
+MACH6_EOF
 gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 
@@ -156,7 +156,7 @@ Update task: assess → completed, post-assess → in_progress.
 ## Step 7: Post assessment
 
 ```bash
-cat > /tmp/gh-comment.md << 'EOF'
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-assessment -->
 ## Review Assessment
 
@@ -174,7 +174,7 @@ cat > /tmp/gh-comment.md << 'EOF'
 
 ---
 *Assessment by mach6*
-EOF
+MACH6_EOF
 gh pr comment <pr-number> --body-file /tmp/gh-comment.md
 ```
 
@@ -189,9 +189,9 @@ Present to the user:
 
 If any findings were classified as **deferred**, ask the user if they want to create issues for them:
 ```bash
-cat > /tmp/gh-body.md << 'EOF'
+cat > /tmp/gh-body.md << 'MACH6_EOF'
 <body referencing PR and finding>
-EOF
+MACH6_EOF
 gh issue create --title "<title>" --body-file /tmp/gh-body.md
 ```
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #178

Updates all mach6 skills to use --body-file instead of inline --body for gh CLI commands, documents gh pr checks exit code 8 behavior, and adds GH_PAGER/GH_EDITOR guidance to prevent agent hangs.

Implementation plan posted as a comment below.