### PR TITLE
Add GPT-5.5 support to openai-codex provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8746,7 +8746,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8775,7 +8775,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8831,7 +8831,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8946,7 +8946,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8995,7 +8995,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9027,7 +9027,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.14.1",
+			"version": "2.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -225,7 +225,7 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 
 /**
  * Thinking/reasoning level for models that support it.
- * Note: "xhigh" is only supported by OpenAI gpt-5.1-codex-max, gpt-5.2, gpt-5.2-codex, gpt-5.3, and gpt-5.3-codex models.
+ * Note: "xhigh" is only supported by OpenAI reasoning models that explicitly advertise extended reasoning (for example GPT-5.2+ and Codex GPT-5.3+).
  */
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -904,9 +904,11 @@ async function generateModels() {
 
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
-	// Context window is based on observed server limits (400s above ~272k), not marketing numbers.
+	// Most Codex models use the observed 272k ChatGPT-auth server limit. GPT-5.5
+	// is documented for Codex with a larger 400k context window.
 	const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 	const CODEX_CONTEXT = 272000;
+	const CODEX_GPT_55_CONTEXT = 400000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
 		{
@@ -946,30 +948,6 @@ async function generateModels() {
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{
-			id: "gpt-5.2",
-			name: "GPT-5.2",
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			baseUrl: CODEX_BASE_URL,
-			reasoning: true,
-			input: ["text", "image"],
-			cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
-			maxTokens: CODEX_MAX_TOKENS,
-		},
-		{
-			id: "gpt-5.2-codex",
-			name: "GPT-5.2 Codex",
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			baseUrl: CODEX_BASE_URL,
-			reasoning: true,
-			input: ["text", "image"],
-			cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
-			maxTokens: CODEX_MAX_TOKENS,
-		},
-		{
 			id: "gpt-5.3-codex",
 			name: "GPT-5.3 Codex",
 			api: "openai-codex-responses",
@@ -1003,6 +981,18 @@ async function generateModels() {
 			input: ["text", "image"],
 			cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
 			contextWindow: CODEX_CONTEXT,
+			maxTokens: CODEX_MAX_TOKENS,
+		},
+		{
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: CODEX_BASE_URL,
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: CODEX_GPT_55_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -151,7 +151,7 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * - Opus 4.6+ models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
-	if (model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3") || model.id.includes("gpt-5.4")) {
+	if (model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3") || model.id.includes("gpt-5.4") || model.id.includes("gpt-5.5")) {
 		return true;
 	}
 

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -151,7 +151,12 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * - Opus 4.6+ models (xhigh maps to adaptive effort "max" on Anthropic-compatible providers)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
-	if (model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3") || model.id.includes("gpt-5.4") || model.id.includes("gpt-5.5")) {
+	if (
+		model.id.includes("gpt-5.2") ||
+		model.id.includes("gpt-5.3") ||
+		model.id.includes("gpt-5.4") ||
+		model.id.includes("gpt-5.5")
+	) {
 		return true;
 	}
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1,5 +1,10 @@
 import type * as NodeOs from "node:os";
-import type { Tool as OpenAITool, ResponseInput, ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import type {
+	Tool as OpenAITool,
+	ResponseCreateParamsStreaming,
+	ResponseInput,
+	ResponseStreamEvent,
+} from "openai/resources/responses/responses.js";
 
 // NEVER convert to top-level runtime imports - breaks browser/Vite builds (web-ui)
 let _os: typeof NodeOs | null = null;
@@ -25,6 +30,7 @@ import type {
 	SimpleStreamOptions,
 	StreamFunction,
 	StreamOptions,
+	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
@@ -57,6 +63,9 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
 	textVerbosity?: "low" | "medium" | "high";
+	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+	/** Optional callback invoked when the HTTP response headers are received (SSE only). */
+	onResponse?: (response: { status: number; headers: Record<string, string> }) => void | Promise<void>;
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
@@ -75,6 +84,8 @@ interface RequestBody {
 	text?: { verbosity?: string };
 	include?: string[];
 	prompt_cache_key?: string;
+	service_tier?: ResponseCreateParamsStreaming["service_tier"];
+	previous_response_id?: string;
 	[key: string]: unknown;
 }
 
@@ -206,6 +217,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						body: bodyJson,
 						signal: options?.signal,
 					});
+					await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) });
 
 					if (response.ok) {
 						break;
@@ -308,7 +320,7 @@ function buildRequestBody(
 		stream: true,
 		instructions: context.systemPrompt,
 		input: messages,
-		text: { verbosity: options?.textVerbosity || "medium" },
+		text: { verbosity: options?.textVerbosity || "low" },
 		include: ["reasoning.encrypted_content"],
 		prompt_cache_key: options?.sessionId,
 		tool_choice: "auto",
@@ -330,12 +342,19 @@ function buildRequestBody(
 		};
 	}
 
+	if (options?.serviceTier !== undefined) {
+		body.service_tier = options.serviceTier;
+	}
+
 	return body;
 }
 
 function clampReasoningEffort(modelId: string, effort: string): string {
 	const id = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
-	if ((id.startsWith("gpt-5.2") || id.startsWith("gpt-5.3") || id.startsWith("gpt-5.4")) && effort === "minimal")
+	if (
+		(id.startsWith("gpt-5.2") || id.startsWith("gpt-5.3") || id.startsWith("gpt-5.4") || id.startsWith("gpt-5.5")) &&
+		effort === "minimal"
+	)
 		return "low";
 	if (id === "gpt-5.1" && effort === "xhigh") return "high";
 	if (id === "gpt-5.1-codex-mini") return effort === "high" || effort === "xhigh" ? "high" : "medium";
@@ -368,7 +387,11 @@ async function processStream(
 	model: Model<"openai-codex-responses">,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	await processResponsesStream(mapCodexEvents(parseSSE(response, options)), output, stream, model, options);
+	await processResponsesStream(mapCodexEvents(parseSSE(response, options)), output, stream, model, {
+		serviceTier: options?.serviceTier,
+		resolveServiceTier: resolveCodexServiceTier,
+		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+	});
 }
 
 async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): AsyncGenerator<ResponseStreamEvent> {
@@ -486,10 +509,17 @@ interface WebSocketLike {
 	removeEventListener(type: WebSocketEventType, listener: WebSocketListener): void;
 }
 
+interface CachedWebSocketContinuationState {
+	lastRequestBody: RequestBody;
+	lastResponseId: string;
+	lastResponseItems: ResponseInput;
+}
+
 interface CachedWebSocketConnection {
 	socket: WebSocketLike;
 	busy: boolean;
 	idleTimer?: ReturnType<typeof setTimeout>;
+	continuation?: CachedWebSocketContinuationState;
 }
 
 const websocketSessionCache = new Map<string, CachedWebSocketConnection>();
@@ -610,7 +640,11 @@ async function acquireWebSocket(
 	headers: Headers,
 	sessionId: string | undefined,
 	signal?: AbortSignal,
-): Promise<{ socket: WebSocketLike; release: (options?: { keep?: boolean }) => void }> {
+): Promise<{
+	socket: WebSocketLike;
+	entry?: CachedWebSocketConnection;
+	release: (options?: { keep?: boolean }) => void;
+}> {
 	if (!sessionId) {
 		const socket = await connectWebSocket(url, headers, signal);
 		return {
@@ -635,6 +669,7 @@ async function acquireWebSocket(
 			cached.busy = true;
 			return {
 				socket: cached.socket,
+				entry: cached,
 				release: ({ keep } = {}) => {
 					if (!keep || !isWebSocketReusable(cached.socket)) {
 						closeWebSocketSilently(cached.socket);
@@ -666,6 +701,7 @@ async function acquireWebSocket(
 	websocketSessionCache.set(sessionId, entry);
 	return {
 		socket,
+		entry,
 		release: ({ keep } = {}) => {
 			if (!keep || !isWebSocketReusable(entry.socket)) {
 				closeWebSocketSilently(entry.socket);
@@ -819,6 +855,60 @@ async function* parseWebSocket(
 	}
 }
 
+function requestBodyWithoutInput(body: RequestBody): RequestBody {
+	const { input: _input, previous_response_id: _previousResponseId, ...rest } = body;
+	return rest;
+}
+
+function responseInputsEqual(a: ResponseInput | undefined, b: ResponseInput | undefined): boolean {
+	return JSON.stringify(a ?? []) === JSON.stringify(b ?? []);
+}
+
+function requestBodiesMatchExceptInput(a: RequestBody, b: RequestBody): boolean {
+	return JSON.stringify(requestBodyWithoutInput(a)) === JSON.stringify(requestBodyWithoutInput(b));
+}
+
+function getCachedWebSocketInputDelta(
+	body: RequestBody,
+	continuation: CachedWebSocketContinuationState,
+): ResponseInput | undefined {
+	if (!requestBodiesMatchExceptInput(body, continuation.lastRequestBody)) {
+		return undefined;
+	}
+
+	const currentInput = body.input ?? [];
+	const baseline = [...(continuation.lastRequestBody.input ?? []), ...continuation.lastResponseItems];
+	if (currentInput.length < baseline.length) {
+		return undefined;
+	}
+
+	const prefix = currentInput.slice(0, baseline.length);
+	if (!responseInputsEqual(prefix, baseline)) {
+		return undefined;
+	}
+
+	return currentInput.slice(baseline.length);
+}
+
+function buildCachedWebSocketRequestBody(entry: CachedWebSocketConnection, body: RequestBody): RequestBody {
+	const continuation = entry.continuation;
+	if (!continuation) {
+		return body;
+	}
+
+	const delta = getCachedWebSocketInputDelta(body, continuation);
+	if (!delta || !continuation.lastResponseId) {
+		entry.continuation = undefined;
+		return body;
+	}
+
+	return {
+		...body,
+		previous_response_id: continuation.lastResponseId,
+		input: delta,
+	};
+}
+
 async function processWebSocketStream(
 	url: string,
 	body: RequestBody,
@@ -829,10 +919,12 @@ async function processWebSocketStream(
 	onStart: () => void,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	const { socket, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal);
+	const { socket, entry, release } = await acquireWebSocket(url, headers, options?.sessionId, options?.signal);
 	let keepConnection = true;
+	const fullBody = body;
+	const requestBody = entry ? buildCachedWebSocketRequestBody(entry, fullBody) : fullBody;
 	try {
-		socket.send(JSON.stringify({ type: "response.create", ...body }));
+		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		onStart();
 		stream.push({ type: "start", partial: output });
 		await processResponsesStream(
@@ -840,17 +932,80 @@ async function processWebSocketStream(
 			output,
 			stream,
 			model,
-			options,
+			{
+				serviceTier: options?.serviceTier,
+				resolveServiceTier: resolveCodexServiceTier,
+				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+			},
 		);
+		if (entry && output.responseId && !options?.signal?.aborted) {
+			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
+				includeSystemPrompt: false,
+			}).filter((item) => item.type !== "function_call_output");
+			entry.continuation = {
+				lastRequestBody: fullBody,
+				lastResponseId: output.responseId,
+				lastResponseItems: responseItems,
+			};
+		}
 		if (options?.signal?.aborted) {
 			keepConnection = false;
 		}
 	} catch (error) {
+		if (entry) {
+			entry.continuation = undefined;
+		}
 		keepConnection = false;
 		throw error;
 	} finally {
 		release({ keep: keepConnection });
 	}
+}
+
+// ============================================================================
+// Service Tier Pricing
+// ============================================================================
+
+function getServiceTierCostMultiplier(
+	serviceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+	modelId?: string,
+): number {
+	switch (serviceTier) {
+		case "flex":
+			return 0.5;
+		case "priority": {
+			const id = modelId?.includes("/") ? modelId.split("/").pop()! : modelId;
+			if (id?.startsWith("gpt-5.5")) return 2.5;
+			return 2;
+		}
+		default:
+			return 1;
+	}
+}
+
+function applyServiceTierPricing(
+	usage: Usage,
+	serviceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+	model: Pick<Model<"openai-codex-responses">, "id">,
+) {
+	const multiplier = getServiceTierCostMultiplier(serviceTier, model.id);
+	if (multiplier === 1) return;
+
+	usage.cost.input *= multiplier;
+	usage.cost.output *= multiplier;
+	usage.cost.cacheRead *= multiplier;
+	usage.cost.cacheWrite *= multiplier;
+	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
+}
+
+function resolveCodexServiceTier(
+	responseTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+	requestedTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+): ResponseCreateParamsStreaming["service_tier"] | undefined {
+	if (responseTier === "default" && (requestedTier === "flex" || requestedTier === "priority")) {
+		return requestedTier;
+	}
+	return responseTier ?? requestedTier;
 }
 
 // ============================================================================

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -217,7 +217,6 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						body: bodyJson,
 						signal: options?.signal,
 					});
-					await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) });
 
 					if (response.ok) {
 						break;
@@ -256,6 +255,14 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 
 			if (!response?.ok) {
 				throw lastError ?? new Error("Failed after retries");
+			}
+
+			// Fire onResponse exactly once, after the retry loop succeeds.
+			// Wrap in its own try/catch so callback errors don't affect stream processing.
+			try {
+				await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) });
+			} catch {
+				// Intentionally ignored — callback errors must not disrupt the stream
 			}
 
 			if (!response.body) {
@@ -649,11 +656,7 @@ async function acquireWebSocket(
 		const socket = await connectWebSocket(url, headers, signal);
 		return {
 			socket,
-			release: ({ keep } = {}) => {
-				if (keep === false) {
-					closeWebSocketSilently(socket);
-					return;
-				}
+			release: () => {
 				closeWebSocketSilently(socket);
 			},
 		};

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -398,6 +398,7 @@ async function processStream(
 		serviceTier: options?.serviceTier,
 		resolveServiceTier: resolveCodexServiceTier,
 		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+		onWarning: options?.onWarning,
 	});
 }
 
@@ -779,9 +780,13 @@ async function* parseWebSocket(
 	const onMessage: WebSocketListener = (event) => {
 		void (async () => {
 			if (!event || typeof event !== "object" || !("data" in event)) return;
-			const text = await decodeWebSocketData((event as { data?: unknown }).data);
-			if (!text) return;
+			let text: string | null | undefined;
 			try {
+				text = await decodeWebSocketData((event as { data?: unknown }).data);
+				if (!text) {
+					wake();
+					return;
+				}
 				const parsed = JSON.parse(text) as Record<string, unknown>;
 				const type = typeof parsed.type === "string" ? parsed.type : "";
 				if (type === "response.completed" || type === "response.done" || type === "response.incomplete") {
@@ -789,9 +794,19 @@ async function* parseWebSocket(
 					done = true;
 				}
 				queue.push(parsed);
-			} catch {
+			} catch (e) {
 				// Malformed WebSocket message — warn but don't drop wake()
-				options?.onWarning?.("ws_parse_error", `Malformed WebSocket message dropped: ${text.slice(0, 200)}`);
+				if (text === undefined) {
+					options?.onWarning?.(
+						"ws_decode_error",
+						`Failed to decode WebSocket message: ${e instanceof Error ? e.message : String(e)}`,
+					);
+				} else {
+					options?.onWarning?.(
+						"ws_parse_error",
+						`Malformed WebSocket message dropped: ${text?.slice(0, 200) ?? ""}`,
+					);
+				}
 			} finally {
 				// Always wake the consumer — even on parse failure — to prevent stream hangs
 				wake();
@@ -939,6 +954,7 @@ async function processWebSocketStream(
 				serviceTier: options?.serviceTier,
 				resolveServiceTier: resolveCodexServiceTier,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+				onWarning: options?.onWarning,
 			},
 		);
 		if (entry && output.responseId && !options?.signal?.aborted) {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -69,6 +69,16 @@ export interface OpenAIResponsesStreamOptions {
 		usage: Usage,
 		serviceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
 	) => void;
+	/**
+	 * Optional callback to resolve the effective service tier when the API
+	 * returns a generic tier (e.g. "default") rather than the requested one.
+	 * Receives the tier from the response and the tier that was requested.
+	 * Should return the tier to use for pricing.
+	 */
+	resolveServiceTier?: (
+		responseTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+		requestedTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
+	) => ResponseCreateParamsStreaming["service_tier"];
 	/** Optional callback for non-fatal warnings during streaming (e.g. malformed JSON chunks). */
 	onWarning?: (code: string, message: string) => void;
 }
@@ -448,6 +458,11 @@ export async function processResponsesStream<TApi extends Api>(
 					arguments: args,
 				};
 
+				// Clean up partialJson from the output block before finalising
+				if (currentBlock && "partialJson" in currentBlock) {
+					delete (currentBlock as ToolCall & { partialJson?: string }).partialJson;
+				}
+
 				currentBlock = null;
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
@@ -470,7 +485,10 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 			calculateCost(model, output.usage);
 			if (options?.applyServiceTierPricing) {
-				const serviceTier = response?.service_tier ?? options.serviceTier;
+				let serviceTier = response?.service_tier ?? options.serviceTier;
+				if (options?.resolveServiceTier) {
+					serviceTier = options.resolveServiceTier(response?.service_tier, options.serviceTier);
+				}
 				options.applyServiceTierPricing(output.usage, serviceTier);
 			}
 			// Map status to stop reason

--- a/packages/ai/test/abort.test.ts
+++ b/packages/ai/test/abort.test.ts
@@ -235,12 +235,12 @@ describe("AI Providers Abort Tests", () => {
 
 	describe("OpenAI Codex Provider Abort", () => {
 		it.skipIf(!openaiCodexToken)("should abort mid-stream", { retry: 3 }, async () => {
-			const llm = getModel("openai-codex", "gpt-5.2-codex");
+			const llm = getModel("openai-codex", "gpt-5.3-codex");
 			await testAbortSignal(llm, { apiKey: openaiCodexToken });
 		});
 
 		it.skipIf(!openaiCodexToken)("should handle immediate abort", { retry: 3 }, async () => {
-			const llm = getModel("openai-codex", "gpt-5.2-codex");
+			const llm = getModel("openai-codex", "gpt-5.3-codex");
 			await testImmediateAbort(llm, { apiKey: openaiCodexToken });
 		});
 	});

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -273,14 +273,20 @@ describe("Context overflow error handling", () => {
 
 	describe("OpenAI Codex (OAuth)", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should detect overflow via isContextOverflow",
+			"gpt-5.3-codex - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("openai-codex", "gpt-5.2-codex");
+				const model = getModel("openai-codex", "gpt-5.3-codex");
 				const result = await testContextOverflow(model, openaiCodexToken!);
 				logResult(result);
 
-				expect(result.stopReason).toBe("error");
-				expect(isContextOverflow(result.response, model.contextWindow)).toBe(true);
+				if (result.stopReason === "error") {
+					expect(isContextOverflow(result.response, model.contextWindow)).toBe(true);
+				} else {
+					expect(result.stopReason).toBe("stop");
+					expect(result.hasUsageData).toBe(true);
+					expect(result.usage.input + result.usage.cacheRead).toBeGreaterThan(model.contextWindow);
+					expect(isContextOverflow(result.response, model.contextWindow)).toBe(true);
+				}
 			},
 			120000,
 		);

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -65,7 +65,7 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	{ provider: "openai", model: "gpt-5-mini", label: "openai-responses-gpt-5-mini" },
 	{ provider: "azure-openai-responses", model: "gpt-4o-mini", label: "azure-openai-responses-gpt-4o-mini" },
 	// OpenAI Codex
-	{ provider: "openai-codex", model: "gpt-5.2-codex", label: "openai-codex-gpt-5.2-codex" },
+	{ provider: "openai-codex", model: "gpt-5.3-codex", label: "openai-codex-gpt-5.3-codex" },
 	// Google Antigravity
 	{ provider: "google-antigravity", model: "gemini-3-flash", label: "antigravity-gemini-3-flash" },
 	{ provider: "google-antigravity", model: "claude-sonnet-4-5", label: "antigravity-claude-sonnet-4-5" },

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -676,37 +676,37 @@ describe("AI Providers Empty Message Tests", () => {
 
 	describe("OpenAI Codex Provider Empty Messages", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle empty content array",
+			"gpt-5.3-codex - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testEmptyMessage(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle empty string content",
+			"gpt-5.3-codex - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testEmptyStringMessage(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle whitespace-only content",
+			"gpt-5.3-codex - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testWhitespaceOnlyMessage(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle empty assistant message in conversation",
+			"gpt-5.3-codex - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testEmptyAssistantMessage(llm, { apiKey: openaiCodexToken });
 			},
 		);

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -428,19 +428,19 @@ describe("Tool Results with Images", () => {
 
 	describe("OpenAI Codex Provider", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle tool result with only image",
+			"gpt-5.3-codex - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await handleToolWithImageResult(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle tool result with text and image",
+			"gpt-5.3-codex - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await handleToolWithTextAndImageResult(llm, { apiKey: openaiCodexToken });
 			},
 		);

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -705,4 +705,640 @@ describe("openai-codex streaming", () => {
 		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token });
 		await streamResult.result();
 	});
+
+	it("passes service_tier in request body when serviceTier is set", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				expect(body?.service_tier).toBe("priority");
+
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, serviceTier: "priority" });
+		await streamResult.result();
+	});
+
+	it("calls onResponse with status and headers", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream", "x-test-header": "yes" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const onResponse = vi.fn();
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, onResponse });
+		await streamResult.result();
+
+		expect(onResponse).toHaveBeenCalledOnce();
+		expect(onResponse).toHaveBeenCalledWith({
+			status: 200,
+			headers: expect.objectContaining({ "content-type": "text/event-stream", "x-test-header": "yes" }),
+		});
+	});
+
+	it.each(["gpt-5.3-codex", "gpt-5.4", "gpt-5.5"])("clamps %s minimal reasoning effort to low", async (modelId) => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+
+		const payload = Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+			"utf8",
+		).toString("base64");
+		const token = `aaa.${payload}.bbb`;
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				expect(body?.reasoning).toEqual({ effort: "low", summary: "auto" });
+
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: modelId,
+			name: modelId,
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			reasoningEffort: "minimal",
+		});
+		await streamResult.result();
+	});
+
+	it("applies flex service tier pricing (0.5x multiplier)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, serviceTier: "flex" });
+		const result = await streamResult.result();
+
+		// 0.5x multiplier: input 5, output 10, cacheRead 0, cacheWrite 0 (no cached tokens in response)
+		expect(result.usage.cost.input).toBeCloseTo(5, 5);
+		expect(result.usage.cost.output).toBeCloseTo(10, 5);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0, 5);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(0, 5);
+		expect(result.usage.cost.total).toBeCloseTo(15, 5);
+	});
+
+	it("applies priority service tier pricing (2.5x for gpt-5.5)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, serviceTier: "priority" });
+		const result = await streamResult.result();
+
+		// 2.5x multiplier: input 25, output 50, cacheRead 0, cacheWrite 0 (no cached tokens in response)
+		expect(result.usage.cost.input).toBeCloseTo(25, 5);
+		expect(result.usage.cost.output).toBeCloseTo(50, 5);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0, 5);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(0, 5);
+		expect(result.usage.cost.total).toBeCloseTo(75, 5);
+	});
+
+	it("applies standard pricing (1x multiplier) when no service tier is set", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token });
+		const result = await streamResult.result();
+
+		// 1x multiplier: input 10, output 20, cacheRead 0, cacheWrite 0 (no cached tokens in response)
+		expect(result.usage.cost.input).toBeCloseTo(10, 5);
+		expect(result.usage.cost.output).toBeCloseTo(20, 5);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0, 5);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(0, 5);
+		expect(result.usage.cost.total).toBeCloseTo(30, 5);
+	});
+
+	it("cleans up partialJson after function call arguments are done", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "test_tool", arguments: "" },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.function_call_arguments.delta", delta: '{"key":' })}`,
+			`data: ${JSON.stringify({ type: "response.function_call_arguments.delta", delta: '"value"}' })}`,
+			`data: ${JSON.stringify({
+				type: "response.function_call_arguments.done",
+				arguments: '{"key":"value"}',
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "function_call",
+					id: "fc_1",
+					call_id: "call_1",
+					name: "test_tool",
+					arguments: '{"key":"value"}',
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Call test tool", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token });
+		const result = await streamResult.result();
+
+		const toolCallBlock = result.content.find((c) => c.type === "toolCall");
+		expect(toolCallBlock).toBeDefined();
+		expect(toolCallBlock).not.toHaveProperty("partialJson");
+		expect((toolCallBlock as any).arguments).toEqual({ key: "value" });
+	});
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1250,6 +1250,311 @@ describe("openai-codex streaming", () => {
 		expect(result.usage.cost.total).toBeCloseTo(30, 5);
 	});
 
+	it("resolves 'default' response tier back to requested tier for pricing (gpt-5.5 priority 2.5x)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		// Build SSE with service_tier: "default" in response.completed
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					service_tier: "default",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		// Request priority tier — response returns "default", should resolve to "priority" → 2.5x for gpt-5.5
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, serviceTier: "priority" });
+		const result = await streamResult.result();
+
+		// 2.5x multiplier applied (not 1x), because "default" resolves to requested "priority"
+		expect(result.usage.cost.input).toBeCloseTo(25, 5);
+		expect(result.usage.cost.output).toBeCloseTo(50, 5);
+		expect(result.usage.cost.total).toBeCloseTo(75, 5);
+	});
+
+	it("calls onResponse once with final status when retries succeed", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = buildSSEPayload({ status: "completed" });
+		const encoder = new TextEncoder();
+
+		let codexCallCount = 0;
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				codexCallCount++;
+				if (codexCallCount === 1) {
+					// First attempt: 429 rate limit (retryable)
+					return new Response(JSON.stringify({ error: { message: "rate limit", type: "rate_limit_exceeded" } }), {
+						status: 429,
+					});
+				}
+				// Second attempt: success with SSE stream
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(sse));
+							controller.close();
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					},
+				);
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const onResponse = vi.fn();
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, onResponse });
+		await streamResult.result();
+
+		// onResponse fires for each fetch response, including retries
+		expect(onResponse).toHaveBeenCalled();
+		// The final call should have status 200
+		const lastCall = onResponse.mock.calls[onResponse.mock.calls.length - 1];
+		expect(lastCall[0].status).toBe(200);
+	});
+
+	it("calls onResponse once with error status for non-retryable 4xx", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				// 400 is not retryable
+				return new Response(JSON.stringify({ error: { message: "Bad request", type: "invalid_request_error" } }), {
+					status: 400,
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const onResponse = vi.fn();
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, onResponse });
+
+		// The stream catches the error internally and returns a result with stopReason "error"
+		const result = await streamResult.result();
+		expect(result.stopReason).toBe("error");
+		// onResponse is NOT called for error responses — it only fires after successful retries
+		expect(onResponse).not.toHaveBeenCalled();
+	});
+
+	it("applies priority service tier pricing (2x for non-gpt-5.5 models)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
+		const sse = buildSSEPayload({ status: "completed" });
+		const encoder = new TextEncoder();
+
+		// Override usage in the SSE payload — buildSSEPayload uses small values, we need large ones
+		const ssePricing = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 1000000,
+						output_tokens: 1000000,
+						total_tokens: 2000000,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(ssePricing));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, serviceTier: "priority" });
+		const result = await streamResult.result();
+
+		// 2x multiplier for non-gpt-5.5 models with priority tier
+		expect(result.usage.cost.input).toBeCloseTo(20, 5);
+		expect(result.usage.cost.output).toBeCloseTo(40, 5);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0, 5);
+		expect(result.usage.cost.cacheWrite).toBeCloseTo(0, 5);
+		expect(result.usage.cost.total).toBeCloseTo(60, 5);
+	});
+
 	it("cleans up partialJson after function call arguments are done", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -303,7 +303,7 @@ describe("openai-codex streaming", () => {
 		expect(result.stopReason).toBe("length");
 	});
 
-	it("sets conversation_id/session_id headers and prompt_cache_key when sessionId is provided", async () => {
+	it("sets session_id header and prompt_cache_key when sessionId is provided", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;
 
@@ -364,13 +364,11 @@ describe("openai-codex streaming", () => {
 			if (url === "https://chatgpt.com/backend-api/codex/responses") {
 				const headers = init?.headers instanceof Headers ? init.headers : undefined;
 				// Verify sessionId is set in headers
-				expect(headers?.get("conversation_id")).toBe(sessionId);
 				expect(headers?.get("session_id")).toBe(sessionId);
 
 				// Verify sessionId is set in request body as prompt_cache_key
 				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
 				expect(body?.prompt_cache_key).toBe(sessionId);
-				expect(body?.prompt_cache_retention).toBe("in-memory");
 
 				return new Response(stream, {
 					status: 200,
@@ -1405,14 +1403,14 @@ describe("openai-codex streaming", () => {
 		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, onResponse });
 		await streamResult.result();
 
-		// onResponse fires for each fetch response, including retries
-		expect(onResponse).toHaveBeenCalled();
+		// onResponse fires once after the retry loop succeeds with a 200
+		expect(onResponse).toHaveBeenCalledOnce();
 		// The final call should have status 200
 		const lastCall = onResponse.mock.calls[onResponse.mock.calls.length - 1];
 		expect(lastCall[0].status).toBe(200);
 	});
 
-	it("calls onResponse once with error status for non-retryable 4xx", async () => {
+	it("does NOT call onResponse for non-retryable 4xx errors", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;
 		const token = mockToken();
@@ -1462,12 +1460,73 @@ describe("openai-codex streaming", () => {
 		expect(onResponse).not.toHaveBeenCalled();
 	});
 
-	it("applies priority service tier pricing (2x for non-gpt-5.5 models)", async () => {
+	it("swallows onResponse callback errors without disrupting the stream", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;
 		const token = mockToken();
 
 		const sse = buildSSEPayload({ status: "completed" });
+		const encoder = new TextEncoder();
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(sse));
+							controller.close();
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					},
+				);
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const onResponse = vi.fn(() => {
+			throw new Error("onResponse explosion");
+		});
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, onResponse });
+		const result = await streamResult.result();
+
+		expect(onResponse).toHaveBeenCalledOnce();
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((c) => c.type === "text")?.text).toBe("Hello");
+	});
+
+	it("applies priority service tier pricing (2x for non-gpt-5.5 models)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+
 		const encoder = new TextEncoder();
 
 		// Override usage in the SSE payload — buildSSEPayload uses small values, we need large ones

--- a/packages/ai/test/openai-codex-websocket.test.ts
+++ b/packages/ai/test/openai-codex-websocket.test.ts
@@ -191,4 +191,180 @@ describe("openai-codex WebSocket streaming", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(onWarning).toHaveBeenCalledWith("ws_parse_error", expect.stringContaining("Malformed WebSocket message"));
 	});
+
+	it("uses delta context (previous_response_id) on follow-up WebSocket requests with the same sessionId", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sessionId = "test-session-delta";
+
+		const sockets: MockWebSocket[] = [];
+		const sentMessages: string[] = [];
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				sockets.push(this);
+			}
+
+			send(data: string): void {
+				sentMessages.push(data);
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "First message", timestamp: Date.now() }],
+		};
+
+		// First request
+		const streamResult1 = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sockets.length === 0) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Send first response with a responseId
+		const firstEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "First" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "First" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_first_123",
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			},
+		];
+
+		for (const event of firstEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result1 = await streamResult1.result();
+		expect(result1.responseId).toBe("resp_first_123");
+
+		// Verify first request did NOT have previous_response_id
+		const firstPayload = JSON.parse(sentMessages[0]);
+		expect(firstPayload).not.toHaveProperty("previous_response_id");
+
+		// Second request with same sessionId
+		const context2: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "First message", timestamp: Date.now() },
+				result1,
+				{ role: "user", content: "Second message", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult2 = streamOpenAICodexResponses(model, context2, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		// The cached WebSocket is reused for the same sessionId, so wait for the second message
+		await vi.waitFor(() => {
+			if (sentMessages.length < 2) throw new Error("Second WebSocket message not yet sent");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Send second response on the reused socket
+		const secondEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_2", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Second" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_2",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Second" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			},
+		];
+
+		for (const event of secondEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result2 = await streamResult2.result();
+		expect(result2.content.find((c) => c.type === "text")?.text).toBe("Second");
+
+		// Verify second request uses delta context: it includes previous_response_id
+		// and sends only the new input item instead of replaying the whole history.
+		const secondPayload = JSON.parse(sentMessages[1]);
+		expect(secondPayload.previous_response_id).toBe("resp_first_123");
+		expect(secondPayload.input.length).toBeLessThan(firstPayload.input.length + 2);
+		expect(secondPayload.input).toHaveLength(1);
+	});
 });

--- a/packages/ai/test/openai-codex-websocket.test.ts
+++ b/packages/ai/test/openai-codex-websocket.test.ts
@@ -367,4 +367,673 @@ describe("openai-codex WebSocket streaming", () => {
 		expect(secondPayload.input.length).toBeLessThan(firstPayload.input.length + 2);
 		expect(secondPayload.input).toHaveLength(1);
 	});
+
+	// --- Fallback tests: getCachedWebSocketInputDelta returns undefined ---
+
+	it("sends full body without previous_response_id when request body changes (body mismatch)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sessionId = "test-body-mismatch";
+
+		const sockets: MockWebSocket[] = [];
+		const sentMessages: string[] = [];
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				sockets.push(this);
+			}
+			send(data: string): void {
+				sentMessages.push(data);
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		// --- First request ---
+		const context1: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+		};
+
+		const streamResult1 = streamOpenAICodexResponses(model, context1, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sockets.length === 0) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Complete first request with a responseId
+		const firstEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_bm_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hi" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_bm_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hi" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_bm_first",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of firstEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result1 = await streamResult1.result();
+		expect(result1.responseId).toBe("resp_bm_first");
+
+		// --- Second request with DIFFERENT systemPrompt (body mismatch) ---
+		const context2: Context = {
+			systemPrompt: "You are a pirate.", // Different system prompt → body mismatch
+			messages: [
+				{ role: "user", content: "Hello", timestamp: Date.now() },
+				result1,
+				{ role: "user", content: "Follow-up", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult2 = streamOpenAICodexResponses(model, context2, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sentMessages.length < 2) throw new Error("Second WebSocket message not yet sent");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Complete second request
+		const secondEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_bm_2", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Arrr" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_bm_2",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Arrr" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_bm_second",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of secondEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result2 = await streamResult2.result();
+		expect(result2.content.find((c) => c.type === "text")?.text).toBe("Arrr");
+
+		// Assert: second request should NOT use previous_response_id
+		// because the body (systemPrompt) changed
+		const secondPayload = JSON.parse(sentMessages[1]);
+		expect(secondPayload).not.toHaveProperty("previous_response_id");
+		// And it should contain the full input array (not a delta)
+		expect(secondPayload.input.length).toBeGreaterThan(1);
+	});
+
+	it("sends full body without previous_response_id when input prefix no longer matches baseline (prefix mismatch)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sessionId = "test-prefix-mismatch";
+
+		const sockets: MockWebSocket[] = [];
+		const sentMessages: string[] = [];
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				sockets.push(this);
+			}
+			send(data: string): void {
+				sentMessages.push(data);
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		// --- First request ---
+		const context1: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Original question", timestamp: Date.now() }],
+		};
+
+		const streamResult1 = streamOpenAICodexResponses(model, context1, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sockets.length === 0) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		const firstEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_pm_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Answer" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_pm_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Answer" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_pm_first",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of firstEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result1 = await streamResult1.result();
+		expect(result1.responseId).toBe("resp_pm_first");
+
+		// --- Second request where the user EDITED the earlier message ---
+		// The first message changed from "Original question" to "Edited question",
+		// so the input no longer starts with the previous baseline → prefix mismatch.
+		const context2: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "Edited question", timestamp: Date.now() }, // Changed!
+				result1,
+				{ role: "user", content: "Follow-up", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult2 = streamOpenAICodexResponses(model, context2, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sentMessages.length < 2) throw new Error("Second WebSocket message not yet sent");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		const secondEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_pm_2", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "New answer" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_pm_2",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "New answer" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_pm_second",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of secondEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result2 = await streamResult2.result();
+		expect(result2.content.find((c) => c.type === "text")?.text).toBe("New answer");
+
+		// Assert: second request should NOT use previous_response_id
+		// because the input prefix (edited message) doesn't match the baseline
+		const secondPayload = JSON.parse(sentMessages[1]);
+		expect(secondPayload).not.toHaveProperty("previous_response_id");
+		// Full input array should be present, not a delta
+		expect(secondPayload.input.length).toBeGreaterThan(1);
+	});
+
+	it("sends full body without previous_response_id when first response has no responseId (missing lastResponseId)", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sessionId = "test-missing-responseid";
+
+		const sockets: MockWebSocket[] = [];
+		const sentMessages: string[] = [];
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				sockets.push(this);
+			}
+			send(data: string): void {
+				sentMessages.push(data);
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		// --- First request: response.completed with NO id ---
+		const context1: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+		};
+
+		const streamResult1 = streamOpenAICodexResponses(model, context1, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sockets.length === 0) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// response.completed WITHOUT an id field → output.responseId stays undefined
+		const firstEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_mr_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hi" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_mr_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hi" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					// No "id" field!
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of firstEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result1 = await streamResult1.result();
+		// No responseId was in the completion event
+		expect(result1.responseId).toBeUndefined();
+
+		// --- Second request: should send full body since continuation was never set ---
+		const context2: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "Hello", timestamp: Date.now() },
+				result1,
+				{ role: "user", content: "Follow-up", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult2 = streamOpenAICodexResponses(model, context2, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sentMessages.length < 2) throw new Error("Second WebSocket message not yet sent");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		const secondEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_mr_2", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "World" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_mr_2",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "World" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_mr_second",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of secondEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result2 = await streamResult2.result();
+		expect(result2.content.find((c) => c.type === "text")?.text).toBe("World");
+
+		// Assert: second request should NOT use previous_response_id
+		// because no continuation was stored (first response had no id)
+		const secondPayload = JSON.parse(sentMessages[1]);
+		expect(secondPayload).not.toHaveProperty("previous_response_id");
+		expect(secondPayload.input.length).toBeGreaterThan(1);
+	});
+
+	it("sends full body without previous_response_id after a WebSocket error clears continuation", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sessionId = "test-error-clears-continuation";
+
+		const sockets: MockWebSocket[] = [];
+		const sentMessages: string[] = [];
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				sockets.push(this);
+			}
+			send(data: string): void {
+				sentMessages.push(data);
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		// --- First request: succeeds normally ---
+		const context1: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+		};
+
+		const streamResult1 = streamOpenAICodexResponses(model, context1, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sockets.length === 0) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		const firstEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_ec_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hi" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_ec_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hi" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_ec_first",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of firstEvents) {
+			sockets[0]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result1 = await streamResult1.result();
+		expect(result1.responseId).toBe("resp_ec_first");
+
+		// --- Second request: triggers a WebSocket error ---
+		const context2: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "Hello", timestamp: Date.now() },
+				result1,
+				{ role: "user", content: "Follow-up", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult2 = streamOpenAICodexResponses(model, context2, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		await vi.waitFor(() => {
+			if (sentMessages.length < 2) throw new Error("Second WebSocket message not yet sent");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Emit an error on the socket — this should clear continuation
+		sockets[0]!.emit("error", { message: "Connection lost" });
+
+		// The error is caught at the stream level and returned with stopReason "error"
+		const result2 = await streamResult2.result();
+		expect(result2.stopReason).toBe("error");
+		expect(result2.errorMessage).toContain("Connection lost");
+
+		// --- Third request: should send full body without previous_response_id ---
+		// (The error cleared the continuation and removed the cached socket)
+		const context3: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "Hello", timestamp: Date.now() },
+				result1,
+				{ role: "user", content: "New follow-up", timestamp: Date.now() },
+			],
+		};
+
+		const streamResult3 = streamOpenAICodexResponses(model, context3, {
+			apiKey: token,
+			transport: "websocket",
+			sessionId,
+		});
+
+		// A new socket should be created since the old one was closed on error
+		await vi.waitFor(() => {
+			if (sockets.length < 2) throw new Error("Third WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 50));
+
+		await vi.waitFor(() => {
+			if (sentMessages.length < 3) throw new Error("Third WebSocket message not yet sent");
+		});
+
+		const thirdEvents = [
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_ec_3", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Retry" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_ec_3",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Retry" }],
+				},
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_ec_third",
+					status: "completed",
+					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+				},
+			},
+		];
+		for (const event of thirdEvents) {
+			sockets[1]!.emit("message", { data: JSON.stringify(event) });
+			await new Promise((r) => setTimeout(r, 5));
+		}
+
+		const result3 = await streamResult3.result();
+		expect(result3.content.find((c) => c.type === "text")?.text).toBe("Retry");
+
+		// Assert: third request should NOT use previous_response_id
+		// because the error cleared the continuation state
+		const thirdPayload = JSON.parse(sentMessages[2]);
+		expect(thirdPayload).not.toHaveProperty("previous_response_id");
+		expect(thirdPayload.input.length).toBeGreaterThan(1);
+	});
 });

--- a/packages/ai/test/openai-codex-websocket.test.ts
+++ b/packages/ai/test/openai-codex-websocket.test.ts
@@ -453,7 +453,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_bm_first",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -509,7 +514,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_bm_second",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -611,7 +621,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_pm_first",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -668,7 +683,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_pm_second",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -771,7 +791,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					// No "id" field!
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -827,7 +852,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_mr_second",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -928,7 +958,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_ec_first",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];
@@ -1018,7 +1053,12 @@ describe("openai-codex WebSocket streaming", () => {
 				response: {
 					id: "resp_ec_third",
 					status: "completed",
-					usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6, input_tokens_details: { cached_tokens: 0 } },
+					usage: {
+						input_tokens: 5,
+						output_tokens: 1,
+						total_tokens: 6,
+						input_tokens_details: { cached_tokens: 0 },
+					},
 				},
 			},
 		];

--- a/packages/ai/test/openai-responses-tool-result-images.test.ts
+++ b/packages/ai/test/openai-responses-tool-result-images.test.ts
@@ -183,8 +183,8 @@ describe("Responses API tool result images", () => {
 		);
 	});
 
-	describe("OpenAI Codex Responses Provider (gpt-5.2-codex)", () => {
-		const model = getModel("openai-codex", "gpt-5.2-codex");
+	describe("OpenAI Codex Responses Provider (gpt-5.3-codex)", () => {
+		const model = getModel("openai-codex", "gpt-5.3-codex");
 
 		it.skipIf(!openaiCodexToken)(
 			"should send tool result images in function_call_output",

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -138,7 +138,7 @@ describe("responseId E2E Tests", () => {
 
 	describe("OpenAI Codex Provider", () => {
 		it.skipIf(!openaiCodexToken)("should expose responseId", { retry: 3, timeout: 30000 }, async () => {
-			const llm = getModel("openai-codex", "gpt-5.2-codex");
+			const llm = getModel("openai-codex", "gpt-5.3-codex");
 			await expectResponseId(llm, { apiKey: openaiCodexToken });
 		});
 	});

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -214,7 +214,11 @@ async function handleThinking<TApi extends Api>(model: Model<TApi>, options?: St
 
 	expect(response.stopReason, `Error: ${response.errorMessage}`).toBe("stop");
 	expect(thinkingStarted).toBe(true);
-	expect(thinkingChunks.length).toBeGreaterThan(0);
+	// ChatGPT Codex may emit reasoning lifecycle events with encrypted reasoning
+	// content but no human-readable thinking deltas.
+	if (model.provider !== "openai-codex") {
+		expect(thinkingChunks.length).toBeGreaterThan(0);
+	}
 	expect(thinkingCompleted).toBe(true);
 	expect(response.content.some((b) => b.type === "thinking")).toBeTruthy();
 }
@@ -1027,8 +1031,8 @@ describe("Generate E2E Tests", () => {
 		});
 	});
 
-	describe("OpenAI Codex Provider (gpt-5.2-codex)", () => {
-		const llm = getModel("openai-codex", "gpt-5.2-codex");
+	describe("OpenAI Codex Provider (gpt-5.3-codex)", () => {
+		const llm = getModel("openai-codex", "gpt-5.3-codex");
 
 		it.skipIf(!openaiCodexToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: openaiCodexToken });

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -31,4 +31,16 @@ describe("supportsXhigh", () => {
 		expect(model).toBeDefined();
 		expect(supportsXhigh(model!)).toBe(true);
 	});
+
+	it("returns true for GPT-5.5 models", () => {
+		const model = getModel("openai-codex", "gpt-5.5");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
+
+	it("returns true for OpenRouter GPT-5.5", () => {
+		const model = getModel("openrouter", "openai/gpt-5.5");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(true);
+	});
 });

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -273,10 +273,10 @@ describe("Token Statistics on Abort", () => {
 
 	describe("OpenAI Codex Provider", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should include token stats when aborted mid-stream",
+			"gpt-5.3-codex - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testTokensOnAbort(llm, { apiKey: openaiCodexToken });
 			},
 		);

--- a/packages/ai/test/tool-call-id-normalization.test.ts
+++ b/packages/ai/test/tool-call-id-normalization.test.ts
@@ -38,7 +38,7 @@ const echoTool: Tool<typeof echoToolSchema> = {
  *
  * 1. Use github-copilot gpt-5.2-codex to generate a tool call
  * 2. Switch to openrouter openai/gpt-5.2-codex and complete
- * 3. Switch to openai-codex gpt-5.2-codex and complete
+ * 3. Switch to openai-codex gpt-5.3-codex and complete
  *
  * Both should succeed without "call_id too long" errors.
  */
@@ -117,7 +117,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 		"github-copilot -> openai-codex should normalize pipe-separated IDs",
 		async () => {
 			const copilotModel = getModel("github-copilot", "gpt-5.2-codex");
-			const codexModel = getModel("openai-codex", "gpt-5.2-codex");
+			const codexModel = getModel("openai-codex", "gpt-5.3-codex");
 
 			// Step 1: Generate tool call with github-copilot
 			const userMessage: Message = {
@@ -266,7 +266,7 @@ describe("Tool Call ID Normalization - Prefilled Context", () => {
 	it.skipIf(!codexToken)(
 		"openai-codex should handle prefilled context with long pipe-separated IDs",
 		async () => {
-			const model = getModel("openai-codex", "gpt-5.2-codex");
+			const model = getModel("openai-codex", "gpt-5.3-codex");
 			const messages = buildPrefilledMessages();
 
 			const response = await completeSimple(

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -290,10 +290,10 @@ describe("Tool Call Without Result Tests", () => {
 
 	describe("OpenAI Codex Provider", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should filter out tool calls without corresponding tool results",
+			"gpt-5.3-codex - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("openai-codex", "gpt-5.2-codex");
+				const model = getModel("openai-codex", "gpt-5.3-codex");
 				await testToolCallWithoutResult(model, { apiKey: openaiCodexToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -653,10 +653,10 @@ describe("totalTokens field", () => {
 
 	describe("OpenAI Codex (OAuth)", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should return totalTokens equal to sum of components",
+			"gpt-5.3-codex - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 
 				console.log(`\nOpenAI Codex / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openaiCodexToken });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -701,28 +701,28 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 
 	describe("OpenAI Codex Provider Unicode Handling", () => {
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle emoji in tool results",
+			"gpt-5.3-codex - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testEmojiInToolResults(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle real-world LinkedIn comment data with emoji",
+			"gpt-5.3-codex - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testRealWorldLinkedInData(llm, { apiKey: openaiCodexToken });
 			},
 		);
 
 		it.skipIf(!openaiCodexToken)(
-			"gpt-5.2-codex - should handle unpaired high surrogate (0xD83D) in tool results",
+			"gpt-5.3-codex - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("openai-codex", "gpt-5.2-codex");
+				const llm = getModel("openai-codex", "gpt-5.3-codex");
 				await testUnpairedHighSurrogate(llm, { apiKey: openaiCodexToken });
 			},
 		);

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/defaults.ts
+++ b/packages/coding-agent/src/core/defaults.ts
@@ -1,3 +1,3 @@
 import type { ThinkingLevel } from "@dreb/agent-core";
 
-export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "xhigh";

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #189

Adds GPT-5.5 support to the `openai-codex` provider and ports upstream service-tier pricing, WebSocket caching, and reasoning defaults.

Implementation plan posted as a comment below.
