### PR TITLE
fix: pin @dreb/* inter-package deps to exact version (fixes bun resolution)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8766,7 +8766,7 @@
 			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dreb/ai": "*"
+				"@dreb/ai": "2.17.0"
 			},
 			"devDependencies": {
 				"@types/node": "^24.3.0",
@@ -8851,10 +8851,10 @@
 			"version": "2.17.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dreb/agent-core": "*",
-				"@dreb/ai": "*",
-				"@dreb/semantic-search": "*",
-				"@dreb/tui": "*",
+				"@dreb/agent-core": "2.17.0",
+				"@dreb/ai": "2.17.0",
+				"@dreb/semantic-search": "2.17.0",
+				"@dreb/tui": "2.17.0",
 				"@huggingface/transformers": "^4.0.1",
 				"@mariozechner/jiti": "^2.6.2",
 				"@silvia-odwyer/photon-node": "^0.3.4",
@@ -9014,7 +9014,7 @@
 			"name": "@dreb/telegram",
 			"version": "2.17.0",
 			"dependencies": {
-				"@dreb/coding-agent": "*",
+				"@dreb/coding-agent": "2.17.0",
 				"grammy": "^1.35.0"
 			},
 			"bin": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,7 +20,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/ai": "*"
+		"@dreb/ai": "2.17.0"
 	},
 	"keywords": [
 		"ai",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -52,10 +52,10 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/agent-core": "*",
-		"@dreb/ai": "*",
-		"@dreb/semantic-search": "*",
-		"@dreb/tui": "*",
+		"@dreb/agent-core": "2.17.0",
+		"@dreb/ai": "2.17.0",
+		"@dreb/semantic-search": "2.17.0",
+		"@dreb/tui": "2.17.0",
 		"@huggingface/transformers": "^4.0.1",
 		"@mariozechner/jiti": "^2.6.2",
 		"@silvia-odwyer/photon-node": "^0.3.4",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -30,7 +30,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@dreb/coding-agent": "*",
+		"@dreb/coding-agent": "2.17.0",
 		"grammy": "^1.35.0"
 	},
 	"devDependencies": {

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -41,6 +41,29 @@ for plugin_json in packages/*/.claude-plugin/plugin.json; do
 	echo "  $plugin_json -> $VERSION"
 done
 
+# Update @dreb/* inter-package dependency specifiers to exact version
+# This ensures package managers (especially bun) install matching versions
+for pkg in packages/*/package.json; do
+	node -e "
+		const fs = require('fs');
+		const pkg = JSON.parse(fs.readFileSync('$pkg', 'utf-8'));
+		let changed = false;
+		for (const depType of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+			if (!pkg[depType]) continue;
+			for (const [name, ver] of Object.entries(pkg[depType])) {
+				if (name.startsWith('@dreb/') && ver !== '$VERSION') {
+					pkg[depType][name] = '$VERSION';
+					changed = true;
+				}
+			}
+		}
+		if (changed) {
+			fs.writeFileSync('$pkg', JSON.stringify(pkg, null, '\t') + '\n');
+			console.log('  $pkg @dreb/* deps -> $VERSION');
+		}
+	"
+done
+
 # Refresh package-lock.json so workspace versions match
 npm install --package-lock-only --ignore-scripts --install-links=false 2>/dev/null
 echo "  package-lock.json refreshed"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -19,11 +19,19 @@ fi
 VERSION=$(node -p "require('./package.json').version")
 echo "Syncing version $VERSION to all packages..."
 
+# Set version and pin @dreb/* inter-package deps to exact version
+# Pinning ensures package managers (especially bun) install matching versions
 for pkg in packages/*/package.json; do
 	node -e "
 		const fs = require('fs');
 		const pkg = JSON.parse(fs.readFileSync('$pkg', 'utf-8'));
 		pkg.version = '$VERSION';
+		for (const depType of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+			if (!pkg[depType]) continue;
+			for (const name of Object.keys(pkg[depType])) {
+				if (name.startsWith('@dreb/')) pkg[depType][name] = '$VERSION';
+			}
+		}
 		fs.writeFileSync('$pkg', JSON.stringify(pkg, null, '\t') + '\n');
 	"
 	echo "  $pkg -> $VERSION"
@@ -39,29 +47,6 @@ for plugin_json in packages/*/.claude-plugin/plugin.json; do
 		fs.writeFileSync('$plugin_json', JSON.stringify(p, null, '  ') + '\n');
 	"
 	echo "  $plugin_json -> $VERSION"
-done
-
-# Update @dreb/* inter-package dependency specifiers to exact version
-# This ensures package managers (especially bun) install matching versions
-for pkg in packages/*/package.json; do
-	node -e "
-		const fs = require('fs');
-		const pkg = JSON.parse(fs.readFileSync('$pkg', 'utf-8'));
-		let changed = false;
-		for (const depType of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
-			if (!pkg[depType]) continue;
-			for (const [name, ver] of Object.entries(pkg[depType])) {
-				if (name.startsWith('@dreb/') && ver !== '$VERSION') {
-					pkg[depType][name] = '$VERSION';
-					changed = true;
-				}
-			}
-		}
-		if (changed) {
-			fs.writeFileSync('$pkg', JSON.stringify(pkg, null, '\t') + '\n');
-			console.log('  $pkg @dreb/* deps -> $VERSION');
-		}
-	"
 done
 
 # Refresh package-lock.json so workspace versions match


### PR DESCRIPTION
Fixes #204

Bun's lockfile resolves `"*"` dependency specifiers to stale cached versions, causing `bunx dreb` to fail with missing exports when `@dreb/ai` is outdated relative to `@dreb/coding-agent`.

**Changes:**
- `scripts/sync-version.sh` now pins all `@dreb/*` inter-package deps to the exact release version
- Updated `packages/agent/package.json`, `packages/coding-agent/package.json`, `packages/telegram/package.json` accordingly
