### PR TITLE
Inject git repo state into system prompt at session start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8733,7 +8733,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8762,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8818,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8933,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8982,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9018,7 +9018,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.12.1",
+			"version": "2.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -62,7 +62,7 @@ import {
 	wrapRegisteredTools,
 } from "./extensions/index.js";
 import { checkScriptContent, extractScriptPaths, isForbiddenCommand } from "./forbidden-commands.js";
-import { getGitRepoState } from "./git-repo-state.js";
+import { type GitRepoState, getGitRepoState } from "./git-repo-state.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -312,6 +312,9 @@ export class AgentSession {
 	private _baseSystemPrompt = "";
 	private _uiType?: string;
 
+	// Git repo state captured once at session start
+	private _gitRepoState: GitRepoState | undefined;
+
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
@@ -325,6 +328,9 @@ export class AgentSession {
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._uiType = config.uiType;
+
+		// Capture git repo state once at session start (before building runtime/system prompt)
+		this._gitRepoState = getGitRepoState(this._cwd) ?? undefined;
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
@@ -1226,7 +1232,7 @@ export class AgentSession {
 			toolSnippets,
 			promptGuidelines,
 			uiType: this._uiType,
-			gitRepoState: getGitRepoState(this._cwd) ?? undefined,
+			gitRepoState: this._gitRepoState,
 		});
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3118,6 +3118,10 @@ export class AgentSession {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
 		}
 
+		// Refresh git state for the resumed session
+		this._gitRepoState = getGitRepoState(this._cwd) ?? undefined;
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+
 		this._reconnectToAgent();
 		return true;
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -62,6 +62,7 @@ import {
 	wrapRegisteredTools,
 } from "./extensions/index.js";
 import { checkScriptContent, extractScriptPaths, isForbiddenCommand } from "./forbidden-commands.js";
+import { getGitRepoState } from "./git-repo-state.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
@@ -1225,6 +1226,7 @@ export class AgentSession {
 			toolSnippets,
 			promptGuidelines,
 			uiType: this._uiType,
+			gitRepoState: getGitRepoState(this._cwd) ?? undefined,
 		});
 	}
 

--- a/packages/coding-agent/src/core/git-repo-state.ts
+++ b/packages/coding-agent/src/core/git-repo-state.ts
@@ -86,7 +86,10 @@ export function getGitRepoState(cwd: string): GitRepoState | null {
 		);
 		if (prResult.status === 0 && prResult.stdout) {
 			try {
-				openPRs = JSON.parse(prResult.stdout);
+				const parsed = JSON.parse(prResult.stdout);
+				if (Array.isArray(parsed)) {
+					openPRs = parsed;
+				}
 			} catch {
 				// malformed JSON — keep empty array
 			}

--- a/packages/coding-agent/src/core/git-repo-state.ts
+++ b/packages/coding-agent/src/core/git-repo-state.ts
@@ -20,10 +20,9 @@ export function getGitRepoState(cwd: string): GitRepoState | null {
 
 	// Branch
 	const branchResult = spawnSync("git", ["branch", "--show-current"], { ...SPAWN_OPTS, cwd });
-	if (branchResult.status !== 0 && branchResult.status !== null) {
-		// git binary unavailable or not a repo at all
-		if (!branchResult.stdout) return null;
-	}
+	// git binary unavailable (ENOENT) or timed out (status: null)
+	if (branchResult.status === null) return null;
+	if (branchResult.status !== 0 && !branchResult.stdout) return null;
 	const branch = branchResult.stdout?.trim() || "detached";
 
 	// Dirty count

--- a/packages/coding-agent/src/core/git-repo-state.ts
+++ b/packages/coding-agent/src/core/git-repo-state.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from "node:child_process";
+import { findGitRoot } from "./git-root.js";
+
+export interface GitRepoState {
+	branch: string;
+	dirtyCount: number;
+	recentCommits: Array<{ hash: string; subject: string }>;
+	recentTags: Array<{ name: string; date: string }>;
+	openPRs: Array<{ number: number; title: string; url: string }>;
+}
+
+const SPAWN_OPTS: { encoding: "utf8"; timeout: number; stdio: ["ignore", "pipe", "ignore"] } = {
+	encoding: "utf8",
+	timeout: 5000,
+	stdio: ["ignore", "pipe", "ignore"],
+};
+
+export function getGitRepoState(cwd: string): GitRepoState | null {
+	if (!findGitRoot(cwd)) return null;
+
+	// Branch
+	const branchResult = spawnSync("git", ["branch", "--show-current"], { ...SPAWN_OPTS, cwd });
+	if (branchResult.status !== 0 && branchResult.status !== null) {
+		// git binary unavailable or not a repo at all
+		if (!branchResult.stdout) return null;
+	}
+	const branch = branchResult.stdout?.trim() || "detached";
+
+	// Dirty count
+	const statusResult = spawnSync("git", ["status", "--porcelain"], { ...SPAWN_OPTS, cwd });
+	let dirtyCount = 0;
+	if (statusResult.status === 0 && statusResult.stdout) {
+		dirtyCount = statusResult.stdout.split("\n").filter((line) => line.length > 0).length;
+	}
+
+	// Recent commits
+	const logResult = spawnSync("git", ["log", "--oneline", "-n", "3", "--no-decorate"], {
+		...SPAWN_OPTS,
+		cwd,
+	});
+	const recentCommits: Array<{ hash: string; subject: string }> = [];
+	if (logResult.status === 0 && logResult.stdout) {
+		for (const line of logResult.stdout.trim().split("\n")) {
+			if (!line) continue;
+			const spaceIdx = line.indexOf(" ");
+			if (spaceIdx === -1) {
+				recentCommits.push({ hash: line, subject: "" });
+			} else {
+				recentCommits.push({
+					hash: line.slice(0, spaceIdx),
+					subject: line.slice(spaceIdx + 1),
+				});
+			}
+		}
+	}
+
+	// Recent tags
+	const tagResult = spawnSync(
+		"git",
+		["tag", "--sort=-creatordate", "--format=%(refname:short) %(creatordate:relative)"],
+		{ ...SPAWN_OPTS, cwd },
+	);
+	const recentTags: Array<{ name: string; date: string }> = [];
+	if (tagResult.status === 0 && tagResult.stdout) {
+		const lines = tagResult.stdout.trim().split("\n");
+		for (const line of lines.slice(0, 3)) {
+			if (!line) continue;
+			const spaceIdx = line.indexOf(" ");
+			if (spaceIdx === -1) {
+				recentTags.push({ name: line, date: "" });
+			} else {
+				recentTags.push({
+					name: line.slice(0, spaceIdx),
+					date: line.slice(spaceIdx + 1),
+				});
+			}
+		}
+	}
+
+	// Open PRs (network call — fail silently)
+	let openPRs: Array<{ number: number; title: string; url: string }> = [];
+	if (branch !== "detached") {
+		const prResult = spawnSync(
+			"gh",
+			["pr", "list", "--head", branch, "--state", "open", "--json", "number,title,url", "--limit", "3"],
+			{ ...SPAWN_OPTS, cwd },
+		);
+		if (prResult.status === 0 && prResult.stdout) {
+			try {
+				openPRs = JSON.parse(prResult.stdout);
+			} catch {
+				// malformed JSON — keep empty array
+			}
+		}
+	}
+
+	return { branch, dirtyCount, recentCommits, recentTags, openPRs };
+}

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDocsPath, getExamplesPath, getReadmePath } from "../config.js";
+import type { GitRepoState } from "./git-repo-state.js";
 import { getMemoryInstructions } from "./memory-prompt.js";
 import type { MemoryIndexes } from "./resource-loader.js";
 import { formatSkillsForPrompt, type Skill } from "./skills.js";
@@ -28,6 +29,8 @@ export interface BuildSystemPromptOptions {
 	memoryIndexes?: MemoryIndexes;
 	/** Pre-loaded skills. */
 	skills?: Skill[];
+	/** Git repo state snapshot (branch, dirty count, recent commits, tags, open PRs). */
+	gitRepoState?: GitRepoState;
 }
 
 function formatMemoryScope(sources: readonly import("./resource-loader.js").MemorySource[], heading: string): string {
@@ -87,6 +90,36 @@ function formatUiSection(uiType: string): string {
 	return `\nUI: ${description}`;
 }
 
+/** Format the git repo state section for the system prompt */
+function formatGitStateSection(state: GitRepoState): string {
+	let section = "\n\n## Project state (true at session start only)\n\n";
+	section += `- Branch: \`${state.branch}\`\n`;
+	section += `- Status: ${state.dirtyCount === 0 ? "clean" : `${state.dirtyCount} uncommitted changes`}\n`;
+
+	if (state.recentCommits.length > 0) {
+		section += "- Recent commits:\n";
+		for (const commit of state.recentCommits) {
+			section += `  - \`${commit.hash} — ${commit.subject}\`\n`;
+		}
+	}
+
+	if (state.recentTags.length > 0) {
+		section += "- Recent releases:\n";
+		for (const tag of state.recentTags) {
+			section += `  - \`${tag.name}\` (${tag.date})\n`;
+		}
+	}
+
+	if (state.openPRs.length > 0) {
+		section += "- Open PRs on this branch:\n";
+		for (const pr of state.openPRs) {
+			section += `  - PR ${pr.number} — ${pr.title} (${pr.url})\n`;
+		}
+	}
+
+	return section;
+}
+
 /** Build the system prompt with tools, guidelines, and context */
 export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): string {
 	const {
@@ -134,6 +167,11 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 		// Append memory indexes
 		prompt += buildMemorySection(options.memoryIndexes);
+
+		// Append git repo state
+		if (options.gitRepoState) {
+			prompt += formatGitStateSection(options.gitRepoState);
+		}
 
 		// Add date and working directory last
 		prompt += `\nCurrent date: ${date}`;
@@ -251,6 +289,11 @@ Dreb documentation (read only when the user asks about dreb itself, its SDK, ext
 
 	// Append memory indexes
 	prompt += buildMemorySection(options.memoryIndexes);
+
+	// Append git repo state
+	if (options.gitRepoState) {
+		prompt += formatGitStateSection(options.gitRepoState);
+	}
 
 	// Add date and working directory last
 	prompt += `\nCurrent date: ${date}`;

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -94,7 +94,7 @@ function formatUiSection(uiType: string): string {
 function formatGitStateSection(state: GitRepoState): string {
 	let section = "\n\n## Project state (true at session start only)\n\n";
 	section += `- Branch: \`${state.branch}\`\n`;
-	section += `- Status: ${state.dirtyCount === 0 ? "clean" : `${state.dirtyCount} uncommitted changes`}\n`;
+	section += `- Status: ${state.dirtyCount === 0 ? "clean" : `${state.dirtyCount} uncommitted ${state.dirtyCount === 1 ? "change" : "changes"}`}\n`;
 
 	if (state.recentCommits.length > 0) {
 		section += "- Recent commits:\n";

--- a/packages/coding-agent/test/git-repo-state-mocked.test.ts
+++ b/packages/coding-agent/test/git-repo-state-mocked.test.ts
@@ -98,4 +98,40 @@ describe("getGitRepoState edge cases (mocked spawnSync)", () => {
 		expect(result).not.toBeNull();
 		expect(result!.recentTags).toEqual([{ name: "v1.0.0", date: "" }]);
 	});
+
+	test("returns null when git branch exits non-zero with empty stdout", () => {
+		mockedSpawnSync.mockReturnValue(makeSpawnResult({ status: 128, stdout: "" }));
+		expect(getGitRepoState("/fake/repo")).toBeNull();
+	});
+
+	test("parses multi-line porcelain output for correct dirtyCount", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "main\n" });
+			if (cmd === "git" && args?.[0] === "status")
+				return makeSpawnResult({ stdout: " M file1.ts\nA  file2.ts\n?? new.ts\n" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "abc1234 fix stuff\n" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "" });
+			if (cmd === "gh") return makeSpawnResult({ stdout: "[]" });
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.dirtyCount).toBe(3);
+	});
+
+	test("non-array JSON from gh results in empty openPRs", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "main\n" });
+			if (cmd === "git" && args?.[0] === "status") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "abc1234 fix stuff\n" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "" });
+			if (cmd === "gh") return makeSpawnResult({ stdout: '{"message":"error"}' });
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.openPRs).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/git-repo-state-mocked.test.ts
+++ b/packages/coding-agent/test/git-repo-state-mocked.test.ts
@@ -1,0 +1,101 @@
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+	spawnSync: vi.fn(),
+}));
+
+vi.mock("../src/core/git-root.js", () => ({
+	findGitRoot: vi.fn(() => "/fake/repo"),
+}));
+
+import { getGitRepoState } from "../src/core/git-repo-state.js";
+
+function makeSpawnResult(overrides: Partial<SpawnSyncReturns<string>> = {}): SpawnSyncReturns<string> {
+	return {
+		pid: 1234,
+		output: [],
+		stdout: "",
+		stderr: "",
+		status: 0,
+		signal: null,
+		error: undefined,
+		...overrides,
+	} as SpawnSyncReturns<string>;
+}
+
+const mockedSpawnSync = vi.mocked(spawnSync);
+
+describe("getGitRepoState edge cases (mocked spawnSync)", () => {
+	beforeEach(() => {
+		mockedSpawnSync.mockReset();
+	});
+
+	test("returns null when git binary is missing (ENOENT, status: null)", () => {
+		mockedSpawnSync.mockReturnValue(
+			makeSpawnResult({ status: null, stdout: null as unknown as string, error: new Error("ENOENT") }),
+		);
+		expect(getGitRepoState("/fake/repo")).toBeNull();
+	});
+
+	test("detached HEAD does not call gh pr list", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "status") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "" });
+			if (cmd === "gh") throw new Error("gh should not be called for detached HEAD");
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.branch).toBe("detached");
+		expect(result!.openPRs).toEqual([]);
+	});
+
+	test("malformed JSON from gh results in empty openPRs", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "main\n" });
+			if (cmd === "git" && args?.[0] === "status") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "abc1234 fix stuff\n" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "" });
+			if (cmd === "gh") return makeSpawnResult({ stdout: "not json{{{" });
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.openPRs).toEqual([]);
+	});
+
+	test("git log line with no space produces hash with empty subject", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "main\n" });
+			if (cmd === "git" && args?.[0] === "status") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "abc1234\n" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "" });
+			if (cmd === "gh") return makeSpawnResult({ stdout: "[]" });
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.recentCommits).toEqual([{ hash: "abc1234", subject: "" }]);
+	});
+
+	test("git tag line with no space produces name with empty date", () => {
+		mockedSpawnSync.mockImplementation(((cmd: string, args: string[]) => {
+			if (cmd === "git" && args?.[0] === "branch") return makeSpawnResult({ stdout: "main\n" });
+			if (cmd === "git" && args?.[0] === "status") return makeSpawnResult({ stdout: "" });
+			if (cmd === "git" && args?.[0] === "log") return makeSpawnResult({ stdout: "abc1234 fix stuff\n" });
+			if (cmd === "git" && args?.[0] === "tag") return makeSpawnResult({ stdout: "v1.0.0\n" });
+			if (cmd === "gh") return makeSpawnResult({ stdout: "[]" });
+			return makeSpawnResult();
+		}) as typeof spawnSync);
+
+		const result = getGitRepoState("/fake/repo");
+		expect(result).not.toBeNull();
+		expect(result!.recentTags).toEqual([{ name: "v1.0.0", date: "" }]);
+	});
+});

--- a/packages/coding-agent/test/git-repo-state.test.ts
+++ b/packages/coding-agent/test/git-repo-state.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { getGitRepoState } from "../src/core/git-repo-state.js";
+
+describe("getGitRepoState", () => {
+	describe("real repo tests", () => {
+		const state = getGitRepoState(process.cwd());
+
+		test("returns non-null for this repo", () => {
+			expect(state).not.toBeNull();
+		});
+
+		test("has a non-empty branch string", () => {
+			expect(state!.branch).toBeTruthy();
+			expect(typeof state!.branch).toBe("string");
+		});
+
+		test("has dirtyCount as a number >= 0", () => {
+			expect(typeof state!.dirtyCount).toBe("number");
+			expect(state!.dirtyCount).toBeGreaterThanOrEqual(0);
+		});
+
+		test("has recentCommits as a non-empty array with hash and subject", () => {
+			expect(Array.isArray(state!.recentCommits)).toBe(true);
+			expect(state!.recentCommits.length).toBeGreaterThan(0);
+			for (const commit of state!.recentCommits) {
+				expect(commit).toHaveProperty("hash");
+				expect(commit).toHaveProperty("subject");
+			}
+		});
+
+		test("has recentTags as an array", () => {
+			expect(Array.isArray(state!.recentTags)).toBe(true);
+		});
+
+		test("has openPRs as an array", () => {
+			expect(Array.isArray(state!.openPRs)).toBe(true);
+		});
+	});
+
+	describe("non-repo test", () => {
+		test("returns null for a directory outside any git repo", () => {
+			const tempDir = mkdtempSync(join(tmpdir(), "git-repo-state-test-"));
+			expect(getGitRepoState(tempDir)).toBeNull();
+		});
+	});
+
+	describe("parsing tests", () => {
+		const state = getGitRepoState(process.cwd());
+
+		test("each commit has a short hash (7+ alphanumeric chars) and non-empty subject", () => {
+			expect(state).not.toBeNull();
+			for (const commit of state!.recentCommits) {
+				expect(commit.hash).toMatch(/^[a-f0-9]{7,}$/);
+				expect(commit.subject.length).toBeGreaterThan(0);
+			}
+		});
+
+		test("if tags exist, each tag has a name and date string", () => {
+			expect(state).not.toBeNull();
+			if (state!.recentTags.length > 0) {
+				for (const tag of state!.recentTags) {
+					expect(tag.name.length).toBeGreaterThan(0);
+					expect(typeof tag.date).toBe("string");
+				}
+			}
+		});
+	});
+});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import type { GitRepoState } from "../src/core/git-repo-state.js";
 import { buildSystemPrompt } from "../src/core/system-prompt.js";
 
 describe("buildSystemPrompt", () => {
@@ -114,6 +115,135 @@ describe("buildSystemPrompt", () => {
 
 			expect(prompt).toContain("Prefer grep/find/ls tools over bash");
 			expect(prompt).not.toContain("Start with `search`");
+		});
+	});
+
+	describe("git repo state", () => {
+		const fullState: GitRepoState = {
+			branch: "feature/foo-bar",
+			dirtyCount: 3,
+			recentCommits: [
+				{ hash: "abc1234", subject: "most recent commit" },
+				{ hash: "def5678", subject: "second recent commit" },
+			],
+			recentTags: [
+				{ name: "v1.2.3", date: "2 days ago" },
+				{ name: "v1.2.2", date: "3 weeks ago" },
+			],
+			openPRs: [{ number: 42, title: "Add feature X", url: "https://github.com/org/repo/pull/42" }],
+		};
+
+		test("full state renders correctly", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: fullState,
+			});
+
+			expect(prompt).toContain("## Project state (true at session start only)");
+			expect(prompt).toContain("- Branch: `feature/foo-bar`");
+			expect(prompt).toContain("- Status: 3 uncommitted changes");
+			expect(prompt).toContain("- Recent commits:");
+			expect(prompt).toContain("  - `abc1234 — most recent commit`");
+			expect(prompt).toContain("  - `def5678 — second recent commit`");
+			expect(prompt).toContain("- Recent releases:");
+			expect(prompt).toContain("  - `v1.2.3` (2 days ago)");
+			expect(prompt).toContain("  - `v1.2.2` (3 weeks ago)");
+			expect(prompt).toContain("- Open PRs on this branch:");
+			expect(prompt).toContain("  - PR 42 — Add feature X (https://github.com/org/repo/pull/42)");
+		});
+
+		test("clean status", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: { ...fullState, dirtyCount: 0 },
+			});
+
+			expect(prompt).toContain("- Status: clean");
+		});
+
+		test("dirty status", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: { ...fullState, dirtyCount: 5 },
+			});
+
+			expect(prompt).toContain("- Status: 5 uncommitted changes");
+		});
+
+		test("omitted when undefined", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("Project state");
+		});
+
+		test("partial data — no tags, no PRs", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: {
+					branch: "main",
+					dirtyCount: 1,
+					recentCommits: [{ hash: "aaa1111", subject: "fix bug" }],
+					recentTags: [],
+					openPRs: [],
+				},
+			});
+
+			expect(prompt).toContain("- Branch: `main`");
+			expect(prompt).toContain("- Status: 1 uncommitted changes");
+			expect(prompt).toContain("- Recent commits:");
+			expect(prompt).toContain("  - `aaa1111 — fix bug`");
+			expect(prompt).not.toContain("Recent releases");
+			expect(prompt).not.toContain("Open PRs");
+		});
+
+		test("detached HEAD", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: { ...fullState, branch: "detached" },
+			});
+
+			expect(prompt).toContain("- Branch: `detached`");
+		});
+
+		test("works with custom prompt", () => {
+			const prompt = buildSystemPrompt({
+				customPrompt: "Custom prompt.",
+				contextFiles: [],
+				skills: [],
+				gitRepoState: fullState,
+			});
+
+			expect(prompt).toContain("Custom prompt.");
+			expect(prompt).toContain("## Project state (true at session start only)");
+		});
+
+		test("section appears before date", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: fullState,
+			});
+
+			const stateIdx = prompt.indexOf("## Project state");
+			const dateIdx = prompt.indexOf("Current date:");
+			expect(stateIdx).toBeGreaterThan(-1);
+			expect(dateIdx).toBeGreaterThan(-1);
+			expect(stateIdx).toBeLessThan(dateIdx);
 		});
 	});
 });

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -201,7 +201,7 @@ describe("buildSystemPrompt", () => {
 			});
 
 			expect(prompt).toContain("- Branch: `main`");
-			expect(prompt).toContain("- Status: 1 uncommitted changes");
+			expect(prompt).toContain("- Status: 1 uncommitted change");
 			expect(prompt).toContain("- Recent commits:");
 			expect(prompt).toContain("  - `aaa1111 — fix bug`");
 			expect(prompt).not.toContain("Recent releases");

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.12.1",
+	"version": "2.13.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #185

Inject git repo state (branch, dirty status, recent commits, recent tags, open PRs) into the system prompt at session start so the agent has immediate awareness of the project's git context.

Implementation plan posted as a comment below.
