### PR TITLE
Ghost text suggestions in the input prompt (Tab to accept)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8763,7 +8763,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8792,7 +8792,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8848,7 +8848,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8963,7 +8963,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9012,7 +9012,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9044,7 +9044,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.16.0",
+			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -62,7 +62,7 @@ dreb
 
 Or use a custom provider (corporate proxy, Bedrock, etc.) — see [Custom providers & models](#providers--models).
 
-Then just talk to dreb. All 10 built-in tools are enabled by default: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Use `--tools` to restrict to a subset (e.g., `--tools read,grep,find,ls` for read-only). Three additional tools — `search`, `skill`, and `tasks_update` — are always active. The model uses these to fulfill your requests. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [packages](#packages).
+Then just talk to dreb. All 10 built-in tools are enabled by default: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Use `--tools` to restrict to a subset (e.g., `--tools read,grep,find,ls` for read-only). Four additional tools — `search`, `skill`, `tasks_update`, and `suggest_next` — are always active. The model uses these to fulfill your requests. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [packages](#packages).
 
 **Also available:** [`@dreb/telegram`](https://www.npmjs.com/package/@dreb/telegram) — run dreb as a Telegram bot (`npm install -g @dreb/telegram`).
 
@@ -585,10 +585,11 @@ cat README.md | dreb -p "Summarize this text"
 
 Available built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`
 
-Three additional tools are always active but don't appear in `--tools`:
+Four additional tools are always active but don't appear in `--tools`:
 - `search` — [semantic codebase search](#semantic-search) using natural language queries
 - `skill` — invokes [skills](#skills) programmatically
 - `tasks_update` — session [task tracking](#task-tracking) with TUI panel
+- `suggest_next` — suggests a next command shown as ghost text (Tab to accept)
 
 ### Resource Options
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -569,7 +569,7 @@ In the default parallel tool execution mode, sibling tool calls from the same as
 import { isToolCallEventType } from "@dreb/coding-agent";
 
 dreb.on("tool_call", async (event, ctx) => {
-  // event.toolName - "bash", "read", "write", "edit", "grep", "find", "ls", "web_search", "web_fetch", "subagent", "search", "skill", "tasks_update", or custom tool names
+  // event.toolName - "bash", "read", "write", "edit", "grep", "find", "ls", "web_search", "web_fetch", "subagent", "search", "skill", "tasks_update", "suggest_next", or custom tool names
   // event.toolCallId
   // event.input - tool parameters
 
@@ -1474,7 +1474,7 @@ async execute(toolCallId, params) {
 
 ### Overriding Built-in Tools
 
-Extensions can override built-in tools (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `search`) by registering a tool with the same name. Interactive mode displays a warning when this happens. The factory-only tools (`skill`, `tasks_update`) can also be overridden.
+Extensions can override built-in tools (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `search`) by registering a tool with the same name. Interactive mode displays a warning when this happens. The factory-only tools (`skill`, `tasks_update`, `suggest_next`) can also be overridden.
 
 ```bash
 # Extension's read tool replaces built-in read

--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -19,7 +19,8 @@ type AgentSessionEvent =
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
   | { type: "background_agent_start"; agentId: string; agentType: string; taskSummary: string }
   | { type: "background_agent_end"; agentId: string; agentType: string; success: boolean }
-  | { type: "tasks_update"; tasks: readonly SessionTask[] };
+  | { type: "tasks_update"; tasks: readonly SessionTask[] }
+  | { type: "suggest_next"; command: string };
 
 // SessionTask shape:
 interface SessionTask {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2816,6 +2816,7 @@ export class AgentSession {
 					"search",
 					"skill",
 					"tasks_update",
+					"suggest_next",
 				];
 		const baseActiveToolNames = options.activeToolNames ?? defaultActiveToolNames;
 		this._refreshToolRegistry({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -129,7 +129,8 @@ export type AgentSessionEvent =
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
 	| { type: "background_agent_start"; agentId: string; agentType: string; taskSummary: string }
 	| { type: "background_agent_end"; agentId: string; agentType: string; success: boolean }
-	| { type: "tasks_update"; tasks: readonly SessionTask[] };
+	| { type: "tasks_update"; tasks: readonly SessionTask[] }
+	| { type: "suggest_next"; command: string };
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
@@ -2744,6 +2745,15 @@ export class AgentSession {
 								// Swallow emit errors (e.g. TUI rendering failures)
 							}
 							return result;
+						},
+					},
+					suggestNext: {
+						onSuggest: (command) => {
+							try {
+								this._emit({ type: "suggest_next", command });
+							} catch {
+								// Swallow emit errors
+							}
 						},
 					},
 					subagent: {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -257,7 +257,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	}
 
 	// Tools that are always active when available (created by factory, not in allTools singleton)
-	const alwaysActiveBuiltins = ["skill", "tasks_update", "search"];
+	const alwaysActiveBuiltins = ["skill", "tasks_update", "search", "suggest_next"];
 	const defaultActiveToolNames: ToolName[] = [
 		"read",
 		"bash",

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -92,6 +92,12 @@ export {
 	subagentToolDefinition,
 } from "./subagent.js";
 export {
+	createSuggestNextToolDefinition,
+	type SuggestNextCallback,
+	type SuggestNextDetails,
+	type SuggestNextInput,
+} from "./suggest-next.js";
+export {
 	createTasksToolDefinition,
 	type SessionTask,
 	type TaskStatus,

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -164,6 +164,7 @@ import {
 	subagentTool,
 	subagentToolDefinition,
 } from "./subagent.js";
+import { createSuggestNextToolDefinition, type SuggestNextCallback } from "./suggest-next.js";
 import { createTasksToolDefinition, type TasksUpdateCallback } from "./tasks.js";
 import { createTmpReadToolDefinition } from "./tmp-read.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
@@ -224,6 +225,7 @@ export interface ToolsOptions {
 	subagent?: SubagentToolOptions;
 	skill?: SkillToolOptions;
 	tasks?: { onUpdate: TasksUpdateCallback };
+	suggestNext?: { onSuggest: SuggestNextCallback };
 }
 
 export function createCodingToolDefinitions(cwd: string, options?: ToolsOptions): ToolDef[] {
@@ -267,6 +269,9 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 	if (options?.tasks) {
 		tools.tasks_update = createTasksToolDefinition(options.tasks.onUpdate);
 	}
+	if (options?.suggestNext) {
+		tools.suggest_next = createSuggestNextToolDefinition(options.suggestNext.onSuggest);
+	}
 	return tools as Record<ToolName | "skill", ToolDef>;
 }
 
@@ -305,6 +310,9 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 	}
 	if (options?.tasks) {
 		tools.tasks_update = wrapToolDefinition(createTasksToolDefinition(options.tasks.onUpdate));
+	}
+	if (options?.suggestNext) {
+		tools.suggest_next = wrapToolDefinition(createSuggestNextToolDefinition(options.suggestNext.onSuggest));
 	}
 	return tools as Record<ToolName | "skill", Tool>;
 }

--- a/packages/coding-agent/src/core/tools/suggest-next.ts
+++ b/packages/coding-agent/src/core/tools/suggest-next.ts
@@ -72,7 +72,9 @@ export function createSuggestNextToolDefinition(
 			"Don't suggest if the conversation is open-ended with no obvious next action",
 		],
 
-		async execute(_toolCallId, { command }: SuggestNextInput, _signal?, _onUpdate?, _ctx?) {
+		async execute(_toolCallId, { command: rawCommand }: SuggestNextInput, _signal?, _onUpdate?, _ctx?) {
+			// Strip control characters (newlines, tabs, etc.) that would corrupt TUI rendering
+			const command = rawCommand?.replace(/[\x00-\x1f\x7f]/g, "").trim();
 			if (!command || !command.startsWith("/")) {
 				return {
 					content: [{ type: "text" as const, text: "Error: command must start with /" }],

--- a/packages/coding-agent/src/core/tools/suggest-next.ts
+++ b/packages/coding-agent/src/core/tools/suggest-next.ts
@@ -1,0 +1,103 @@
+/**
+ * Suggest next command tool.
+ *
+ * Allows the agent to suggest a command the user might want to run next.
+ * The suggestion is shown as ghost text in the editor prompt (Tab to accept).
+ */
+
+import { Text } from "@dreb/tui";
+import { type Static, Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "../extensions/types.js";
+
+// ============================================================================
+// Types
+
+export interface SuggestNextDetails {
+	suggestion: string;
+}
+
+export type SuggestNextCallback = (suggestion: string) => void;
+
+// ============================================================================
+// Schema
+
+const suggestNextSchema = Type.Object({
+	command: Type.String({
+		description: "The suggested command for the user to run next (e.g. /skill:mach6-push, /compact)",
+	}),
+});
+
+export type SuggestNextInput = Static<typeof suggestNextSchema>;
+
+// ============================================================================
+// Render helpers
+
+function formatSuggestNextCall(args: { command?: string } | undefined, theme: any): string {
+	const cmd = args?.command ?? "";
+	return `${theme.fg("toolTitle", theme.bold("suggest_next"))} ${theme.fg("accent", cmd)}`;
+}
+
+function formatSuggestNextResult(
+	result: { content: Array<{ type: string; text?: string }>; details?: SuggestNextDetails },
+	theme: any,
+): string {
+	const details = result.details;
+	if (!details) {
+		const text = result.content?.[0];
+		return text?.type === "text" && text.text ? theme.fg("toolOutput", text.text) : "";
+	}
+	return theme.fg("toolOutput", `→ ${details.suggestion}`);
+}
+
+// ============================================================================
+// Tool definition factory
+
+export function createSuggestNextToolDefinition(
+	onSuggest: SuggestNextCallback,
+): ToolDefinition<typeof suggestNextSchema, SuggestNextDetails | undefined> {
+	return {
+		name: "suggest_next",
+		label: "suggest_next",
+		description:
+			"Suggest a command for the user to run next. Shows as ghost text in the prompt that the user can Tab-accept.",
+
+		parameters: suggestNextSchema,
+
+		promptSnippet: "Suggest a next command (shown as ghost text the user can Tab-accept)",
+
+		promptGuidelines: [
+			"Call suggest_next at the end of your turn when there's a clear next action the user might want",
+			"Use full command syntax: /skill:name args, /compact, etc.",
+			"Only suggest one command — pick the most likely next step",
+			"Don't suggest if the conversation is open-ended with no obvious next action",
+		],
+
+		async execute(_toolCallId, { command }: SuggestNextInput, _signal?, _onUpdate?, _ctx?) {
+			if (!command || !command.startsWith("/")) {
+				return {
+					content: [{ type: "text" as const, text: "Error: command must start with /" }],
+					details: undefined,
+				};
+			}
+
+			onSuggest(command);
+
+			return {
+				content: [{ type: "text" as const, text: `Suggestion registered: ${command}` }],
+				details: { suggestion: command },
+			};
+		},
+
+		renderCall(args, theme, context) {
+			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+			text.setText(formatSuggestNextCall(args, theme));
+			return text;
+		},
+
+		renderResult(result, _options, theme, context) {
+			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+			text.setText(formatSuggestNextResult(result as any, theme));
+			return text;
+		},
+	};
+}

--- a/packages/coding-agent/src/core/tools/tmp-read.ts
+++ b/packages/coding-agent/src/core/tools/tmp-read.ts
@@ -15,12 +15,27 @@ import { createReadToolDefinition, type ReadToolOptions } from "./read.js";
 const ALLOWED_PREFIX = "/tmp";
 const SANDBOX_CWD = "/tmp";
 
+// On macOS, /tmp is a symlink to /private/tmp. Resolve it once at startup
+// so that realpathSync results (which follow symlinks) can be correctly matched.
+let resolvedAllowedPrefix: string;
+try {
+	resolvedAllowedPrefix = realpathSync(ALLOWED_PREFIX);
+} catch {
+	resolvedAllowedPrefix = ALLOWED_PREFIX;
+}
+
 /**
  * Check whether a resolved absolute path is under /tmp.
  * Handles exact "/tmp" match and "/tmp/..." paths, rejects "/tmpevil" etc.
+ * Also handles macOS where /tmp resolves to /private/tmp.
  */
 function isUnderTmp(absolutePath: string): boolean {
-	return absolutePath === ALLOWED_PREFIX || absolutePath.startsWith(`${ALLOWED_PREFIX}/`);
+	return (
+		absolutePath === ALLOWED_PREFIX ||
+		absolutePath.startsWith(`${ALLOWED_PREFIX}/`) ||
+		absolutePath === resolvedAllowedPrefix ||
+		absolutePath.startsWith(`${resolvedAllowedPrefix}/`)
+	);
 }
 
 export function createTmpReadToolDefinition(options?: ReadToolOptions): ToolDefinition<any, any> {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2625,7 +2625,6 @@ export class InteractiveMode {
 				// Show suggestion as ghost text if editor is empty
 				if (this.editor.setGhostText && this.editor.getText() === "") {
 					this.editor.setGhostText(event.command);
-					this.ui.requestRender();
 				}
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2023,6 +2023,8 @@ export class InteractiveMode {
 		// Set up handlers on defaultEditor - they use this.editor for text access
 		// so they work correctly regardless of which editor is active
 		this.defaultEditor.onEscape = () => {
+			// Always clear ghost text on Escape (CustomEditor intercepts before super.handleInput)
+			this.editor.setGhostText?.(null);
 			if (this.loadingAnimation) {
 				this.cancelBackgroundAgents();
 				this.restoreQueuedMessagesToEditor({ abort: true });

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1248,6 +1248,7 @@ export class InteractiveMode {
 					}
 
 					// Clear UI state
+					this.editor.setGhostText?.(null);
 					this.chatContainer.clear();
 					this.pendingMessagesContainer.clear();
 					this.compactionQueuedMessages = [];
@@ -3940,6 +3941,7 @@ export class InteractiveMode {
 		this.statusContainer.clear();
 
 		// Clear UI state
+		this.editor.setGhostText?.(null);
 		this.pendingMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2318,6 +2318,8 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				// Clear ghost text when a new agent turn starts
+				this.editor.setGhostText?.(null);
 				// Restore main escape handler if retry handler is still active
 				// (retry success event fires later, but we need main handler now)
 				if (this.retryEscapeHandler) {
@@ -2616,6 +2618,15 @@ export class InteractiveMode {
 			case "tasks_update": {
 				this.tasksPanel.update(event.tasks);
 				this.ui.requestRender();
+				break;
+			}
+
+			case "suggest_next": {
+				// Show suggestion as ghost text if editor is empty
+				if (this.editor.setGhostText && this.editor.getText() === "") {
+					this.editor.setGhostText(event.command);
+					this.ui.requestRender();
+				}
 				break;
 			}
 		}

--- a/packages/coding-agent/test/footer-data-provider.test.ts
+++ b/packages/coding-agent/test/footer-data-provider.test.ts
@@ -77,7 +77,7 @@ function createReftableWorktree(tempDir: string): WorktreeFixture {
 	return { worktreeDir, reftableDir };
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<void> {
+async function waitFor(condition: () => boolean, timeoutMs = 8000): Promise<void> {
 	const startedAt = Date.now();
 	while (!condition()) {
 		if (Date.now() - startedAt > timeoutMs) {
@@ -173,6 +173,8 @@ describe("FooterDataProvider reftable branch detection", () => {
 
 		const provider = new FooterDataProvider();
 		try {
+			// Allow fs.watch to fully initialize before writing
+			await new Promise((resolve) => setTimeout(resolve, 50));
 			expect(provider.getGitBranch()).toBe("main");
 			vi.mocked(spawnSync).mockClear();
 			const onBranchChange = vi.fn();
@@ -196,6 +198,8 @@ describe("FooterDataProvider reftable branch detection", () => {
 
 		const provider = new FooterDataProvider();
 		try {
+			// Allow fs.watch to fully initialize before writing
+			await new Promise((resolve) => setTimeout(resolve, 50));
 			expect(provider.getGitBranch()).toBe("main");
 			vi.mocked(execFile).mockClear();
 
@@ -217,6 +221,8 @@ describe("FooterDataProvider reftable branch detection", () => {
 
 		const provider = new FooterDataProvider();
 		try {
+			// Allow fs.watch to fully initialize before writing
+			await new Promise((resolve) => setTimeout(resolve, 50));
 			expect(provider.getGitBranch()).toBe("main");
 			resolvedBranch = "foo";
 			const onBranchChange = vi.fn();

--- a/packages/coding-agent/test/suggest-next.test.ts
+++ b/packages/coding-agent/test/suggest-next.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSuggestNextToolDefinition, type SuggestNextDetails } from "../src/core/tools/suggest-next.js";
+
+describe("suggest_next tool", () => {
+	function createTool() {
+		const onSuggest = vi.fn();
+		const tool = createSuggestNextToolDefinition(onSuggest);
+		// Cast execute to skip the ctx parameter (not used by this tool)
+		const execute = tool.execute.bind(tool) as (
+			toolCallId: string,
+			params: { command: string },
+			signal?: AbortSignal,
+			onUpdate?: any,
+		) => Promise<{ content: Array<{ type: string; text?: string }>; details?: SuggestNextDetails }>;
+		return { execute, onSuggest };
+	}
+
+	it("calls onSuggest callback with the command", async () => {
+		const { execute, onSuggest } = createTool();
+
+		const result = await execute("call-1", { command: "/skill:mach6-push" });
+
+		expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-push");
+		expect(result.details).toEqual({ suggestion: "/skill:mach6-push" });
+		expect(result.content[0]).toEqual({ type: "text", text: "Suggestion registered: /skill:mach6-push" });
+	});
+
+	it("rejects commands that don't start with /", async () => {
+		const { execute, onSuggest } = createTool();
+
+		const result = await execute("call-2", { command: "npm run build" });
+
+		expect(onSuggest).not.toHaveBeenCalled();
+		expect(result.details).toBeUndefined();
+		expect(result.content[0]?.text).toContain("Error");
+	});
+
+	it("rejects empty command", async () => {
+		const { execute, onSuggest } = createTool();
+
+		const result = await execute("call-3", { command: "" });
+
+		expect(onSuggest).not.toHaveBeenCalled();
+		expect(result.details).toBeUndefined();
+	});
+
+	it("accepts various command formats", async () => {
+		const { execute, onSuggest } = createTool();
+
+		await execute("call-4", { command: "/compact" });
+		expect(onSuggest).toHaveBeenCalledWith("/compact");
+
+		await execute("call-5", { command: "/skill:mach6-review 42" });
+		expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-review 42");
+
+		await execute("call-6", { command: "/skill:mach6-plan 201" });
+		expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-plan 201");
+	});
+});

--- a/packages/coding-agent/test/suggest-next.test.ts
+++ b/packages/coding-agent/test/suggest-next.test.ts
@@ -56,4 +56,42 @@ describe("suggest_next tool", () => {
 		await execute("call-6", { command: "/skill:mach6-plan 201" });
 		expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-plan 201");
 	});
+
+	describe("control character sanitization", () => {
+		it("strips control characters and accepts valid command", async () => {
+			const { execute, onSuggest } = createTool();
+
+			const result = await execute("call-7", { command: "/skill:mach6-push\nrm -rf /" });
+
+			expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-pushrm -rf /");
+			expect(result.details).toEqual({ suggestion: "/skill:mach6-pushrm -rf /" });
+		});
+
+		it("strips leading newline — resulting command starts with / so it passes", async () => {
+			const { execute, onSuggest } = createTool();
+
+			const result = await execute("call-8", { command: "\n/compact" });
+
+			expect(onSuggest).toHaveBeenCalledWith("/compact");
+			expect(result.details).toEqual({ suggestion: "/compact" });
+		});
+
+		it("rejects command that becomes empty after stripping control chars", async () => {
+			const { execute, onSuggest } = createTool();
+
+			const result = await execute("call-9", { command: "\n\t\r" });
+
+			expect(onSuggest).not.toHaveBeenCalled();
+			expect(result.details).toBeUndefined();
+		});
+
+		it("strips tabs and other control chars from middle of command", async () => {
+			const { execute, onSuggest } = createTool();
+
+			const result = await execute("call-10", { command: "/skill:mach6\t-plan 42" });
+
+			expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-plan 42");
+			expect(result.details).toEqual({ suggestion: "/skill:mach6-plan 42" });
+		});
+	});
 });

--- a/packages/coding-agent/test/tmp-read.test.ts
+++ b/packages/coding-agent/test/tmp-read.test.ts
@@ -93,7 +93,7 @@ describe("tmp_read path validation", () => {
 	describe("blocked paths — symlink escapes", () => {
 		const testDir = "/tmp/dreb-tmp-read-test";
 		const symlinkPath = `${testDir}/symlink-escape`;
-		const targetPath = "/etc/hostname"; // a readable file outside /tmp
+		const targetPath = "/etc/hosts"; // a readable file outside /tmp (exists on both Linux and macOS)
 
 		beforeAll(() => {
 			mkdirSync(testDir, { recursive: true });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.16.0",
+	"version": "2.17.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -603,8 +603,7 @@ export class Editor implements Component, Focusable {
 
 		// Clear ghost text on any input except Tab (Tab is handled by handleTabCompletion)
 		if (this.ghostText && !kb.matches(data, "tui.input.tab")) {
-			this.ghostText = null;
-			this.tui.requestRender();
+			this.setGhostText(null);
 		}
 
 		// Ctrl+C - let parent handle (exit/clear)
@@ -964,6 +963,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	setText(text: string): void {
+		this.ghostText = null;
 		this.cancelAutocomplete();
 		this.lastAction = null;
 		this.historyIndex = -1; // Exit history browsing mode
@@ -2074,6 +2074,8 @@ export class Editor implements Component, Focusable {
 		if (this.ghostText && this.isEditorEmpty()) {
 			const text = this.ghostText;
 			this.ghostText = null;
+			this.pushUndoSnapshot();
+			this.lastAction = null;
 			this.setTextInternal(text);
 			return;
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -200,6 +200,7 @@ interface LayoutLine {
 export interface EditorTheme {
 	borderColor: (str: string) => string;
 	selectList: SelectListTheme;
+	ghostText?: (str: string) => string;
 }
 
 export interface EditorOptions {
@@ -268,6 +269,9 @@ export class Editor implements Component, Focusable {
 	// Character jump mode
 	private jumpMode: "forward" | "backward" | null = null;
 
+	// Ghost text suggestion (dim text shown after cursor, Tab to accept)
+	private ghostText: string | null = null;
+
 	// Preferred visual column for vertical cursor movement (sticky column)
 	private preferredVisualCol: number | null = null;
 
@@ -325,6 +329,18 @@ export class Editor implements Component, Focusable {
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
 		this.cancelAutocomplete();
 		this.autocompleteProvider = provider;
+	}
+
+	/** Set ghost text (dim suggestion shown after cursor). Tab accepts, any input dismisses. */
+	setGhostText(text: string | null): void {
+		if (this.ghostText !== text) {
+			this.ghostText = text;
+			this.tui.requestRender();
+		}
+	}
+
+	getGhostText(): string | null {
+		return this.ghostText;
 	}
 
 	/**
@@ -490,6 +506,18 @@ export class Editor implements Component, Focusable {
 					if (lineVisibleWidth > contentWidth && paddingX > 0) {
 						cursorInPadding = true;
 					}
+					// Ghost text: show dim suggestion after cursor when editor is empty
+					if (this.ghostText && this.isEditorEmpty()) {
+						const availableWidth = contentWidth - lineVisibleWidth;
+						if (availableWidth > 0) {
+							const truncatedGhost = truncateToWidth(this.ghostText, availableWidth);
+							const styled = this.theme.ghostText
+								? this.theme.ghostText(truncatedGhost)
+								: `\x1b[2m${truncatedGhost}\x1b[0m`;
+							displayText = displayText + styled;
+							lineVisibleWidth = lineVisibleWidth + visibleWidth(truncatedGhost);
+						}
+					}
 				}
 			}
 
@@ -571,6 +599,12 @@ export class Editor implements Component, Focusable {
 				return;
 			}
 			return;
+		}
+
+		// Clear ghost text on any input except Tab (Tab is handled by handleTabCompletion)
+		if (this.ghostText && !kb.matches(data, "tui.input.tab")) {
+			this.ghostText = null;
+			this.tui.requestRender();
 		}
 
 		// Ctrl+C - let parent handle (exit/clear)
@@ -2036,6 +2070,14 @@ export class Editor implements Component, Focusable {
 	}
 
 	private handleTabCompletion(): void {
+		// Ghost text takes priority: Tab accepts ghost text when editor is empty
+		if (this.ghostText && this.isEditorEmpty()) {
+			const text = this.ghostText;
+			this.ghostText = null;
+			this.setTextInternal(text);
+			return;
+		}
+
 		if (!this.autocompleteProvider) return;
 
 		const currentLine = this.state.lines[this.state.cursorLine] || "";

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -60,6 +60,16 @@ export interface EditorComponent extends Component {
 	setAutocompleteProvider?(provider: AutocompleteProvider): void;
 
 	// =========================================================================
+	// Ghost text (optional)
+	// =========================================================================
+
+	/** Set ghost text suggestion (dim text after cursor, Tab to accept) */
+	setGhostText?(text: string | null): void;
+
+	/** Get current ghost text */
+	getGhostText?(): string | null;
+
+	// =========================================================================
 	// Appearance (optional)
 	// =========================================================================
 

--- a/packages/tui/test/editor-ghost-text.test.ts
+++ b/packages/tui/test/editor-ghost-text.test.ts
@@ -93,6 +93,8 @@ describe("Editor ghost text", () => {
 
 			// Editor is not empty so Tab should not accept ghost text — content preserved
 			assert.strictEqual(editor.getText(), "hello");
+			// Ghost text is retained (Tab is excluded from the general dismiss guard)
+			assert.strictEqual(editor.getGhostText(), "/skill:mach6-push");
 		});
 	});
 

--- a/packages/tui/test/editor-ghost-text.test.ts
+++ b/packages/tui/test/editor-ghost-text.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { Editor } from "../src/components/editor.js";
+import { TUI } from "../src/tui.js";
+import { visibleWidth } from "../src/utils.js";
+import { defaultEditorTheme } from "./test-themes.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+/** Create a TUI with a virtual terminal for testing */
+function createTestTUI(cols = 80, rows = 24): TUI {
+	return new TUI(new VirtualTerminal(cols, rows));
+}
+
+describe("Editor ghost text", () => {
+	describe("setGhostText / getGhostText", () => {
+		it("starts with null ghost text", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("stores ghost text", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-plan 42");
+			assert.strictEqual(editor.getGhostText(), "/skill:mach6-plan 42");
+		});
+
+		it("clears ghost text with null", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-plan 42");
+			editor.setGhostText(null);
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+	});
+
+	describe("rendering", () => {
+		it("renders ghost text with dim ANSI when editor is empty", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			const lines = editor.render(40);
+			// The content line (between borders) should contain the ghost text
+			const contentLine = lines[1]; // First line is top border
+			assert.ok(contentLine, "Content line should exist");
+			assert.ok(contentLine.includes("/skill:mach6-push"), "Should contain ghost text");
+			// Should contain dim escape code
+			assert.ok(contentLine.includes("\x1b[2m"), "Should contain dim ANSI code");
+		});
+
+		it("does not render ghost text when editor has content", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+			editor.setText("hello");
+
+			const lines = editor.render(40);
+			const contentLine = lines[1];
+			assert.ok(contentLine, "Content line should exist");
+			// Ghost text should NOT appear
+			assert.ok(!contentLine.includes("/skill:mach6-push"), "Should not contain ghost text when editor has content");
+		});
+
+		it("truncates ghost text to available width", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-plan-with-a-very-long-argument 12345");
+
+			// Render with narrow width - cursor takes 1 col
+			const lines = editor.render(20);
+			const contentLine = lines[1];
+			assert.ok(contentLine, "Content line should exist");
+			// The stripped content should fit within 20 chars
+			const stripped = stripVTControlCharacters(contentLine);
+			assert.ok(visibleWidth(stripped) <= 20, `Line width ${visibleWidth(stripped)} should be <= 20`);
+		});
+	});
+
+	describe("Tab to accept", () => {
+		it("Tab accepts ghost text into editor content", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("\t"); // Tab
+
+			assert.strictEqual(editor.getText(), "/skill:mach6-push");
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("Tab does not accept ghost text when editor has content", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setText("hello");
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("\t"); // Tab
+
+			// Ghost text should have been cleared by setText, but even if set manually,
+			// editor is not empty so Tab should not accept
+			assert.notStrictEqual(editor.getText(), "/skill:mach6-push");
+		});
+	});
+
+	describe("dismiss on input", () => {
+		it("clears ghost text on character input", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("a");
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("clears ghost text on Escape", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("\x1b"); // Escape
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("clears ghost text on arrow key", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("\x1b[C"); // Right arrow
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("does not clear ghost text on Tab (Tab accepts instead)", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			// Tab should accept, not just clear
+			editor.handleInput("\t");
+
+			// Ghost text cleared because it was accepted
+			assert.strictEqual(editor.getGhostText(), null);
+			// Content should be the ghost text
+			assert.strictEqual(editor.getText(), "/skill:mach6-push");
+		});
+	});
+});

--- a/packages/tui/test/editor-ghost-text.test.ts
+++ b/packages/tui/test/editor-ghost-text.test.ts
@@ -91,9 +91,8 @@ describe("Editor ghost text", () => {
 
 			editor.handleInput("\t"); // Tab
 
-			// Ghost text should have been cleared by setText, but even if set manually,
-			// editor is not empty so Tab should not accept
-			assert.notStrictEqual(editor.getText(), "/skill:mach6-push");
+			// Editor is not empty so Tab should not accept ghost text — content preserved
+			assert.strictEqual(editor.getText(), "hello");
 		});
 	});
 
@@ -136,6 +135,39 @@ describe("Editor ghost text", () => {
 			assert.strictEqual(editor.getGhostText(), null);
 			// Content should be the ghost text
 			assert.strictEqual(editor.getText(), "/skill:mach6-push");
+		});
+	});
+
+	describe("setText clears ghost text", () => {
+		it("setText clears ghost text to prevent stale suggestions", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.setText("");
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+
+		it("setText with content also clears ghost text", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.setText("hello");
+
+			assert.strictEqual(editor.getGhostText(), null);
+		});
+	});
+
+	describe("undo after Tab-accept", () => {
+		it("Tab-accept is undoable with undo key", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.setGhostText("/skill:mach6-push");
+
+			editor.handleInput("\t"); // Tab to accept
+			assert.strictEqual(editor.getText(), "/skill:mach6-push");
+
+			editor.handleInput("\x1f"); // Ctrl+- (undo keybinding)
+			assert.strictEqual(editor.getText(), "");
 		});
 	});
 });

--- a/test.sh
+++ b/test.sh
@@ -16,13 +16,14 @@ if NO_COLOR=1 npm test > "$LOG_FILE" 2>&1; then
     # Aggregate results across all test runners (vitest + node:test)
     # Vitest lines have leading whitespace: "      Tests  N passed | M skipped (T)"
     # Node test runner lines: "# tests N", "# pass N", "# fail N"
-    VITEST_PASSED=$(grep -oP 'Tests\s+\K\d+(?=\s+passed)' "$LOG_FILE" | awk '{s+=$1} END {print s+0}')
+    # Use awk instead of grep -P for macOS compatibility (BSD grep lacks -P)
+    VITEST_PASSED=$(awk '/Tests[[:space:]]+[0-9]+[[:space:]]+passed/ { for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/ && $(i+1) == "passed") s+=$i } END {print s+0}' "$LOG_FILE")
     # Vitest format: "Tests  N failed | M passed" — "N failed" comes before "passed"
-    VITEST_FAILED=$(grep -oP 'Tests\s+\K\d+(?=\s+failed)' "$LOG_FILE" | awk '{s+=$1} END {print s+0}')
-    VITEST_SKIPPED=$(grep -oP '\|\s+\K\d+(?=\s+skipped)' "$LOG_FILE" | awk '{s+=$1} END {print s+0}')
+    VITEST_FAILED=$(awk '/Tests[[:space:]]+[0-9]+[[:space:]]+failed/ { for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/ && $(i+1) == "failed") s+=$i } END {print s+0}' "$LOG_FILE")
+    VITEST_SKIPPED=$(awk '/\|[[:space:]]+[0-9]+[[:space:]]+skipped/ { for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/ && $(i+1) == "skipped") s+=$i } END {print s+0}' "$LOG_FILE")
     # Node v24: "# pass N" / "# fail N" — Node v25: "ℹ pass N" / "ℹ fail N"
-    NODE_PASSED=$(grep -P '^(\s*#|ℹ)\s+pass\s' "$LOG_FILE" | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
-    NODE_FAILED=$(grep -P '^(\s*#|ℹ)\s+fail\s' "$LOG_FILE" | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
+    NODE_PASSED=$(awk '/^[[:space:]]*(#|ℹ)[[:space:]]+pass[[:space:]]/ { for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) s+=$i } END {print s+0}' "$LOG_FILE")
+    NODE_FAILED=$(awk '/^[[:space:]]*(#|ℹ)[[:space:]]+fail[[:space:]]/ { for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) s+=$i } END {print s+0}' "$LOG_FILE")
 
     TOTAL_PASSED=$((VITEST_PASSED + NODE_PASSED))
     TOTAL_FAILED=$((VITEST_FAILED + NODE_FAILED))
@@ -47,7 +48,7 @@ else
     echo "─────────────────────────────────"
     echo ""
     # Show per-runner summaries
-    grep -P '(Tests\s+\d+|# tests\s+\d+|# fail\s+\d+|Test Files)' "$LOG_FILE" | tail -10
+    grep -E '(Tests[[:space:]]+[0-9]+|# tests[[:space:]]+[0-9]+|# fail[[:space:]]+[0-9]+|Test Files)' "$LOG_FILE" | tail -10
     echo ""
     echo "Full log: $LOG_FILE"
     exit $EXIT_CODE


### PR DESCRIPTION
Closes #201

Add ghost text (dim gray) to the Editor input prompt showing suggested next commands after an agent turn. User can Tab to accept or type to dismiss.

Implementation plan posted as a comment below.

### Example Screenshots

<img width="458" height="103" alt="Screenshot 2026-05-12 at 12 44 39" src="https://github.com/user-attachments/assets/b066f4a9-9632-4974-b9e8-340b66b6062d" />

---

<img width="465" height="280" alt="Screenshot 2026-05-12 at 14 43 43" src="https://github.com/user-attachments/assets/d83e84c6-36de-4211-9a9e-eff8568384a8" />

