### PR TITLE
Replace stale Gemini Flash-Lite default model

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -128,7 +128,7 @@ export interface AgentOptions {
 export class Agent {
 	private _state: AgentState = {
 		systemPrompt: "",
-		model: getModel("google", "gemini-2.5-flash-lite-preview-06-17"),
+		model: getModel("google", "gemini-2.5-flash-lite"),
 		thinkingLevel: "off",
 		tools: [],
 		messages: [],


### PR DESCRIPTION
Closes #222

Replace stale `gemini-2.5-flash-lite-preview-06-17` default model ID with `gemini-2.5-flash-lite` in the Agent class. The preview model was dropped from the generated model registry, breaking the monorepo build.

Implementation plan posted as a comment below.
