### PR TITLE
docs: bun cache troubleshooting for stale @dreb/* deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Or route through a custom provider — corporate proxy, OpenAI-compatible local 
 
 Platform notes: [Windows](packages/coding-agent/docs/windows.md), [Termux/Android](packages/coding-agent/docs/termux.md), [tmux](packages/coding-agent/docs/tmux.md), [terminal setup](packages/coding-agent/docs/terminal-setup.md), and [shell aliases](packages/coding-agent/docs/shell-aliases.md).
 
+**Bun users:** Bun's lockfile can cache stale versions of `@dreb/*` packages, causing import errors after upgrades. If you hit missing export errors with `bunx dreb`, clear the cache and re-install:
+
+```bash
+bun pm cache rm
+bunx --force dreb
+```
+
 ### Building from source
 
 ```bash

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -68,6 +68,8 @@ Then just talk to dreb. All 10 built-in tools are enabled by default: `read`, `w
 
 **Platform notes:** [Windows](docs/windows.md) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
 
+**Bun users:** Bun's lockfile can cache stale `@dreb/*` versions after upgrades, causing missing-export errors. Fix with `bun pm cache rm && bunx --force dreb`.
+
 ---
 
 ### Building from source


### PR DESCRIPTION
Fixes #204
Supersedes #205

## Problem

Bun's lockfile resolves `"*"` dependency specifiers to stale cached versions, causing `bunx dreb` to fail with missing exports after upgrades.

## Why not pin versions in source?

The `"*"` specifier is **intentional** — it guarantees workspace symlinks always resolve to local source during development, regardless of version drift. With pinned versions, `npm install` fails if workspace package versions ever get out of sync (tested: npm tries to fetch from registry instead of symlinking when the pinned version doesn't match the local workspace package).

See AGENTS.md "Workspace Link Safety" for full context.

## Fix

Document the workaround for bun users in both READMEs:

```bash
bun pm cache rm
bunx --force dreb
```

This is a bun-specific package manager quirk, not a dreb bug.
