### PR TITLE
Add built-in wait tool for explicit no-op turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See the full coding-agent docs in [packages/coding-agent](packages/coding-agent/
 
 ### Tools and interaction
 
-dreb ships with 10 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Four more tools are always active when available: `search` for semantic codebase search, `skill` for loading workflows, `tasks_update` for visible task tracking, and `suggest_next` for ghost text command suggestions (Tab to accept).
+dreb ships with 11 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, and `wait`. Four more tools are always active when available: `search` for semantic codebase search, `skill` for loading workflows, `tasks_update` for visible task tracking, and `suggest_next` for ghost text command suggestions (Tab to accept).
 
 Interactive mode adds slash commands such as `/model`, `/settings`, `/resume`, `/tree`, `/fork`, `/compact`, `/dream`, `/buddy`, `/export`, `/reload`, `/hotkeys`, and `/changelog`. The message queue lets you steer a running agent or queue follow-up work without waiting for the current turn to finish.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -2312,9 +2312,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -2340,9 +2340,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -2358,9 +2358,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6622,22 +6622,22 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
 				"@protobufjs/fetch": "^1.1.0",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.1",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
 				"long": "^5.0.0"
 			},
@@ -8763,7 +8763,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8792,7 +8792,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8848,7 +8848,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8963,7 +8963,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9012,7 +9012,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9044,7 +9044,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.17.0",
+			"version": "2.18.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -62,7 +62,7 @@ dreb
 
 Or use a custom provider (corporate proxy, Bedrock, etc.) — see [Custom providers & models](#providers--models).
 
-Then just talk to dreb. All 10 built-in tools are enabled by default: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, and `subagent`. Use `--tools` to restrict to a subset (e.g., `--tools read,grep,find,ls` for read-only). Four additional tools — `search`, `skill`, `tasks_update`, and `suggest_next` — are always active. The model uses these to fulfill your requests. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [packages](#packages).
+Then just talk to dreb. All 11 built-in tools are enabled by default: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, and `wait`. Use `--tools` to restrict to a subset (e.g., `--tools read,grep,find,ls` for read-only). Four additional tools — `search`, `skill`, `tasks_update`, and `suggest_next` — are always active. The model uses these to fulfill your requests. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [packages](#packages).
 
 **Also available:** [`@dreb/telegram`](https://www.npmjs.com/package/@dreb/telegram) — run dreb as a Telegram bot (`npm install -g @dreb/telegram`).
 
@@ -585,7 +585,7 @@ cat README.md | dreb -p "Summarize this text"
 | `--tools <list>` | Comma-separated list of tools to enable (default: all) |
 | `--no-tools` | Disable all built-in tools (extension tools still work) |
 
-Available built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`
+Available built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `wait`
 
 Four additional tools are always active but don't appear in `--tools`:
 - `search` — [semantic codebase search](#semantic-search) using natural language queries

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -569,7 +569,7 @@ In the default parallel tool execution mode, sibling tool calls from the same as
 import { isToolCallEventType } from "@dreb/coding-agent";
 
 dreb.on("tool_call", async (event, ctx) => {
-  // event.toolName - "bash", "read", "write", "edit", "grep", "find", "ls", "web_search", "web_fetch", "subagent", "search", "skill", "tasks_update", "suggest_next", or custom tool names
+  // event.toolName - "bash", "read", "write", "edit", "grep", "find", "ls", "web_search", "web_fetch", "subagent", "wait", "search", "skill", "tasks_update", "suggest_next", or custom tool names
   // event.toolCallId
   // event.input - tool parameters
 
@@ -1474,7 +1474,7 @@ async execute(toolCallId, params) {
 
 ### Overriding Built-in Tools
 
-Extensions can override built-in tools (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `search`) by registering a tool with the same name. Interactive mode displays a warning when this happens. The factory-only tools (`skill`, `tasks_update`, `suggest_next`) can also be overridden.
+Extensions can override built-in tools (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `wait`, `search`) by registering a tool with the same name. Interactive mode displays a warning when this happens. The factory-only tools (`skill`, `tasks_update`, `suggest_next`) can also be overridden.
 
 ```bash
 # Extension's read tool replaces built-in read

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -326,5 +326,6 @@ ${chalk.bold("Available Tools (default: all):")}
   web_search - Search the web
   web_fetch  - Fetch URL content
   subagent   - Delegate tasks to independent subagents
+  wait       - Do nothing and end your turn (explicit no-op)
 `);
 }

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -219,7 +219,7 @@ ${chalk.bold("Options:")}
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching
   --no-tools                     Disable all built-in tools
   --tools <tools>                Comma-separated list of tools to enable (default: all)
-                                 Available: read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent
+                                 Available: read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent, wait
   --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2813,6 +2813,7 @@ export class AgentSession {
 					"web_search",
 					"web_fetch",
 					"subagent",
+					"wait",
 					"search",
 					"skill",
 					"tasks_update",

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -63,7 +63,7 @@ export interface CreateAgentSessionOptions {
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel }>;
 
-	/** Built-in tools to use. Default: all standard tools [read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent]. `skill`, `tasks_update`, and `search` are always active regardless of this setting. */
+	/** Built-in tools to use. Default: all standard tools [read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent, wait]. `skill`, `tasks_update`, and `search` are always active regardless of this setting. */
 	tools?: Tool[];
 	/** Custom tools to register (in addition to built-in tools). */
 	customTools?: ToolDefinition[];

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -269,6 +269,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		"web_search",
 		"web_fetch",
 		"subagent",
+		"wait",
 	];
 	const initialActiveToolNames: string[] = options.tools
 		? [...options.tools.map((t) => t.name).filter((n): n is ToolName => n in allTools), ...alwaysActiveBuiltins]

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -237,6 +237,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		"web_search",
 		"web_fetch",
 		"subagent",
+		"wait",
 	];
 	const visibleTools = tools.filter((name) => !!toolSnippets?.[name]);
 	const toolsList =

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -81,6 +81,7 @@ export {
 	type BackgroundAgentInfo,
 	createSubagentTool,
 	createSubagentToolDefinition,
+	filterSubagentTools,
 	getBackgroundAgents,
 	getRunningBackgroundAgents,
 	pruneBackgroundAgents,
@@ -116,7 +117,16 @@ export {
 	truncateLine,
 	truncateTail,
 } from "./truncate.js";
-export { createWaitToolDefinition, type WaitToolDetails, type WaitToolInput, waitToolDefinition } from "./wait.js";
+export {
+	createWaitToolDefinition,
+	formatWaitCall,
+	formatWaitResult,
+	type WaitAgentInfo,
+	type WaitToolDetails,
+	type WaitToolInput,
+	type WaitToolOptions,
+	waitToolDefinition,
+} from "./wait.js";
 export {
 	createWebFetchTool,
 	createWebFetchToolDefinition,
@@ -167,6 +177,7 @@ import { createSkillTool, createSkillToolDefinition, type SkillToolOptions } fro
 import {
 	createSubagentTool,
 	createSubagentToolDefinition,
+	getRunningBackgroundAgents,
 	type SubagentToolOptions,
 	subagentTool,
 	subagentToolDefinition,
@@ -270,7 +281,7 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 		web_fetch: createWebFetchToolDefinition(cwd),
 		subagent: createSubagentToolDefinition(cwd, options?.subagent),
 		tmp_read: createTmpReadToolDefinition(options?.read),
-		wait: createWaitToolDefinition(),
+		wait: createWaitToolDefinition({ getRunningAgents: getRunningBackgroundAgents }),
 	};
 	if (isSearchAvailable()) {
 		tools.search = createSearchToolDefinition(cwd);
@@ -313,7 +324,7 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 		web_fetch: createWebFetchTool(cwd),
 		subagent: createSubagentTool(cwd, options?.subagent),
 		tmp_read: wrapToolDefinition(createTmpReadToolDefinition(options?.read)),
-		wait: wrapToolDefinition(createWaitToolDefinition()),
+		wait: wrapToolDefinition(createWaitToolDefinition({ getRunningAgents: getRunningBackgroundAgents })),
 	};
 	if (isSearchAvailable()) {
 		tools.search = createSearchTool(cwd);

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -116,6 +116,7 @@ export {
 	truncateLine,
 	truncateTail,
 } from "./truncate.js";
+export { createWaitToolDefinition, type WaitToolDetails, type WaitToolInput, waitToolDefinition } from "./wait.js";
 export {
 	createWebFetchTool,
 	createWebFetchToolDefinition,
@@ -174,6 +175,7 @@ import { createSuggestNextToolDefinition, type SuggestNextCallback } from "./sug
 import { createTasksToolDefinition, type TasksUpdateCallback } from "./tasks.js";
 import { createTmpReadToolDefinition } from "./tmp-read.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
+import { createWaitToolDefinition, waitToolDefinition } from "./wait.js";
 import {
 	createWebFetchTool,
 	createWebFetchToolDefinition,
@@ -194,6 +196,7 @@ export const readOnlyTools: Tool[] = [readTool, grepTool, findTool, lsTool];
 
 const tmpReadToolDefinition = createTmpReadToolDefinition();
 const tmpReadTool = wrapToolDefinition(tmpReadToolDefinition);
+const waitTool = wrapToolDefinition(waitToolDefinition);
 
 export const allTools = {
 	read: readTool,
@@ -207,6 +210,7 @@ export const allTools = {
 	web_fetch: webFetchTool,
 	subagent: subagentTool,
 	tmp_read: tmpReadTool,
+	wait: waitTool,
 };
 
 export const allToolDefinitions = {
@@ -221,6 +225,7 @@ export const allToolDefinitions = {
 	web_fetch: webFetchToolDefinition,
 	subagent: subagentToolDefinition,
 	tmp_read: tmpReadToolDefinition,
+	wait: waitToolDefinition,
 };
 
 export type ToolName = keyof typeof allTools;
@@ -265,6 +270,7 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 		web_fetch: createWebFetchToolDefinition(cwd),
 		subagent: createSubagentToolDefinition(cwd, options?.subagent),
 		tmp_read: createTmpReadToolDefinition(options?.read),
+		wait: createWaitToolDefinition(),
 	};
 	if (isSearchAvailable()) {
 		tools.search = createSearchToolDefinition(cwd);
@@ -307,6 +313,7 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 		web_fetch: createWebFetchTool(cwd),
 		subagent: createSubagentTool(cwd, options?.subagent),
 		tmp_read: wrapToolDefinition(createTmpReadToolDefinition(options?.read)),
+		wait: wrapToolDefinition(createWaitToolDefinition()),
 	};
 	if (isSearchAvailable()) {
 		tools.search = createSearchTool(cwd);

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -157,31 +157,25 @@ const NODE_EXEC = process.execPath;
 // never no-op; they have a task to complete) and subagent (no recursive spawning).
 const SUBAGENT_EXCLUDED_TOOLS = ["wait", "subagent"] as const;
 
-// Default tools for subagents when no tools are specified in the agent definition.
-// Intentionally excludes everything in SUBAGENT_EXCLUDED_TOOLS.
-const SUBAGENT_DEFAULT_TOOLS = [
-	"read",
-	"bash",
-	"edit",
-	"write",
-	"grep",
-	"find",
-	"ls",
-	"web_search",
-	"web_fetch",
-	"search",
-];
+// Default standard tools for subagents when no tools are specified in the agent
+// definition. This is the set passed via --tools to the child process.
+//
+// NOTE: Always-active tools (search, skill, tasks_update, suggest_next) are NOT
+// listed here — the child process adds them unconditionally regardless of --tools.
+// Internal tools (tmp_read) are also excluded.
+const SUBAGENT_DEFAULT_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls", "web_search", "web_fetch"];
 
 /**
  * Filter a comma-separated tools string, removing any tools in SUBAGENT_EXCLUDED_TOOLS.
- * Returns the filtered tools as a comma-separated string, or undefined if all were excluded.
+ * Returns the filtered tools as a comma-separated string (always non-empty — falls
+ * back to SUBAGENT_DEFAULT_TOOLS if all specified tools were excluded).
  */
-export function filterSubagentTools(tools: string | undefined): string | undefined {
+export function filterSubagentTools(tools: string | undefined): string {
 	if (!tools) return SUBAGENT_DEFAULT_TOOLS.join(",");
 	const filtered = tools
 		.split(",")
 		.map((t) => t.trim())
-		.filter((t) => !SUBAGENT_EXCLUDED_TOOLS.includes(t as any))
+		.filter((t) => !(SUBAGENT_EXCLUDED_TOOLS as readonly string[]).includes(t))
 		.join(",");
 	return filtered || SUBAGENT_DEFAULT_TOOLS.join(",");
 }
@@ -235,10 +229,9 @@ async function spawnSubagent(
 			args.push("--provider", parentProvider);
 		}
 	}
-	const toolsArg = filterSubagentTools(agentConfig.tools);
-	if (toolsArg) {
-		args.push("--tools", toolsArg);
-	}
+	// Always pass --tools to ensure wait/subagent are excluded from child processes.
+	// filterSubagentTools always returns a non-empty string.
+	args.push("--tools", filterSubagentTools(agentConfig.tools));
 	if (agentConfig.systemPrompt) {
 		args.push("--append-system-prompt", agentConfig.systemPrompt);
 	}

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -153,6 +153,39 @@ export interface SubagentResult {
 const DREB_SCRIPT = process.argv[1] || "dreb";
 const NODE_EXEC = process.execPath;
 
+// Tools that must never be available to subagents — wait (subagents should
+// never no-op; they have a task to complete) and subagent (no recursive spawning).
+const SUBAGENT_EXCLUDED_TOOLS = ["wait", "subagent"] as const;
+
+// Default tools for subagents when no tools are specified in the agent definition.
+// Intentionally excludes everything in SUBAGENT_EXCLUDED_TOOLS.
+const SUBAGENT_DEFAULT_TOOLS = [
+	"read",
+	"bash",
+	"edit",
+	"write",
+	"grep",
+	"find",
+	"ls",
+	"web_search",
+	"web_fetch",
+	"search",
+];
+
+/**
+ * Filter a comma-separated tools string, removing any tools in SUBAGENT_EXCLUDED_TOOLS.
+ * Returns the filtered tools as a comma-separated string, or undefined if all were excluded.
+ */
+export function filterSubagentTools(tools: string | undefined): string | undefined {
+	if (!tools) return SUBAGENT_DEFAULT_TOOLS.join(",");
+	const filtered = tools
+		.split(",")
+		.map((t) => t.trim())
+		.filter((t) => !SUBAGENT_EXCLUDED_TOOLS.includes(t as any))
+		.join(",");
+	return filtered || SUBAGENT_DEFAULT_TOOLS.join(",");
+}
+
 // TODO: Support PATH-based binary discovery.
 // Currently returns the captured argv[1].
 function findDrebBinary(): string {
@@ -202,22 +235,9 @@ async function spawnSubagent(
 			args.push("--provider", parentProvider);
 		}
 	}
-	// Tools that must never be available to subagents — wait (subagents should
-	// never no-op; they have a task to complete) and subagent (no recursive spawning).
-	const SUBAGENT_EXCLUDED_TOOLS = ["wait", "subagent"];
-	if (agentConfig.tools) {
-		const filtered = agentConfig.tools
-			.split(",")
-			.map((t) => t.trim())
-			.filter((t) => !SUBAGENT_EXCLUDED_TOOLS.includes(t))
-			.join(",");
-		if (filtered) {
-			args.push("--tools", filtered);
-		}
-	} else {
-		// No tools specified — pass explicit defaults minus excluded tools
-		const defaults = ["read", "bash", "edit", "write", "grep", "find", "ls", "web_search", "web_fetch", "search"];
-		args.push("--tools", defaults.join(","));
+	const toolsArg = filterSubagentTools(agentConfig.tools);
+	if (toolsArg) {
+		args.push("--tools", toolsArg);
 	}
 	if (agentConfig.systemPrompt) {
 		args.push("--append-system-prompt", agentConfig.systemPrompt);

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -202,8 +202,22 @@ async function spawnSubagent(
 			args.push("--provider", parentProvider);
 		}
 	}
+	// Tools that must never be available to subagents — wait (subagents should
+	// never no-op; they have a task to complete) and subagent (no recursive spawning).
+	const SUBAGENT_EXCLUDED_TOOLS = ["wait", "subagent"];
 	if (agentConfig.tools) {
-		args.push("--tools", agentConfig.tools);
+		const filtered = agentConfig.tools
+			.split(",")
+			.map((t) => t.trim())
+			.filter((t) => !SUBAGENT_EXCLUDED_TOOLS.includes(t))
+			.join(",");
+		if (filtered) {
+			args.push("--tools", filtered);
+		}
+	} else {
+		// No tools specified — pass explicit defaults minus excluded tools
+		const defaults = ["read", "bash", "edit", "write", "grep", "find", "ls", "web_search", "web_fetch", "search"];
+		args.push("--tools", defaults.join(","));
 	}
 	if (agentConfig.systemPrompt) {
 		args.push("--append-system-prompt", agentConfig.systemPrompt);

--- a/packages/coding-agent/src/core/tools/wait.ts
+++ b/packages/coding-agent/src/core/tools/wait.ts
@@ -12,8 +12,21 @@ import type { ToolDefinition } from "../extensions/types.js";
 // ============================================================================
 // Types
 
+/** Minimal shape of a running background agent (avoids importing from subagent.ts to prevent circular deps). */
+export interface WaitAgentInfo {
+	agentId: string;
+	agentType: string;
+	taskSummary: string;
+}
+
 export interface WaitToolDetails {
 	reason: string | undefined;
+	runningAgents: readonly WaitAgentInfo[];
+}
+
+export interface WaitToolOptions {
+	/** Returns currently running background agents. Injected by the factory to avoid circular imports. */
+	getRunningAgents?: () => readonly WaitAgentInfo[];
 }
 
 // ============================================================================
@@ -32,7 +45,7 @@ export type WaitToolInput = Static<typeof waitSchema>;
 // ============================================================================
 // Render helpers
 
-function formatWaitCall(args: { reason?: string } | undefined, theme: any): string {
+export function formatWaitCall(args: { reason?: string } | undefined, theme: any): string {
 	const reason = args?.reason;
 	if (reason) {
 		return `${theme.fg("toolTitle", theme.bold("wait"))} ${theme.fg("muted", reason)}`;
@@ -40,11 +53,16 @@ function formatWaitCall(args: { reason?: string } | undefined, theme: any): stri
 	return theme.fg("toolTitle", theme.bold("wait"));
 }
 
-function formatWaitResult(
-	_result: { content: Array<{ type: string; text?: string }>; details?: WaitToolDetails },
+export function formatWaitResult(
+	result: { content: Array<{ type: string; text?: string }>; details?: WaitToolDetails },
 	theme: any,
 ): string {
-	return theme.fg("muted", "→ resumed");
+	const agents = result.details?.runningAgents ?? [];
+	if (agents.length > 0) {
+		const agentList = agents.map((a) => `${a.agentId.slice(0, 12)} ${a.agentType}`).join(", ");
+		return theme.fg("muted", `→ doing nothing (waiting on: ${agentList})`);
+	}
+	return theme.fg("muted", "→ doing nothing — no subagents running");
 }
 
 // ============================================================================
@@ -72,7 +90,7 @@ export const waitToolDefinition: ToolDefinition<typeof waitSchema, WaitToolDetai
 
 		return {
 			content: [{ type: "text" as const, text }],
-			details: { reason },
+			details: { reason, runningAgents: [] as WaitAgentInfo[] },
 		};
 	},
 
@@ -90,8 +108,26 @@ export const waitToolDefinition: ToolDefinition<typeof waitSchema, WaitToolDetai
 };
 
 // ============================================================================
-// Factory (for consistency with other tools, though wait has no dependencies)
+// Factory — accepts optional getRunningAgents callback to show background agent
+// status in the result. The callback is injected here (rather than imported from
+// subagent.ts) to avoid a circular dependency through model-resolver → args → index.
 
-export function createWaitToolDefinition(): ToolDefinition<typeof waitSchema, WaitToolDetails | undefined> {
-	return waitToolDefinition;
+export function createWaitToolDefinition(
+	options?: WaitToolOptions,
+): ToolDefinition<typeof waitSchema, WaitToolDetails | undefined> {
+	if (!options?.getRunningAgents) return waitToolDefinition;
+
+	return {
+		...waitToolDefinition,
+		async execute(_toolCallId, params: WaitToolInput, _signal?, _onUpdate?, _ctx?) {
+			const reason = params.reason?.trim() || undefined;
+			const runningAgents = options.getRunningAgents!();
+			const text = reason ? `Waiting: ${reason}` : "Waiting…";
+
+			return {
+				content: [{ type: "text" as const, text }],
+				details: { reason, runningAgents },
+			};
+		},
+	};
 }

--- a/packages/coding-agent/src/core/tools/wait.ts
+++ b/packages/coding-agent/src/core/tools/wait.ts
@@ -1,0 +1,97 @@
+/**
+ * Wait tool — explicit no-op for models that don't know how to end a turn.
+ *
+ * Some models (notably Kimi) invent useless `bash` calls to simulate waiting.
+ * This tool gives them a sanctioned no-op action that cleanly ends the turn.
+ */
+
+import { Text } from "@dreb/tui";
+import { type Static, Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "../extensions/types.js";
+
+// ============================================================================
+// Types
+
+export interface WaitToolDetails {
+	reason: string | undefined;
+}
+
+// ============================================================================
+// Schema
+
+const waitSchema = Type.Object({
+	reason: Type.Optional(
+		Type.String({
+			description: "Optional reason for waiting (e.g. 'background subagent still running')",
+		}),
+	),
+});
+
+export type WaitToolInput = Static<typeof waitSchema>;
+
+// ============================================================================
+// Render helpers
+
+function formatWaitCall(args: { reason?: string } | undefined, theme: any): string {
+	const reason = args?.reason;
+	if (reason) {
+		return `${theme.fg("toolTitle", theme.bold("wait"))} ${theme.fg("muted", reason)}`;
+	}
+	return theme.fg("toolTitle", theme.bold("wait"));
+}
+
+function formatWaitResult(
+	_result: { content: Array<{ type: string; text?: string }>; details?: WaitToolDetails },
+	theme: any,
+): string {
+	return theme.fg("muted", "→ resumed");
+}
+
+// ============================================================================
+// Tool definition (singleton — no cwd or callback dependencies)
+
+export const waitToolDefinition: ToolDefinition<typeof waitSchema, WaitToolDetails | undefined> = {
+	name: "wait",
+	label: "wait",
+	description:
+		"Do nothing and end your turn. Use this when you are explicitly told to wait, or when background subagents are running and you have no other work to do.",
+
+	parameters: waitSchema,
+
+	promptSnippet: "Do nothing and end your turn (use when waiting for background work to complete)",
+
+	promptGuidelines: [
+		"Use `wait` only when explicitly told to wait, or when background subagents are still running and you have no other work to do",
+		"Do NOT use `wait` as a general-purpose delay or sleep — it returns immediately",
+		"If you need to wait for something, call `wait` once — do not loop or call it repeatedly",
+	],
+
+	async execute(_toolCallId, params: WaitToolInput, _signal?, _onUpdate?, _ctx?) {
+		const reason = params.reason?.trim() || undefined;
+		const text = reason ? `Waiting: ${reason}` : "Waiting…";
+
+		return {
+			content: [{ type: "text" as const, text }],
+			details: { reason },
+		};
+	},
+
+	renderCall(args, theme, context) {
+		const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+		text.setText(formatWaitCall(args, theme));
+		return text;
+	},
+
+	renderResult(result, _options, theme, context) {
+		const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+		text.setText(formatWaitResult(result as any, theme));
+		return text;
+	},
+};
+
+// ============================================================================
+// Factory (for consistency with other tools, though wait has no dependencies)
+
+export function createWaitToolDefinition(): ToolDefinition<typeof waitSchema, WaitToolDetails | undefined> {
+	return waitToolDefinition;
+}

--- a/packages/coding-agent/src/core/tools/wait.ts
+++ b/packages/coding-agent/src/core/tools/wait.ts
@@ -91,6 +91,7 @@ export const waitToolDefinition: ToolDefinition<typeof waitSchema, WaitToolDetai
 		return {
 			content: [{ type: "text" as const, text }],
 			details: { reason, runningAgents: [] as WaitAgentInfo[] },
+			endTurn: true,
 		};
 	},
 
@@ -127,6 +128,7 @@ export function createWaitToolDefinition(
 			return {
 				content: [{ type: "text" as const, text }],
 				details: { reason, runningAgents },
+				endTurn: true,
 			};
 		},
 	};

--- a/packages/coding-agent/test/tools/wait.test.ts
+++ b/packages/coding-agent/test/tools/wait.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { createWaitToolDefinition, type WaitToolDetails, waitToolDefinition } from "../../src/core/tools/wait.js";
+import { filterSubagentTools } from "../../src/core/tools/subagent.js";
+import {
+	createWaitToolDefinition,
+	formatWaitCall,
+	formatWaitResult,
+	type WaitToolDetails,
+	waitToolDefinition,
+} from "../../src/core/tools/wait.js";
+
+// Lightweight mock theme matching patterns in subagent-agent-type.test.ts
+const mockTheme = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+};
 
 describe("wait tool", () => {
 	// Cast execute to skip the ctx parameter (not used by this tool)
@@ -14,28 +27,28 @@ describe("wait tool", () => {
 		const result = await execute("call-1", {});
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting…" });
-		expect(result.details).toEqual({ reason: undefined });
+		expect(result.details?.reason).toBeUndefined();
 	});
 
 	it("returns confirmation text with a reason", async () => {
 		const result = await execute("call-2", { reason: "background subagent still running" });
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting: background subagent still running" });
-		expect(result.details).toEqual({ reason: "background subagent still running" });
+		expect(result.details?.reason).toBe("background subagent still running");
 	});
 
 	it("trims whitespace-only reason to undefined", async () => {
 		const result = await execute("call-3", { reason: "   " });
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting…" });
-		expect(result.details).toEqual({ reason: undefined });
+		expect(result.details?.reason).toBeUndefined();
 	});
 
 	it("trims reason string", async () => {
 		const result = await execute("call-4", { reason: "  waiting for agent  " });
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting: waiting for agent" });
-		expect(result.details).toEqual({ reason: "waiting for agent" });
+		expect(result.details?.reason).toBe("waiting for agent");
 	});
 
 	it("returns immediately (is synchronous aside from Promise wrapper)", async () => {
@@ -45,6 +58,12 @@ describe("wait tool", () => {
 
 		// Should complete in well under 50ms — it's a pure no-op
 		expect(elapsed).toBeLessThan(50);
+	});
+
+	it("includes runningAgents in details", async () => {
+		const result = await execute("call-6", {});
+		// No agents spawned in test context, so should be empty array
+		expect(result.details?.runningAgents).toEqual([]);
 	});
 
 	it("has correct tool metadata", () => {
@@ -72,5 +91,104 @@ describe("wait tool", () => {
 			expect(created.label).toBe("wait");
 			expect(created.description).toBe(waitToolDefinition.description);
 		});
+	});
+});
+
+describe("formatWaitCall", () => {
+	it("renders just 'wait' with no reason", () => {
+		expect(formatWaitCall(undefined, mockTheme)).toBe("wait");
+	});
+
+	it("renders just 'wait' with empty reason", () => {
+		expect(formatWaitCall({}, mockTheme)).toBe("wait");
+	});
+
+	it("renders wait with reason", () => {
+		expect(formatWaitCall({ reason: "agents running" }, mockTheme)).toBe("wait agents running");
+	});
+});
+
+describe("formatWaitResult", () => {
+	it("shows 'doing nothing — no subagents running' when no agents", () => {
+		const result = {
+			content: [{ type: "text", text: "Waiting…" }],
+			details: { reason: undefined, runningAgents: [] },
+		};
+		expect(formatWaitResult(result, mockTheme)).toBe("→ doing nothing — no subagents running");
+	});
+
+	it("shows running agents when present", () => {
+		const result = {
+			content: [{ type: "text", text: "Waiting…" }],
+			details: {
+				reason: undefined,
+				runningAgents: [
+					{
+						agentId: "abc123def456gh",
+						agentType: "code-reviewer",
+						taskSummary: "review",
+						startedAt: 0,
+						status: "running" as const,
+					},
+					{
+						agentId: "xyz789012345ab",
+						agentType: "error-auditor",
+						taskSummary: "audit",
+						startedAt: 0,
+						status: "running" as const,
+					},
+				],
+			},
+		};
+		expect(formatWaitResult(result, mockTheme)).toBe(
+			"→ doing nothing (waiting on: abc123def456 code-reviewer, xyz789012345 error-auditor)",
+		);
+	});
+
+	it("handles missing details gracefully", () => {
+		const result = { content: [{ type: "text", text: "Waiting…" }] };
+		expect(formatWaitResult(result, mockTheme)).toBe("→ doing nothing — no subagents running");
+	});
+});
+
+describe("filterSubagentTools", () => {
+	it("returns defaults when tools is undefined", () => {
+		const result = filterSubagentTools(undefined);
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+	});
+
+	it("filters out wait from tool list", () => {
+		const result = filterSubagentTools("read,bash,wait,grep");
+		expect(result).toBe("read,bash,grep");
+	});
+
+	it("filters out subagent from tool list", () => {
+		const result = filterSubagentTools("read,subagent,bash");
+		expect(result).toBe("read,bash");
+	});
+
+	it("filters out both wait and subagent", () => {
+		const result = filterSubagentTools("read,wait,bash,subagent,grep");
+		expect(result).toBe("read,bash,grep");
+	});
+
+	it("returns defaults when all tools are excluded", () => {
+		const result = filterSubagentTools("wait,subagent");
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+	});
+
+	it("returns defaults when only wait is specified", () => {
+		const result = filterSubagentTools("wait");
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+	});
+
+	it("trims whitespace around tool names", () => {
+		const result = filterSubagentTools("read , bash , wait , grep");
+		expect(result).toBe("read,bash,grep");
+	});
+
+	it("passes through valid tools unchanged", () => {
+		const result = filterSubagentTools("read,bash,edit,write");
+		expect(result).toBe("read,bash,edit,write");
 	});
 });

--- a/packages/coding-agent/test/tools/wait.test.ts
+++ b/packages/coding-agent/test/tools/wait.test.ts
@@ -4,6 +4,7 @@ import {
 	createWaitToolDefinition,
 	formatWaitCall,
 	formatWaitResult,
+	type WaitAgentInfo,
 	type WaitToolDetails,
 	waitToolDefinition,
 } from "../../src/core/tools/wait.js";
@@ -21,13 +22,14 @@ describe("wait tool", () => {
 		params: { reason?: string },
 		signal?: AbortSignal,
 		onUpdate?: any,
-	) => Promise<{ content: Array<{ type: string; text?: string }>; details?: WaitToolDetails }>;
+	) => Promise<{ content: Array<{ type: string; text?: string }>; details?: WaitToolDetails; endTurn?: boolean }>;
 
 	it("returns confirmation text with no reason", async () => {
 		const result = await execute("call-1", {});
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting…" });
 		expect(result.details?.reason).toBeUndefined();
+		expect(result.endTurn).toBe(true);
 	});
 
 	it("returns confirmation text with a reason", async () => {
@@ -35,6 +37,7 @@ describe("wait tool", () => {
 
 		expect(result.content[0]).toEqual({ type: "text", text: "Waiting: background subagent still running" });
 		expect(result.details?.reason).toBe("background subagent still running");
+		expect(result.endTurn).toBe(true);
 	});
 
 	it("trims whitespace-only reason to undefined", async () => {
@@ -85,11 +88,40 @@ describe("wait tool", () => {
 	});
 
 	describe("createWaitToolDefinition factory", () => {
-		it("returns the same shape as the singleton", () => {
+		it("returns the same shape as the singleton when called without args", () => {
 			const created = createWaitToolDefinition();
 			expect(created.name).toBe("wait");
 			expect(created.label).toBe("wait");
 			expect(created.description).toBe(waitToolDefinition.description);
+		});
+
+		it("populates runningAgents from the injected callback", async () => {
+			const agents: WaitAgentInfo[] = [
+				{ agentId: "abc123def456gh", agentType: "code-reviewer", taskSummary: "review PR" },
+			];
+			const tool = createWaitToolDefinition({ getRunningAgents: () => agents });
+			const result = (await tool.execute("id", {}, undefined, undefined, undefined as any)) as any;
+			expect(result.details?.runningAgents).toEqual(agents);
+			expect(result.endTurn).toBe(true);
+		});
+
+		it("trims reason when callback is provided", async () => {
+			const tool = createWaitToolDefinition({ getRunningAgents: () => [] });
+			const result = (await tool.execute(
+				"id",
+				{ reason: "  trimmed  " },
+				undefined,
+				undefined,
+				undefined as any,
+			)) as any;
+			expect(result.details?.reason).toBe("trimmed");
+			expect(result.content[0]).toEqual({ type: "text", text: "Waiting: trimmed" });
+		});
+
+		it("returns endTurn: true from factory-created tool", async () => {
+			const tool = createWaitToolDefinition({ getRunningAgents: () => [] });
+			const result = (await tool.execute("id", {}, undefined, undefined, undefined as any)) as any;
+			expect(result.endTurn).toBe(true);
 		});
 	});
 });

--- a/packages/coding-agent/test/tools/wait.test.ts
+++ b/packages/coding-agent/test/tools/wait.test.ts
@@ -154,7 +154,7 @@ describe("formatWaitResult", () => {
 describe("filterSubagentTools", () => {
 	it("returns defaults when tools is undefined", () => {
 		const result = filterSubagentTools(undefined);
-		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch");
 	});
 
 	it("filters out wait from tool list", () => {
@@ -174,12 +174,12 @@ describe("filterSubagentTools", () => {
 
 	it("returns defaults when all tools are excluded", () => {
 		const result = filterSubagentTools("wait,subagent");
-		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch");
 	});
 
 	it("returns defaults when only wait is specified", () => {
 		const result = filterSubagentTools("wait");
-		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch,search");
+		expect(result).toBe("read,bash,edit,write,grep,find,ls,web_search,web_fetch");
 	});
 
 	it("trims whitespace around tool names", () => {

--- a/packages/coding-agent/test/tools/wait.test.ts
+++ b/packages/coding-agent/test/tools/wait.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { createWaitToolDefinition, type WaitToolDetails, waitToolDefinition } from "../../src/core/tools/wait.js";
+
+describe("wait tool", () => {
+	// Cast execute to skip the ctx parameter (not used by this tool)
+	const execute = waitToolDefinition.execute.bind(waitToolDefinition) as (
+		toolCallId: string,
+		params: { reason?: string },
+		signal?: AbortSignal,
+		onUpdate?: any,
+	) => Promise<{ content: Array<{ type: string; text?: string }>; details?: WaitToolDetails }>;
+
+	it("returns confirmation text with no reason", async () => {
+		const result = await execute("call-1", {});
+
+		expect(result.content[0]).toEqual({ type: "text", text: "Waiting…" });
+		expect(result.details).toEqual({ reason: undefined });
+	});
+
+	it("returns confirmation text with a reason", async () => {
+		const result = await execute("call-2", { reason: "background subagent still running" });
+
+		expect(result.content[0]).toEqual({ type: "text", text: "Waiting: background subagent still running" });
+		expect(result.details).toEqual({ reason: "background subagent still running" });
+	});
+
+	it("trims whitespace-only reason to undefined", async () => {
+		const result = await execute("call-3", { reason: "   " });
+
+		expect(result.content[0]).toEqual({ type: "text", text: "Waiting…" });
+		expect(result.details).toEqual({ reason: undefined });
+	});
+
+	it("trims reason string", async () => {
+		const result = await execute("call-4", { reason: "  waiting for agent  " });
+
+		expect(result.content[0]).toEqual({ type: "text", text: "Waiting: waiting for agent" });
+		expect(result.details).toEqual({ reason: "waiting for agent" });
+	});
+
+	it("returns immediately (is synchronous aside from Promise wrapper)", async () => {
+		const start = Date.now();
+		await execute("call-5", { reason: "test" });
+		const elapsed = Date.now() - start;
+
+		// Should complete in well under 50ms — it's a pure no-op
+		expect(elapsed).toBeLessThan(50);
+	});
+
+	it("has correct tool metadata", () => {
+		expect(waitToolDefinition.name).toBe("wait");
+		expect(waitToolDefinition.label).toBe("wait");
+		expect(waitToolDefinition.promptSnippet).toBeTruthy();
+		expect(waitToolDefinition.promptGuidelines).toBeTruthy();
+		expect(waitToolDefinition.promptGuidelines!.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("description mentions ending the turn", () => {
+		expect(waitToolDefinition.description).toContain("end your turn");
+	});
+
+	it("prompt guidelines scope usage narrowly", () => {
+		const guidelines = waitToolDefinition.promptGuidelines!.join(" ");
+		expect(guidelines).toContain("explicitly told to wait");
+		expect(guidelines).toContain("background subagents");
+	});
+
+	describe("createWaitToolDefinition factory", () => {
+		it("returns the same shape as the singleton", () => {
+			const created = createWaitToolDefinition();
+			expect(created.name).toBe("wait");
+			expect(created.label).toBe("wait");
+			expect(created.description).toBe(waitToolDefinition.description);
+		});
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.17.0",
+	"version": "2.18.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #207

Add a built-in `wait` tool that does nothing, returns immediately, and ends the agent's turn. This gives models (notably Kimi) a sanctioned no-op action instead of inventing useless `bash` calls to simulate waiting.

Implementation plan posted as a comment below.
