### PR TITLE
Add process-safe rate-limited queue to web_search tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.11.1",
+			"version": "2.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 - Added skill system enhancements: `argument-hint` frontmatter field shown in `/` menu autocomplete, `user-invocable` field to hide skills from the `/` menu while keeping them available to the model, `disable-model-invocation` field to restrict skills to user-only invocation, and a dedicated `skill` tool for model-invocable skill execution with full content substitution (`$ARGUMENTS`, `$0`..`$N`, `$@`, `${@:N}`, `${DREB_SKILL_DIR}`, `${DREB_SESSION_ID}`) ([#7](https://github.com/aebrer/dreb/issues/7))
 - Added `sessionDir` setting support in global and project `settings.json` so session storage can be configured without passing `--session-dir` on every invocation ([#2598](https://github.com/badlogic/pi-mono/pull/2598) by [@smcllns](https://github.com/smcllns))
+- Added process-safe rate-limited queue for `web_search` tool — throttles rapid successive searches (including from parallel subagents) using `proper-lockfile` + timestamp file for cross-process coordination. Default minimum spacing is 10 seconds. Configurable via `DREB_WEB_SEARCH_RATE_LIMIT_MS` env var or `search.rate_limit_ms` in config file. Explore agents now have access to `web_search` and `web_fetch`. ([#180](https://github.com/aebrer/dreb/issues/180))
+
 - Added `/dream` memory consolidation command — backs up all memory directories, merges duplicates, scans session history for unrecorded patterns, prunes stale entries, and validates links. Uses tar.gz archives with retention policy (keep last 10), lockfile-based concurrency protection, and a 10-step LLM pipeline with explicit backup verification. Configurable archive path via `dream.archivePath` setting. ([#99](https://github.com/aebrer/dreb/issues/99))
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -665,6 +665,10 @@ dreb --thinking high "Solve this complex problem"
 | `DREB_PACKAGE_DIR` | Override package directory (useful for Nix/Guix where store paths tokenize poorly) |
 | `DREB_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
 | `DREB_OFFLINE` | Disable startup network ops (same as `--offline`) |
+| `DREB_SEARCH_BACKEND` | Search backend: `ddg` (default), `searxng`, or `brave` |
+| `DREB_SEARXNG_URL` | Base URL for SearXNG backend (default: `http://localhost:8888`) |
+| `DREB_BRAVE_API_KEY` | API key for Brave search backend |
+| `DREB_WEB_SEARCH_RATE_LIMIT_MS` | Minimum delay between web searches in milliseconds (default: `10000`) |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 
 ---

--- a/packages/coding-agent/agents/explore.md
+++ b/packages/coding-agent/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: Explore
-description: Codebase exploration — find files, search code, answer questions. Read-only.
-tools: read, grep, find, ls, bash, search
+description: Codebase and web exploration — find files, search code, search the web, answer questions. Read-only.
+tools: read, grep, find, ls, bash, search, web_search, web_fetch
 model: zai/glm-5-turbo, anthropic/sonnet
 ---
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/web-search-queue.ts
+++ b/packages/coding-agent/src/core/tools/web-search-queue.ts
@@ -63,9 +63,19 @@ export class WebSearchQueue {
 			try {
 				return await fn();
 			} finally {
+				// Ensure time file directory exists before writing
+				const timeDir = dirname(this.timeFilePath);
+				if (!existsSync(timeDir)) {
+					mkdirSync(timeDir, { recursive: true });
+				}
 				// Update timestamp even on error to prevent retry storms
-				const timestampData: TimestampData = { lastSearchTime: Date.now() };
-				writeFileSync(this.timeFilePath, JSON.stringify(timestampData));
+				try {
+					const timestampData: TimestampData = { lastSearchTime: Date.now() };
+					writeFileSync(this.timeFilePath, JSON.stringify(timestampData));
+				} catch (tsErr) {
+					// Don't let timestamp write failure mask the original error
+					console.error(`Failed to write search timestamp: ${tsErr}`);
+				}
 			}
 		} finally {
 			try {

--- a/packages/coding-agent/src/core/tools/web-search-queue.ts
+++ b/packages/coding-agent/src/core/tools/web-search-queue.ts
@@ -26,12 +26,17 @@ export class WebSearchQueue {
 
 	async enqueue<T>(fn: () => Promise<T>): Promise<T> {
 		// Ensure parent directory and lock file exist (proper-lockfile requires the file to exist)
-		const dir = dirname(this.lockFilePath);
-		if (!existsSync(dir)) {
-			mkdirSync(dir, { recursive: true });
-		}
-		if (!existsSync(this.lockFilePath)) {
-			writeFileSync(this.lockFilePath, "");
+		try {
+			const dir = dirname(this.lockFilePath);
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true });
+			}
+			if (!existsSync(this.lockFilePath)) {
+				writeFileSync(this.lockFilePath, "");
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			throw new Error(`Failed to initialize web search queue lock file at ${this.lockFilePath}: ${msg}`);
 		}
 
 		let release: (() => Promise<void>) | undefined;

--- a/packages/coding-agent/src/core/tools/web-search-queue.ts
+++ b/packages/coding-agent/src/core/tools/web-search-queue.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import lockfile from "proper-lockfile";
+import { getAgentDir } from "../../config.js";
+
+export interface WebSearchQueueOptions {
+	rateLimitMs?: number;
+	lockFilePath?: string;
+	timeFilePath?: string;
+}
+
+interface TimestampData {
+	lastSearchTime: number;
+}
+
+export class WebSearchQueue {
+	private readonly rateLimitMs: number;
+	private readonly lockFilePath: string;
+	private readonly timeFilePath: string;
+
+	constructor(options: WebSearchQueueOptions = {}) {
+		this.rateLimitMs = options.rateLimitMs ?? 10_000;
+		this.lockFilePath = options.lockFilePath ?? join(getAgentDir(), "web-search-queue.lock");
+		this.timeFilePath = options.timeFilePath ?? join(getAgentDir(), "web-search-queue.time");
+	}
+
+	async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+		// Ensure parent directory and lock file exist (proper-lockfile requires the file to exist)
+		const dir = dirname(this.lockFilePath);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		if (!existsSync(this.lockFilePath)) {
+			writeFileSync(this.lockFilePath, "");
+		}
+
+		let release: (() => Promise<void>) | undefined;
+		try {
+			release = await lockfile.lock(this.lockFilePath, {
+				stale: 60_000,
+				retries: { retries: 10, factor: 2, minTimeout: 100, maxTimeout: 10_000, randomize: true },
+			});
+
+			// Read last search timestamp
+			let lastSearchTime = 0;
+			try {
+				const raw = readFileSync(this.timeFilePath, "utf-8");
+				const data = JSON.parse(raw) as TimestampData;
+				if (typeof data.lastSearchTime === "number") {
+					lastSearchTime = data.lastSearchTime;
+				}
+			} catch {
+				// Missing or malformed — treat as 0
+			}
+
+			// Enforce rate limit
+			const delayNeeded = Math.max(0, this.rateLimitMs - (Date.now() - lastSearchTime));
+			if (delayNeeded > 0) {
+				await new Promise((resolve) => setTimeout(resolve, delayNeeded));
+			}
+
+			// Execute the search operation
+			try {
+				return await fn();
+			} finally {
+				// Update timestamp even on error to prevent retry storms
+				const timestampData: TimestampData = { lastSearchTime: Date.now() };
+				writeFileSync(this.timeFilePath, JSON.stringify(timestampData));
+			}
+		} finally {
+			try {
+				await release?.();
+			} catch {
+				// Swallow unlock errors
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/core/tools/web.ts
+++ b/packages/coding-agent/src/core/tools/web.ts
@@ -372,7 +372,7 @@ function getSearchQueue(): WebSearchQueue {
 	return searchQueue;
 }
 
-async function executeSearch(query: string): Promise<SearchResult[]> {
+export async function executeSearch(query: string): Promise<SearchResult[]> {
 	return getSearchQueue().enqueue(async () => {
 		const config = getSearchConfig();
 		switch (config.backend) {

--- a/packages/coding-agent/src/core/tools/web.ts
+++ b/packages/coding-agent/src/core/tools/web.ts
@@ -10,6 +10,7 @@ import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/type
 import { getTextOutput, invalidArgText, str } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
+import { WebSearchQueue } from "./web-search-queue.js";
 
 // ---------------------------------------------------------------------------
 // Shared: HTTP fetching and HTML extraction
@@ -289,6 +290,7 @@ export interface WebSearchConfig {
 	backend?: "ddg" | "searxng" | "brave";
 	searxngUrl?: string;
 	braveApiKey?: string;
+	rateLimitMs?: number;
 }
 
 interface DrebConfig {
@@ -296,6 +298,7 @@ interface DrebConfig {
 		backend?: string;
 		searxng_url?: string;
 		brave_api_key?: string;
+		rate_limit_ms?: number;
 	};
 }
 
@@ -336,24 +339,52 @@ function getSearchConfig(): WebSearchConfig {
 			);
 		}
 	}
+
+	const rateLimitEnv = process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+	let rateLimitMs = 10_000;
+	if (rateLimitEnv) {
+		const parsed = parseInt(rateLimitEnv, 10);
+		if (!Number.isNaN(parsed) && parsed >= 0) {
+			rateLimitMs = parsed;
+		} else {
+			console.error(`Warning: invalid DREB_WEB_SEARCH_RATE_LIMIT_MS "${rateLimitEnv}", using default`);
+		}
+	} else if (fileConfig.search?.rate_limit_ms !== undefined) {
+		const parsed = parseInt(String(fileConfig.search.rate_limit_ms), 10);
+		if (!Number.isNaN(parsed) && parsed >= 0) {
+			rateLimitMs = parsed;
+		}
+	}
+
 	return {
 		backend,
 		searxngUrl: process.env.DREB_SEARXNG_URL || fileConfig.search?.searxng_url || "http://localhost:8888",
 		braveApiKey: process.env.DREB_BRAVE_API_KEY || fileConfig.search?.brave_api_key,
+		rateLimitMs,
 	};
 }
 
-async function executeSearch(query: string): Promise<SearchResult[]> {
-	const config = getSearchConfig();
-	switch (config.backend) {
-		case "searxng":
-			return searchSearXNG(query, config.searxngUrl!);
-		case "brave":
-			if (!config.braveApiKey) throw new Error("DREB_BRAVE_API_KEY not set");
-			return searchBrave(query, config.braveApiKey);
-		default:
-			return searchDuckDuckGo(query);
+let searchQueue: WebSearchQueue | undefined;
+function getSearchQueue(): WebSearchQueue {
+	if (!searchQueue) {
+		searchQueue = new WebSearchQueue({ rateLimitMs: getSearchConfig().rateLimitMs });
 	}
+	return searchQueue;
+}
+
+async function executeSearch(query: string): Promise<SearchResult[]> {
+	return getSearchQueue().enqueue(async () => {
+		const config = getSearchConfig();
+		switch (config.backend) {
+			case "searxng":
+				return searchSearXNG(query, config.searxngUrl!);
+			case "brave":
+				if (!config.braveApiKey) throw new Error("DREB_BRAVE_API_KEY not set");
+				return searchBrave(query, config.braveApiKey);
+			default:
+				return searchDuckDuckGo(query);
+		}
+	});
 }
 
 function formatSearchCall(

--- a/packages/coding-agent/src/core/tools/web.ts
+++ b/packages/coding-agent/src/core/tools/web.ts
@@ -325,7 +325,7 @@ function loadDrebConfig(): DrebConfig {
 	return {};
 }
 
-function getSearchConfig(): WebSearchConfig {
+export function getSearchConfig(): WebSearchConfig {
 	const fileConfig = loadDrebConfig();
 	// Environment variables override config file
 	const rawBackend = process.env.DREB_SEARCH_BACKEND || fileConfig.search?.backend;
@@ -353,6 +353,10 @@ function getSearchConfig(): WebSearchConfig {
 		const parsed = parseInt(String(fileConfig.search.rate_limit_ms), 10);
 		if (!Number.isNaN(parsed) && parsed >= 0) {
 			rateLimitMs = parsed;
+		} else {
+			console.error(
+				`Warning: invalid search.rate_limit_ms in config file "${fileConfig.search.rate_limit_ms}", using default`,
+			);
 		}
 	}
 
@@ -364,12 +368,8 @@ function getSearchConfig(): WebSearchConfig {
 	};
 }
 
-let searchQueue: WebSearchQueue | undefined;
 function getSearchQueue(): WebSearchQueue {
-	if (!searchQueue) {
-		searchQueue = new WebSearchQueue({ rateLimitMs: getSearchConfig().rateLimitMs });
-	}
-	return searchQueue;
+	return new WebSearchQueue({ rateLimitMs: getSearchConfig().rateLimitMs });
 }
 
 export async function executeSearch(query: string): Promise<SearchResult[]> {

--- a/packages/coding-agent/test/web-search-queue.test.ts
+++ b/packages/coding-agent/test/web-search-queue.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { executeSearch } from "../src/core/tools/web.js";
+import { executeSearch, getSearchConfig } from "../src/core/tools/web.js";
 import { WebSearchQueue } from "../src/core/tools/web-search-queue.js";
 
 describe("WebSearchQueue", () => {
@@ -161,6 +161,23 @@ describe("WebSearchQueue", () => {
 		// Should complete very quickly — no 5-second delay
 		expect(elapsed).toBeLessThan(500);
 	});
+
+	it("handles corrupted time file gracefully", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 5000,
+			lockFilePath,
+			timeFilePath,
+		});
+		// Write garbage to the time file
+		writeFileSync(timeFilePath, "{broken json");
+
+		const start = Date.now();
+		await queue.enqueue(async () => "ok");
+		const elapsed = Date.now() - start;
+
+		// Should complete quickly — no 5-second delay
+		expect(elapsed).toBeLessThan(500);
+	});
 });
 
 describe("executeSearch integration", () => {
@@ -232,5 +249,103 @@ describe("executeSearch integration", () => {
 		await Promise.all([executeSearch("q1"), executeSearch("q2"), executeSearch("q3")]);
 
 		expect(maxConcurrent).toBe(1);
+	});
+
+	it("propagates backend errors through the queue", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
+
+		await expect(executeSearch("query")).rejects.toThrow("network failure");
+	});
+});
+
+describe("getSearchConfig", () => {
+	let tempDir: string;
+	let originalCwd: string;
+	let originalRateLimit: string | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "dreb-search-config-"));
+		originalCwd = process.cwd();
+		originalRateLimit = process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (originalRateLimit !== undefined) {
+			process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = originalRateLimit;
+		} else {
+			delete process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	it("returns default rateLimitMs of 10000 when nothing is configured", () => {
+		// Change to temp dir with no config file
+		process.chdir(tempDir);
+		delete process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(10_000);
+	});
+
+	it("reads rateLimitMs from env var", () => {
+		process.chdir(tempDir);
+		process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = "500";
+
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(500);
+	});
+
+	it("reads rateLimitMs from config file", () => {
+		process.chdir(tempDir);
+		delete process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+
+		// Create .dreb/config.json in the temp dir
+		const configDir = join(tempDir, ".dreb");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.json"), JSON.stringify({ search: { rate_limit_ms: 300 } }));
+
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(300);
+	});
+
+	it("env var takes precedence over config file", () => {
+		process.chdir(tempDir);
+		process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = "500";
+
+		// Also create a config file — env var should win
+		const configDir = join(tempDir, ".dreb");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.json"), JSON.stringify({ search: { rate_limit_ms: 300 } }));
+
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(500);
+	});
+
+	it("falls back to default on invalid env var and logs warning", () => {
+		process.chdir(tempDir);
+		process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = "abc";
+
+		const errorSpy = vi.spyOn(console, "error");
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(10_000);
+		expect(errorSpy).toHaveBeenCalledWith(`Warning: invalid DREB_WEB_SEARCH_RATE_LIMIT_MS "abc", using default`);
+	});
+
+	it("falls back to default on invalid config file value and logs warning", () => {
+		process.chdir(tempDir);
+		delete process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+
+		const configDir = join(tempDir, ".dreb");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.json"), JSON.stringify({ search: { rate_limit_ms: "invalid" } }));
+
+		const errorSpy = vi.spyOn(console, "error");
+		const config = getSearchConfig();
+		expect(config.rateLimitMs).toBe(10_000);
+		expect(errorSpy).toHaveBeenCalledWith(
+			'Warning: invalid search.rate_limit_ms in config file "invalid", using default',
+		);
 	});
 });

--- a/packages/coding-agent/test/web-search-queue.test.ts
+++ b/packages/coding-agent/test/web-search-queue.test.ts
@@ -1,0 +1,152 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WebSearchQueue } from "../src/core/tools/web-search-queue.js";
+
+describe("WebSearchQueue", () => {
+	let tempDir: string;
+	let lockFilePath: string;
+	let timeFilePath: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "dreb-web-search-queue-"));
+		lockFilePath = join(tempDir, "queue.lock");
+		timeFilePath = join(tempDir, "queue.time");
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("serializes concurrent calls", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 0,
+			lockFilePath,
+			timeFilePath,
+		});
+
+		let running = 0;
+		let maxConcurrent = 0;
+
+		const track = async () => {
+			running++;
+			maxConcurrent = Math.max(maxConcurrent, running);
+			// Hold for a bit to let other enqueues pile up
+			await new Promise((r) => setTimeout(r, 50));
+			running--;
+			return "done";
+		};
+
+		await Promise.all([queue.enqueue(track), queue.enqueue(track), queue.enqueue(track)]);
+
+		expect(maxConcurrent).toBe(1);
+	});
+
+	it("enforces minimum spacing", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 200,
+			lockFilePath,
+			timeFilePath,
+		});
+
+		const startTimes: number[] = [];
+
+		const record = async () => {
+			startTimes.push(Date.now());
+		};
+
+		await queue.enqueue(record);
+		await queue.enqueue(record);
+
+		expect(startTimes.length).toBe(2);
+		const gap = startTimes[1] - startTimes[0];
+		expect(gap).toBeGreaterThanOrEqual(190); // small tolerance for timer imprecision
+	});
+
+	it("custom rate limit respects constructor option", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 50,
+			lockFilePath,
+			timeFilePath,
+		});
+
+		const startTimes: number[] = [];
+
+		const record = async () => {
+			startTimes.push(Date.now());
+		};
+
+		await queue.enqueue(record);
+		await queue.enqueue(record);
+
+		expect(startTimes.length).toBe(2);
+		const gap = startTimes[1] - startTimes[0];
+		expect(gap).toBeGreaterThanOrEqual(45); // small tolerance
+	});
+
+	it("error during search still updates timestamp", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 100,
+			lockFilePath,
+			timeFilePath,
+		});
+
+		// First call throws
+		await expect(
+			queue.enqueue(async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		// Timestamp file should exist and have a recent timestamp
+		expect(existsSync(timeFilePath)).toBe(true);
+		const data = JSON.parse(readFileSync(timeFilePath, "utf-8"));
+		expect(typeof data.lastSearchTime).toBe("number");
+		expect(data.lastSearchTime).toBeGreaterThan(0);
+
+		// Second call should be delayed (proving timestamp was written by the failed call)
+		const start = Date.now();
+		await queue.enqueue(async () => "ok");
+		const elapsed = Date.now() - start;
+		// Should have waited ~100ms minus whatever already elapsed
+		expect(elapsed).toBeGreaterThanOrEqual(80);
+	});
+
+	it("uses custom lock and time file paths", async () => {
+		const customDir = join(tempDir, "custom");
+		mkdirSync(customDir, { recursive: true });
+		const customLock = join(customDir, "my.lock");
+		const customTime = join(customDir, "my.time");
+
+		const queue = new WebSearchQueue({
+			rateLimitMs: 0,
+			lockFilePath: customLock,
+			timeFilePath: customTime,
+		});
+
+		await queue.enqueue(async () => "hello");
+
+		expect(existsSync(customLock)).toBe(true);
+		expect(existsSync(customTime)).toBe(true);
+		const data = JSON.parse(readFileSync(customTime, "utf-8"));
+		expect(typeof data.lastSearchTime).toBe("number");
+	});
+
+	it("handles missing time file gracefully (no delay on first call)", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 5000, // high limit — should NOT cause delay on first call
+			lockFilePath,
+			timeFilePath,
+		});
+
+		expect(existsSync(timeFilePath)).toBe(false);
+
+		const start = Date.now();
+		await queue.enqueue(async () => "first");
+		const elapsed = Date.now() - start;
+
+		// Should complete very quickly — no 5-second delay
+		expect(elapsed).toBeLessThan(500);
+	});
+});

--- a/packages/coding-agent/test/web-search-queue.test.ts
+++ b/packages/coding-agent/test/web-search-queue.test.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeSearch } from "../src/core/tools/web.js";
 import { WebSearchQueue } from "../src/core/tools/web-search-queue.js";
 
 describe("WebSearchQueue", () => {
@@ -41,6 +42,17 @@ describe("WebSearchQueue", () => {
 		await Promise.all([queue.enqueue(track), queue.enqueue(track), queue.enqueue(track)]);
 
 		expect(maxConcurrent).toBe(1);
+	});
+
+	it("returns the value from the wrapped function", async () => {
+		const queue = new WebSearchQueue({
+			rateLimitMs: 0,
+			lockFilePath,
+			timeFilePath,
+		});
+
+		const result = await queue.enqueue(async () => 42);
+		expect(result).toBe(42);
 	});
 
 	it("enforces minimum spacing", async () => {
@@ -148,5 +160,77 @@ describe("WebSearchQueue", () => {
 
 		// Should complete very quickly — no 5-second delay
 		expect(elapsed).toBeLessThan(500);
+	});
+});
+
+describe("executeSearch integration", () => {
+	let tempDir: string;
+	let originalAgentDir: string | undefined;
+	let originalRateLimit: string | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "dreb-web-search-int-"));
+		originalAgentDir = process.env.DREB_CODING_AGENT_DIR;
+		originalRateLimit = process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = "0";
+	});
+
+	afterEach(() => {
+		if (originalAgentDir !== undefined) {
+			process.env.DREB_CODING_AGENT_DIR = originalAgentDir;
+		} else {
+			delete process.env.DREB_CODING_AGENT_DIR;
+		}
+		if (originalRateLimit !== undefined) {
+			process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS = originalRateLimit;
+		} else {
+			delete process.env.DREB_WEB_SEARCH_RATE_LIMIT_MS;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	it("routes through the queue and returns search results", async () => {
+		const mockHtml = `
+			<div class="result results_links">
+				<a class="result__a" href="https://example.com/page">Test Title</a>
+				<div class="result__snippet">Test snippet content</div>
+			</div>
+		`;
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => mockHtml,
+		});
+
+		const results = await executeSearch("test query");
+
+		expect(results).toHaveLength(1);
+		expect(results[0].title).toBe("Test Title");
+		expect(results[0].url).toBe("https://example.com/page");
+		expect(results[0].snippet).toBe("Test snippet content");
+	});
+
+	it("serializes concurrent executeSearch calls through the queue", async () => {
+		let running = 0;
+		let maxConcurrent = 0;
+
+		globalThis.fetch = vi.fn().mockImplementation(async () => {
+			running++;
+			maxConcurrent = Math.max(maxConcurrent, running);
+			await new Promise((r) => setTimeout(r, 50));
+			running--;
+			return {
+				ok: true,
+				status: 200,
+				text: async () =>
+					`<div class="result results_links"><a class="result__a" href="https://example.com">Title</a><div class="result__snippet">Snippet</div></div>`,
+			};
+		});
+
+		await Promise.all([executeSearch("q1"), executeSearch("q2"), executeSearch("q3")]);
+
+		expect(maxConcurrent).toBe(1);
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #180

Add a process-safe, cross-process rate-limited queue to the `web_search` tool so that rapid successive searches (including from parallel subagents) are throttled instead of hammering providers.

Implementation plan posted as a comment below.
