### PR TITLE
docs: document get_performance_stats RPC and update Telegram /stats

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -129,7 +129,7 @@ The interface from top to bottom:
 - **Startup header** - Shows shortcuts (`/hotkeys` for all), loaded AGENTS.md files, prompt templates, skills, and extensions
 - **Messages** - Your messages, assistant responses, tool calls and results, notifications, errors, and extension UI
 - **Editor** - Where you type; border color indicates thinking level
-- **Footer** - Working directory, session name, total token/cache usage, cost, context usage, current model
+- **Footer** - Working directory, session name, total token/cache usage, cost, context usage, current model, and rolling tokens-per-second (median TPS with long-term delta)
 
 The editor can be temporarily replaced by other UI, like built-in `/settings` or custom UI from extensions (e.g., a Q&A tool that lets the user answer model questions in a structured format). [Extensions](#extensions) can also replace the editor, add widgets above/below it, a status line, custom footer, or overlays.
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -535,6 +535,36 @@ Response:
 
 `contextUsage` is omitted when no model or context window is available. `contextUsage.tokens` and `contextUsage.percent` are `null` immediately after compaction until a fresh post-compaction assistant response provides valid usage data.
 
+#### get_performance_stats
+
+Get rolling performance statistics (tokens-per-second) for all models with recorded data.
+
+```json
+{"type": "get_performance_stats"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_performance_stats",
+  "success": true,
+  "data": {
+    "models": [
+      {
+        "provider": "anthropic",
+        "modelId": "claude-sonnet-4",
+        "median": 31,
+        "mean": 32,
+        "count": 100
+      }
+    ]
+  }
+}
+```
+
+`models` contains per-model rolling averages computed from the agent's performance log. Each entry includes the median TPS, mean TPS, and number of recorded turns for that model. Returns an empty `models` array when no performance data has been recorded.
+
 #### export_html
 
 Export session to an HTML file.

--- a/packages/coding-agent/docs/session.md
+++ b/packages/coding-agent/docs/session.md
@@ -416,3 +416,27 @@ Key methods for working with sessions programmatically.
 - `getSessionId()` - Session UUID
 - `getSessionFile()` - Session file path (undefined for in-memory)
 - `isPersisted()` - Whether session is saved to disk
+
+---
+
+## Performance Log
+
+Assistant response performance is recorded to a JSONL file for rolling TPS statistics:
+
+```
+~/.dreb/agent/performance.jsonl
+```
+
+Each line is a JSON object with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | ISO string | When the response completed |
+| `sessionId` | string | Session that produced the response |
+| `provider` | string | Model provider (e.g. `anthropic`) |
+| `modelId` | string | Model identifier (e.g. `claude-sonnet-4`) |
+| `outputTokens` | number | Output tokens from the response |
+| `durationMs` | number | Response duration in milliseconds |
+| `tps` | number | Computed tokens per second (`outputTokens * 1000 / durationMs`) |
+
+Entries are written atomically with file locking for safe concurrent access. The log is pruned daily, removing entries older than 30 days. Responses with `stopReason` of `error` or `aborted`, zero output tokens, or durations under 10ms are not recorded.

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -765,6 +765,14 @@ ctx.ui.setWidget("my-widget", undefined);
 
 **Examples:** [plan-mode.ts](../examples/extensions/plan-mode.ts)
 
+### Built-in Footer
+
+The default footer shows three lines (when space allows):
+
+1. **Path** — Current working directory (with `~` for home), git branch in parentheses, and session name if set. Dimmed.
+2. **Stats** — Cumulative token usage (↑input ↓output Rread Wwrite), cost (with daily total when cross-session), and context-window percentage (colored red above 90%, yellow above 70%). When a model is selected and enough turns have been recorded, a rolling TPS suffix appears: `~31 tok/s [100] · 10% ↑ median [10000]`. The recent median (last 10 turns) is compared against the long-term baseline (last 10,000 turns). Dimmed.
+3. **Extension statuses** — Alphabetical list of persistent status texts set by extensions via `ctx.ui.setStatus()`.
+
 ### Pattern 6: Custom Footer
 
 Replace the footer. `footerData` exposes data not otherwise accessible to extensions.

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -84,7 +84,7 @@ systemctl --user enable --now dreb-telegram
 
 ### Agent
 - `/status` — Connection & version info
-- `/stats` — Token usage & cost
+- `/stats` — Token usage, cost, and per-model performance stats (rolling TPS)
 - `/compact` — Compact context
 - `/model [pattern]` — View/switch model
 - `/thinking [level]` — View/set thinking level


### PR DESCRIPTION
Documents the new performance tracking features from PR 196.