### PR TITLE
docs: fix root README tool count, add documentation guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,16 @@ If it reports stale packages, remove the stale directories and re-establish work
 
 **Never create a git tag without first bumping `package.json` to match.**
 
+## Documentation
+
+**The root `README.md` is the most important documentation file in this repo.** It is the first thing users and contributors see. When features, tools, or capabilities change, the root README must be updated alongside `packages/coding-agent/README.md` and any relevant files in `packages/coding-agent/docs/`. Do not assume that updating package-level docs is sufficient — if the root README describes the feature, it must stay accurate.
+
+Documentation files to check on every feature change:
+- `README.md` (root — the public face of the project)
+- `packages/coding-agent/README.md` (detailed product docs)
+- `packages/coding-agent/docs/` (feature-specific docs: extensions, json, rpc, sdk, etc.)
+- `AGENTS.md` (this file — development guide)
+
 ## Completeness Rule
 
 **Don't defer parts of categorical work.** If the task is "fix docs," fix ALL docs — don't cherry-pick the easy ones and punt the rest to a follow-up. Same applies to failing tests and discovered bugs: if you find it during the work, fix it now. "Out of scope" is not an excuse to ship known-broken things.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the full coding-agent docs in [packages/coding-agent](packages/coding-agent/
 
 ### Tools and interaction
 
-dreb ships with 10 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Three more tools are always active when available: `search` for semantic codebase search, `skill` for loading workflows, and `tasks_update` for visible task tracking.
+dreb ships with 10 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Four more tools are always active when available: `search` for semantic codebase search, `skill` for loading workflows, `tasks_update` for visible task tracking, and `suggest_next` for ghost text command suggestions (Tab to accept).
 
 Interactive mode adds slash commands such as `/model`, `/settings`, `/resume`, `/tree`, `/fork`, `/compact`, `/dream`, `/buddy`, `/export`, `/reload`, `/hotkeys`, and `/changelog`. The message queue lets you steer a running agent or queue follow-up work without waiting for the current turn to finish.
 


### PR DESCRIPTION
Fixes documentation gaps missed in PR 202 (v2.17.0):

1. **Root README** — Updated "Three more tools are always active" → "Four" and added `suggest_next` with description. The root README is the first thing users see and was stale after the ghost text feature landed.

2. **AGENTS.md** — Added a new "Documentation" section emphasizing that the root `README.md` is the most important doc file and must be updated alongside package-level docs on every feature change. Lists all documentation files to check.
