### PR TITLE
Port upstream security fix and bug fixes from pi-mono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -726,13 +726,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.13.1",
-				"fast-xml-parser": "5.5.8",
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2248,6 +2249,18 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3119,9 +3132,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6530,9 +6543,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
 			"dev": true,
 			"funding": [
 				{
@@ -8733,7 +8746,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8762,7 +8775,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8818,7 +8831,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8933,7 +8946,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8982,7 +8995,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -8999,10 +9012,6 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"packages/telegram/node_modules/@dreb/coding-agent": {
-			"resolved": "packages/coding-agent",
-			"link": true
-		},
 		"packages/telegram/node_modules/@types/node": {
 			"version": "24.12.0",
 			"dev": true,
@@ -9018,7 +9027,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.14.0",
+			"version": "2.14.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -262,8 +262,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
+			let sawMessageStart = false;
+			let sawMessageStop = false;
+
 			for await (const event of anthropicStream) {
 				if (event.type === "message_start") {
+					sawMessageStart = true;
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event
 					// This ensures we have input token counts even if the stream is aborted early
@@ -415,11 +419,18 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					calculateCost(model, output.usage);
+				} else if (event.type === "message_stop") {
+					sawMessageStop = true;
 				}
 			}
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			// Detect incomplete streams — connection dropped after start but before stop
+			if (sawMessageStart && !sawMessageStop) {
+				throw new Error("Anthropic stream ended before message_stop — response may be incomplete");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -262,12 +262,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
-			let sawMessageStart = false;
-			let sawMessageStop = false;
-
 			for await (const event of anthropicStream) {
 				if (event.type === "message_start") {
-					sawMessageStart = true;
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event
 					// This ensures we have input token counts even if the stream is aborted early
@@ -419,18 +415,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					calculateCost(model, output.usage);
-				} else if (event.type === "message_stop") {
-					sawMessageStop = true;
 				}
 			}
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
-			}
-
-			// Detect incomplete streams — connection dropped after start but before stop
-			if (sawMessageStart && !sawMessageStop) {
-				throw new Error("Anthropic stream ended before message_stop — response may be incomplete");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
@@ -100,9 +100,21 @@ function loadContextFilesFromDir(
 		join(".dreb", "CONTEXT.MD"),
 	];
 	const results: Array<{ path: string; content: string }> = [];
+	const seenRealPaths = new Set<string>();
 	for (const filename of candidates) {
 		const filePath = join(dir, filename);
 		if (existsSync(filePath)) {
+			// Deduplicate by realpath to avoid loading the same file twice on
+			// case-insensitive filesystems (macOS) where AGENTS.md and AGENTS.MD
+			// resolve to the same inode.
+			let realPath: string;
+			try {
+				realPath = realpathSync(filePath);
+			} catch {
+				realPath = filePath;
+			}
+			if (seenRealPaths.has(realPath)) continue;
+			seenRealPaths.add(realPath);
 			try {
 				results.push({
 					path: filePath,

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -89,7 +89,16 @@ function loadContextFilesFromDir(
 	dir: string,
 	diagnostics?: ResourceDiagnostic[],
 ): Array<{ path: string; content: string }> {
-	const candidates = ["AGENTS.md", "CLAUDE.md", join(".claude", "CLAUDE.md"), join(".dreb", "CONTEXT.md")];
+	const candidates = [
+		"AGENTS.md",
+		"AGENTS.MD",
+		"CLAUDE.md",
+		"CLAUDE.MD",
+		join(".claude", "CLAUDE.md"),
+		join(".claude", "CLAUDE.MD"),
+		join(".dreb", "CONTEXT.md"),
+		join(".dreb", "CONTEXT.MD"),
+	];
 	const results: Array<{ path: string; content: string }> = [];
 	for (const filename of candidates) {
 		const filePath = join(dir, filename);

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -252,9 +252,10 @@ export async function computeEditDiff(
 		// Check if file exists and is readable
 		try {
 			await access(absolutePath, constants.R_OK);
-		} catch {
+		} catch (accessErr: any) {
 			// access() threw — file missing or unreadable
-			return { error: `File not found: ${path}` };
+			const code = accessErr?.code ? `. Error code: ${accessErr.code}` : "";
+			return { error: `Could not access file: ${path}${code}` };
 		}
 
 		// Read the file

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -168,12 +168,13 @@ export function createEditToolDefinition(
 								// Check if file exists.
 								try {
 									await ops.access(absolutePath);
-								} catch {
+								} catch (accessErr: any) {
 									// access() threw — file missing or unreadable
 									if (signal) {
 										signal.removeEventListener("abort", onAbort);
 									}
-									reject(new Error(`File not found: ${path}`));
+									const code = accessErr?.code ? `. Error code: ${accessErr.code}` : "";
+									reject(new Error(`Could not access file: ${path}${code}`));
 									return;
 								}
 

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -209,7 +209,7 @@ export function createFindToolDefinition(
 						// Manual --ignore-file collection was removed because fd applies
 						// those patterns globally, causing venv/.gitignore files containing
 						// bare "*" to suppress all results. See issue #17.
-						args.push(pattern, searchPath);
+						args.push("--", pattern, searchPath);
 
 						// Include tool-visible .dreb/ subdirs when searching from project root.
 						// fd bypasses .gitignore for explicit path arguments.

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -220,7 +220,7 @@ export function createGrepToolDefinition(
 						if (ignoreCase) args.push("--ignore-case");
 						if (literal) args.push("--fixed-strings");
 						if (glob) args.push("--glob", glob);
-						args.push(pattern, searchPath);
+						args.push("--", pattern, searchPath);
 
 						// Include tool-visible .dreb/ subdirs when searching from project root.
 						// rg bypasses .gitignore for explicit path arguments.

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -515,6 +515,23 @@ describe("Coding Agent Tools", () => {
 			// Ensure second match is not present
 			expect(output).not.toContain("match two");
 		});
+
+		it("should treat flag-shaped patterns as literal text, not as rg options (security)", async () => {
+			// Regression test: without the "--" end-of-options separator, a pattern like
+			// "--pre=/tmp/evil.sh" would be interpreted as an rg flag, enabling RCE.
+			const testFile = join(testDir, "safe.txt");
+			writeFileSync(testFile, "some content\n");
+
+			const scopedGrep = createGrepTool(testDir);
+			const result = await scopedGrep.execute("test-flag-injection", {
+				pattern: "--pre=/tmp/evil.sh",
+			});
+
+			const output = getTextOutput(result);
+			// Should complete without error — the flag-shaped string is treated as a
+			// literal pattern that simply doesn't match anything.
+			expect(output).toContain("No matches found");
+		});
 	});
 
 	describe("find tool", () => {
@@ -617,6 +634,22 @@ describe("Coding Agent Tools", () => {
 			const output = getTextOutput(result);
 			expect(output).toContain("kept.txt");
 			expect(output).not.toContain("ignored.txt");
+		});
+
+		it("should treat flag-shaped patterns as literal text, not as fd options (security)", async () => {
+			// Regression test: without the "--" end-of-options separator, a pattern like
+			// "--exec=evil" would be interpreted as an fd flag.
+			writeFileSync(join(testDir, "safe.txt"), "content");
+
+			const scopedFind = createFindTool(testDir);
+			const result = await scopedFind.execute("test-flag-injection-find", {
+				pattern: "--exec=evil",
+			});
+
+			const output = getTextOutput(result);
+			// Should complete without error — the flag-shaped string is treated as a
+			// literal glob pattern that simply doesn't match anything.
+			expect(output).toContain("No files found");
 		});
 	});
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -315,11 +315,11 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	get columns(): number {
-		return process.stdout.columns || 80;
+		return process.stdout.columns || Number(process.env.COLUMNS) || 80;
 	}
 
 	get rows(): number {
-		return process.stdout.rows || 24;
+		return process.stdout.rows || Number(process.env.LINES) || 24;
 	}
 
 	moveBy(lines: number): void {


### PR DESCRIPTION
## Summary

Audit of recent pi-mono (upstream) commits identified a **critical RCE vulnerability** and several bug fixes applicable to dreb. This PR ports the fixes.

Closes no existing issue — discovered via upstream audit.

---

## Changes

### 🔴 Critical: Tool argument injection (RCE)

**Files:** `grep.ts`, `find.ts`

The `grep` and `find` tools pass user-controlled `pattern` arguments directly to `rg`/`fd` without an end-of-options separator. A malicious pattern like `--pre=/tmp/evil.sh` is interpreted as a CLI flag by ripgrep, executing arbitrary code.

**Fix:** Insert `"--"` before positional arguments in both tools.

### 🟠 High: Anthropic incomplete stream detection

**File:** `anthropic.ts`

If the Anthropic SSE stream drops after `message_start` but before `message_stop`, the partial response was silently accepted as complete. This could produce truncated outputs with no error signal.

**Fix:** Track `sawMessageStart`/`sawMessageStop` sentinels; throw if the stream ends without `message_stop`.

### 🟡 Medium: Edit access error misleads model

**Files:** `edit.ts`, `edit-diff.ts`

When `access()` fails (e.g. `EACCES` on a read-only file), the error was reported as `"File not found"` — causing the model to try creating the file instead of understanding the real problem.

**Fix:** Surface the actual error code: `"Could not access file: path. Error code: EACCES"`

### 🟡 Medium: Terminal dimensions in non-TTY contexts

**File:** `terminal.ts`

`ProcessTerminal` fell back to hardcoded 80×24 when `process.stdout.columns/rows` was undefined, ignoring the standard `COLUMNS`/`LINES` env vars.

**Fix:** Check env vars as intermediate fallback before hardcoded defaults.

### 🟢 Low: Uppercase context file extensions

**File:** `resource-loader.ts`

On case-sensitive filesystems (Linux), `AGENTS.MD` was silently ignored — only `AGENTS.md` was checked.

**Fix:** Add `.MD` variants to the candidate list.
