### PR TITLE
Add OAuth refresh buffer to prevent premature 401s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8746,7 +8746,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8775,7 +8775,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8831,7 +8831,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8946,7 +8946,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -8995,7 +8995,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9027,7 +9027,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.15.1",
+			"version": "2.15.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -47,7 +47,13 @@ import { antigravityOAuthProvider } from "./google-antigravity.js";
 import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
 import { kimiCodingOAuthProvider } from "./kimi-coding.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
-import { isOAuthTokenExpired, type OAuthCredentials, type OAuthProviderId, type OAuthProviderInfo, type OAuthProviderInterface } from "./types.js";
+import {
+	isOAuthTokenExpired,
+	type OAuthCredentials,
+	type OAuthProviderId,
+	type OAuthProviderInfo,
+	type OAuthProviderInterface,
+} from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	githubCopilotOAuthProvider,

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -47,7 +47,7 @@ import { antigravityOAuthProvider } from "./google-antigravity.js";
 import { geminiCliOAuthProvider } from "./google-gemini-cli.js";
 import { kimiCodingOAuthProvider } from "./kimi-coding.js";
 import { openaiCodexOAuthProvider } from "./openai-codex.js";
-import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.js";
+import { isOAuthTokenExpired, type OAuthCredentials, type OAuthProviderId, type OAuthProviderInfo, type OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	githubCopilotOAuthProvider,
@@ -158,8 +158,8 @@ export async function getOAuthApiKey(
 		return null;
 	}
 
-	// Refresh if expired
-	if (Date.now() >= creds.expires) {
+	// Refresh if expired or within proactive buffer
+	if (isOAuthTokenExpired(creds)) {
 		try {
 			creds = await provider.refreshToken(creds);
 		} catch (_error) {

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -7,6 +7,14 @@ export type OAuthCredentials = {
 	[key: string]: unknown;
 };
 
+/** Proactive refresh buffer to avoid 401s from clock skew / server-side early expiry (ms) */
+export const REFRESH_BUFFER_MS = 60_000;
+
+/** Check whether an OAuth token is expired or within the proactive refresh buffer. */
+export function isOAuthTokenExpired(credentials: OAuthCredentials, now = Date.now()): boolean {
+	return now >= credentials.expires - REFRESH_BUFFER_MS;
+}
+
 export type OAuthProviderId = string;
 
 /** @deprecated Use OAuthProviderId instead */

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -12,7 +12,9 @@ export const REFRESH_BUFFER_MS = 60_000;
 
 /** Check whether an OAuth token is expired or within the proactive refresh buffer. */
 export function isOAuthTokenExpired(credentials: OAuthCredentials, now = Date.now()): boolean {
-	return now >= credentials.expires - REFRESH_BUFFER_MS;
+	const expires = Number(credentials.expires);
+	if (!Number.isFinite(expires)) return true;
+	return now >= expires - REFRESH_BUFFER_MS;
 }
 
 export type OAuthProviderId = string;

--- a/packages/ai/test/kimi-coding-oauth.test.ts
+++ b/packages/ai/test/kimi-coding-oauth.test.ts
@@ -794,7 +794,7 @@ describe("Kimi For Coding OAuth", () => {
 			const creds: OAuthCredentials = {
 				refresh: "r",
 				access: "my-access-token",
-				expires: Date.now() + 1000,
+				expires: Date.now() + 120_000,
 			};
 			expect(kimiCodingOAuthProvider.getApiKey(creds)).toBe("my-access-token");
 		});
@@ -811,7 +811,7 @@ describe("Kimi For Coding OAuth", () => {
 			} = {
 				refresh: "r",
 				access: "a",
-				expires: Date.now() + 1000,
+				expires: Date.now() + 120_000,
 				modelId: "kimi-k2-0715-chat",
 				contextLength: 131072,
 			};
@@ -864,7 +864,7 @@ describe("Kimi For Coding OAuth", () => {
 			const creds: OAuthCredentials = {
 				refresh: "r",
 				access: "a",
-				expires: Date.now() + 1000,
+				expires: Date.now() + 120_000,
 			};
 
 			const models = [

--- a/packages/ai/test/oauth-utils.test.ts
+++ b/packages/ai/test/oauth-utils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOAuthApiKey, registerOAuthProvider, unregisterOAuthProvider } from "../src/utils/oauth/index.js";
-import { isOAuthTokenExpired, REFRESH_BUFFER_MS } from "../src/utils/oauth/types.js";
 import type { OAuthCredentials } from "../src/utils/oauth/types.js";
+import { isOAuthTokenExpired, REFRESH_BUFFER_MS } from "../src/utils/oauth/types.js";
 
 describe("isOAuthTokenExpired", () => {
 	it("returns false when now is exactly 1ms before the buffer boundary", () => {

--- a/packages/ai/test/oauth-utils.test.ts
+++ b/packages/ai/test/oauth-utils.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getOAuthApiKey, registerOAuthProvider, unregisterOAuthProvider } from "../src/utils/oauth/index.js";
+import { REFRESH_BUFFER_MS } from "../src/utils/oauth/types.js";
+import type { OAuthCredentials } from "../src/utils/oauth/types.js";
+
+describe("getOAuthApiKey", () => {
+	const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+	beforeEach(() => {
+		registerOAuthProvider({
+			id: providerId,
+			name: "Test OAuth Provider",
+			async login() {
+				throw new Error("Not used in this test");
+			},
+			async refreshToken(credentials) {
+				return {
+					...credentials,
+					access: "refreshed-access-token",
+					expires: Date.now() + 3600_000,
+				};
+			},
+			getApiKey(credentials) {
+				return `Bearer ${credentials.access}`;
+			},
+		});
+	});
+
+	afterEach(() => {
+		unregisterOAuthProvider(providerId);
+		vi.useRealTimers();
+	});
+
+	it("returns current access token when token is far from expiry", async () => {
+		const now = 1_000_000;
+		vi.setSystemTime(now);
+
+		const credentials: Record<string, OAuthCredentials> = {
+			[providerId]: {
+				refresh: "refresh-token",
+				access: "current-access-token",
+				expires: now + REFRESH_BUFFER_MS + 5000,
+			},
+		};
+
+		const result = await getOAuthApiKey(providerId, credentials);
+		expect(result).not.toBeNull();
+		expect(result?.apiKey).toBe("Bearer current-access-token");
+		expect(result?.newCredentials.access).toBe("current-access-token");
+	});
+
+	it("refreshes token when within the proactive buffer", async () => {
+		const now = 1_000_000;
+		vi.setSystemTime(now);
+
+		const credentials: Record<string, OAuthCredentials> = {
+			[providerId]: {
+				refresh: "refresh-token",
+				access: "current-access-token",
+				expires: now + REFRESH_BUFFER_MS - 1000,
+			},
+		};
+
+		const result = await getOAuthApiKey(providerId, credentials);
+		expect(result).not.toBeNull();
+		expect(result?.apiKey).toBe("Bearer refreshed-access-token");
+		expect(result?.newCredentials.access).toBe("refreshed-access-token");
+	});
+
+	it("refreshes token when already expired", async () => {
+		const now = 1_000_000;
+		vi.setSystemTime(now);
+
+		const credentials: Record<string, OAuthCredentials> = {
+			[providerId]: {
+				refresh: "refresh-token",
+				access: "expired-access-token",
+				expires: now - 1000,
+			},
+		};
+
+		const result = await getOAuthApiKey(providerId, credentials);
+		expect(result).not.toBeNull();
+		expect(result?.apiKey).toBe("Bearer refreshed-access-token");
+		expect(result?.newCredentials.access).toBe("refreshed-access-token");
+	});
+
+	it("returns null when credentials are missing", async () => {
+		const credentials: Record<string, OAuthCredentials> = {};
+		const result = await getOAuthApiKey(providerId, credentials);
+		expect(result).toBeNull();
+	});
+
+	it("throws wrapped error when refresh fails", async () => {
+		const now = 1_000_000;
+		vi.setSystemTime(now);
+
+		unregisterOAuthProvider(providerId);
+		registerOAuthProvider({
+			id: providerId,
+			name: "Failing Provider",
+			async login() {
+				throw new Error("Not used");
+			},
+			async refreshToken() {
+				throw new Error("network error");
+			},
+			getApiKey(credentials) {
+				return `Bearer ${credentials.access}`;
+			},
+		});
+
+		const credentials: Record<string, OAuthCredentials> = {
+			[providerId]: {
+				refresh: "refresh-token",
+				access: "expired-access-token",
+				expires: now - 1000,
+			},
+		};
+
+		await expect(getOAuthApiKey(providerId, credentials)).rejects.toThrow(
+			`Failed to refresh OAuth token for ${providerId}`,
+		);
+	});
+});

--- a/packages/ai/test/oauth-utils.test.ts
+++ b/packages/ai/test/oauth-utils.test.ts
@@ -1,7 +1,46 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOAuthApiKey, registerOAuthProvider, unregisterOAuthProvider } from "../src/utils/oauth/index.js";
-import { REFRESH_BUFFER_MS } from "../src/utils/oauth/types.js";
+import { isOAuthTokenExpired, REFRESH_BUFFER_MS } from "../src/utils/oauth/types.js";
 import type { OAuthCredentials } from "../src/utils/oauth/types.js";
+
+describe("isOAuthTokenExpired", () => {
+	it("returns false when now is exactly 1ms before the buffer boundary", () => {
+		const expires = 1_000_000;
+		const now = expires - REFRESH_BUFFER_MS - 1;
+		const credentials = { refresh: "r", access: "a", expires };
+		expect(isOAuthTokenExpired(credentials, now)).toBe(false);
+	});
+
+	it("returns true when now is exactly at the buffer boundary", () => {
+		const expires = 1_000_000;
+		const now = expires - REFRESH_BUFFER_MS;
+		const credentials = { refresh: "r", access: "a", expires };
+		expect(isOAuthTokenExpired(credentials, now)).toBe(true);
+	});
+
+	it("returns true when now is exactly 1ms past the buffer boundary", () => {
+		const expires = 1_000_000;
+		const now = expires - REFRESH_BUFFER_MS + 1;
+		const credentials = { refresh: "r", access: "a", expires };
+		expect(isOAuthTokenExpired(credentials, now)).toBe(true);
+	});
+
+	it("returns true for non-finite expires values", () => {
+		expect(isOAuthTokenExpired({ refresh: "r", access: "a", expires: NaN }, 0)).toBe(true);
+		expect(isOAuthTokenExpired({ refresh: "r", access: "a", expires: undefined as any }, 0)).toBe(true);
+		expect(isOAuthTokenExpired({ refresh: "r", access: "a", expires: Infinity }, 0)).toBe(true);
+	});
+
+	it("defaults now to Date.now()", () => {
+		const future = Date.now() + 3600_000;
+		const credentials = { refresh: "r", access: "a", expires: future };
+		expect(isOAuthTokenExpired(credentials)).toBe(false);
+
+		const past = Date.now() - 1000;
+		const expired = { refresh: "r", access: "a", expires: past };
+		expect(isOAuthTokenExpired(expired)).toBe(true);
+	});
+});
 
 describe("getOAuthApiKey", () => {
 	const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -65,6 +104,44 @@ describe("getOAuthApiKey", () => {
 		expect(result).not.toBeNull();
 		expect(result?.apiKey).toBe("Bearer refreshed-access-token");
 		expect(result?.newCredentials.access).toBe("refreshed-access-token");
+	});
+
+	it("refreshes short-lifetime tokens that are immediately within the buffer", async () => {
+		const now = 1_000_000;
+		vi.setSystemTime(now);
+
+		unregisterOAuthProvider(providerId);
+		registerOAuthProvider({
+			id: providerId,
+			name: "Short Token Provider",
+			async login() {
+				throw new Error("Not used");
+			},
+			async refreshToken(credentials) {
+				return {
+					...credentials,
+					access: "long-lived-token",
+					expires: now + 3600_000,
+				};
+			},
+			getApiKey(credentials) {
+				return `Bearer ${credentials.access}`;
+			},
+		});
+
+		const credentials: Record<string, OAuthCredentials> = {
+			[providerId]: {
+				refresh: "refresh-token",
+				access: "short-lived-token",
+				expires: now + 30_000,
+			},
+		};
+
+		const result = await getOAuthApiKey(providerId, credentials);
+		expect(result).not.toBeNull();
+		expect(result?.apiKey).toBe("Bearer long-lived-token");
+		expect(result?.newCredentials.access).toBe("long-lived-token");
+		expect(result?.newCredentials.expires).toBe(now + 3600_000);
 	});
 
 	it("refreshes token when already expired", async () => {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -7,7 +7,7 @@
  */
 
 import { getEnvApiKey, type OAuthCredentials, type OAuthLoginCallbacks, type OAuthProviderId } from "@dreb/ai";
-import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from "@dreb/ai/oauth";
+import { getOAuthApiKey, getOAuthProvider, getOAuthProviders, isOAuthTokenExpired } from "@dreb/ai/oauth";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -379,7 +379,7 @@ export class AuthStorage {
 				return { result: null };
 			}
 
-			if (Date.now() < cred.expires) {
+			if (!isOAuthTokenExpired(cred)) {
 				return { result: { apiKey: provider.getApiKey(cred), newCredentials: cred } };
 			}
 
@@ -436,7 +436,7 @@ export class AuthStorage {
 				// Fall through to env var / fallback resolver instead of returning undefined.
 			} else {
 				// Check if token needs refresh
-				const needsRefresh = Date.now() >= cred.expires;
+				const needsRefresh = isOAuthTokenExpired(cred);
 
 				if (needsRefresh) {
 					// Use locked refresh to prevent race conditions
@@ -451,7 +451,7 @@ export class AuthStorage {
 						this.reload();
 						const updatedCred = this.data[providerId];
 
-						if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
+						if (updatedCred?.type === "oauth" && !isOAuthTokenExpired(updatedCred)) {
 							// Another instance refreshed successfully, use those credentials
 							return provider.getApiKey(updatedCred);
 						}

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -452,14 +452,18 @@ describe("AuthStorage", () => {
 			const sharedBackend = new InMemoryAuthStorageBackend();
 			sharedBackend.withLock(() => ({
 				result: undefined,
-				next: JSON.stringify({
-					[providerId]: {
-						type: "oauth",
-						refresh: "refresh-token",
-						access: "current-access-token",
-						expires: now + REFRESH_BUFFER_MS - 1000,
+				next: JSON.stringify(
+					{
+						[providerId]: {
+							type: "oauth",
+							refresh: "refresh-token",
+							access: "current-access-token",
+							expires: now + REFRESH_BUFFER_MS - 1000,
+						},
 					},
-				}, null, 2),
+					null,
+					2,
+				),
 			}));
 
 			// Create two instances sharing the same backend
@@ -506,6 +510,69 @@ describe("AuthStorage", () => {
 
 			const apiKey = await authStorage.getApiKey(providerId);
 			expect(apiKey).toBeUndefined();
+
+			const errors = authStorage.drainErrors();
+			expect(errors.length).toBeGreaterThan(0);
+			expect(errors[0]).toBeInstanceOf(Error);
+			expect(errors[0].message).toContain("Failed to refresh OAuth token");
+		});
+
+		test("recovers with fresh credentials when another instance refreshed during failed refresh", async () => {
+			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			const now = Date.now();
+			const sharedBackend = new InMemoryAuthStorageBackend();
+
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Provider",
+				async login() {
+					throw new Error("Not used");
+				},
+				async refreshToken() {
+					// Simulate another instance refreshing the token while this one fails
+					sharedBackend.withLock(() => ({
+						result: undefined,
+						next: JSON.stringify(
+							{
+								[providerId]: {
+									type: "oauth",
+									refresh: "refresh-token",
+									access: "fresh-access-token-from-another-instance",
+									expires: now + 3600_000,
+								},
+							},
+							null,
+							2,
+						),
+					}));
+					throw new Error("Refresh failed");
+				},
+				getApiKey(credentials) {
+					return `Bearer ${credentials.access}`;
+				},
+			});
+
+			// Initialize with expired credentials
+			sharedBackend.withLock(() => ({
+				result: undefined,
+				next: JSON.stringify(
+					{
+						[providerId]: {
+							type: "oauth",
+							refresh: "refresh-token",
+							access: "expired-access-token",
+							expires: now - 10_000,
+						},
+					},
+					null,
+					2,
+				),
+			}));
+
+			authStorage = AuthStorage.fromStorage(sharedBackend);
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBe("Bearer fresh-access-token-from-another-instance");
 
 			const errors = authStorage.drainErrors();
 			expect(errors.length).toBeGreaterThan(0);

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { REFRESH_BUFFER_MS, registerOAuthProvider } from "@dreb/ai/oauth";
 import lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { AuthStorage } from "../src/core/auth-storage.js";
+import { AuthStorage, InMemoryAuthStorageBackend } from "../src/core/auth-storage.js";
 import { clearConfigValueCache } from "../src/core/resolve-config-value.js";
 
 describe("AuthStorage", () => {
@@ -449,26 +449,68 @@ describe("AuthStorage", () => {
 			});
 
 			const now = Date.now();
-			const backend = new AuthStorage.inMemory({
-				[providerId]: {
-					type: "oauth",
-					refresh: "refresh-token",
-					access: "current-access-token",
-					expires: now + REFRESH_BUFFER_MS - 1000,
-				},
-			}).getAll();
+			const sharedBackend = new InMemoryAuthStorageBackend();
+			sharedBackend.withLock(() => ({
+				result: undefined,
+				next: JSON.stringify({
+					[providerId]: {
+						type: "oauth",
+						refresh: "refresh-token",
+						access: "current-access-token",
+						expires: now + REFRESH_BUFFER_MS - 1000,
+					},
+				}, null, 2),
+			}));
+
+			// Create two instances sharing the same backend
+			const storage1 = AuthStorage.fromStorage(sharedBackend);
+			const storage2 = AuthStorage.fromStorage(sharedBackend);
 
 			// First instance refreshes
-			const storage1 = AuthStorage.inMemory(backend);
 			const key1 = await storage1.getApiKey(providerId);
 			expect(key1).toBe("Bearer refreshed-v1");
 			expect(refreshCount).toBe(1);
 
-			// Second instance with same backend sees refreshed credentials
-			const storage2 = AuthStorage.inMemory(storage1.getAll());
+			// Second instance with same backend should not re-refresh
 			const key2 = await storage2.getApiKey(providerId);
 			expect(key2).toBe("Bearer refreshed-v1");
 			expect(refreshCount).toBe(1);
+		});
+
+		test("returns undefined when refresh truly fails", async () => {
+			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Provider",
+				async login() {
+					throw new Error("Not used");
+				},
+				async refreshToken() {
+					throw new Error("Refresh failed");
+				},
+				getApiKey(credentials) {
+					return `Bearer ${credentials.access}`;
+				},
+			});
+
+			const now = Date.now();
+			authStorage = AuthStorage.inMemory({
+				[providerId]: {
+					type: "oauth",
+					refresh: "refresh-token",
+					access: "expired-access-token",
+					expires: now - 10_000,
+				},
+			});
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBeUndefined();
+
+			const errors = authStorage.drainErrors();
+			expect(errors.length).toBeGreaterThan(0);
+			expect(errors[0]).toBeInstanceOf(Error);
+			expect(errors[0].message).toContain("Failed to refresh OAuth token");
 		});
 	});
 

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerOAuthProvider } from "@dreb/ai/oauth";
+import { REFRESH_BUFFER_MS, registerOAuthProvider } from "@dreb/ai/oauth";
 import lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
@@ -344,6 +344,131 @@ describe("AuthStorage", () => {
 
 			const secondTry = await authStorage.getApiKey(providerId);
 			expect(secondTry).toBe("Bearer refreshed-access-token");
+		});
+	});
+
+	describe("oauth refresh buffer", () => {
+		test("returns existing OAuth key without refresh when token is outside buffer", async () => {
+			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			const refreshSpy = vi.fn(async (credentials: { refresh: string; access: string; expires: number }) => ({
+				...credentials,
+				access: "refreshed-access-token",
+				expires: Date.now() + 3600_000,
+			}));
+
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Provider",
+				async login() {
+					throw new Error("Not used");
+				},
+				refreshToken: refreshSpy,
+				getApiKey(credentials) {
+					return `Bearer ${credentials.access}`;
+				},
+			});
+
+			const now = Date.now();
+			authStorage = AuthStorage.inMemory({
+				[providerId]: {
+					type: "oauth",
+					refresh: "refresh-token",
+					access: "current-access-token",
+					expires: now + REFRESH_BUFFER_MS + 5000,
+				},
+			});
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBe("Bearer current-access-token");
+			expect(refreshSpy).not.toHaveBeenCalled();
+		});
+
+		test("refreshes and persists when token is within the buffer", async () => {
+			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			const refreshSpy = vi.fn(async (credentials: { refresh: string; access: string; expires: number }) => ({
+				...credentials,
+				access: "refreshed-access-token",
+				expires: Date.now() + 3600_000,
+			}));
+
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Provider",
+				async login() {
+					throw new Error("Not used");
+				},
+				refreshToken: refreshSpy,
+				getApiKey(credentials) {
+					return `Bearer ${credentials.access}`;
+				},
+			});
+
+			const now = Date.now();
+			authStorage = AuthStorage.inMemory({
+				[providerId]: {
+					type: "oauth",
+					refresh: "refresh-token",
+					access: "current-access-token",
+					expires: now + REFRESH_BUFFER_MS - 1000,
+				},
+			});
+
+			const apiKey = await authStorage.getApiKey(providerId);
+			expect(apiKey).toBe("Bearer refreshed-access-token");
+			expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+			// Verify persisted credentials were updated
+			const stored = authStorage.get(providerId);
+			expect(stored?.type).toBe("oauth");
+			if (stored?.type === "oauth") {
+				expect(stored.access).toBe("refreshed-access-token");
+			}
+		});
+
+		test("inside-lock double-check does not re-refresh after another instance succeeded", async () => {
+			const providerId = `test-oauth-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			let refreshCount = 0;
+
+			registerOAuthProvider({
+				id: providerId,
+				name: "Test OAuth Provider",
+				async login() {
+					throw new Error("Not used");
+				},
+				async refreshToken(credentials) {
+					refreshCount++;
+					return {
+						...credentials,
+						access: `refreshed-v${refreshCount}`,
+						expires: Date.now() + 3600_000,
+					};
+				},
+				getApiKey(credentials) {
+					return `Bearer ${credentials.access}`;
+				},
+			});
+
+			const now = Date.now();
+			const backend = new AuthStorage.inMemory({
+				[providerId]: {
+					type: "oauth",
+					refresh: "refresh-token",
+					access: "current-access-token",
+					expires: now + REFRESH_BUFFER_MS - 1000,
+				},
+			}).getAll();
+
+			// First instance refreshes
+			const storage1 = AuthStorage.inMemory(backend);
+			const key1 = await storage1.getApiKey(providerId);
+			expect(key1).toBe("Bearer refreshed-v1");
+			expect(refreshCount).toBe(1);
+
+			// Second instance with same backend sees refreshed credentials
+			const storage2 = AuthStorage.inMemory(storage1.getAll());
+			const key2 = await storage2.getApiKey(providerId);
+			expect(key2).toBe("Bearer refreshed-v1");
+			expect(refreshCount).toBe(1);
 		});
 	});
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.15.1",
+	"version": "2.15.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #191

Add a proactive 60-second refresh buffer to OAuth access tokens to prevent 401s caused by clock skew, network latency, and server-side early invalidation.

Implementation plan posted as a comment below.
