### PR TITLE
Auto-set terminal tab title based on session task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8763,7 +8763,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8792,7 +8792,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8848,7 +8848,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8963,7 +8963,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9012,7 +9012,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9044,7 +9044,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.19.3",
+			"version": "2.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -348,8 +348,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras", () => {
-		it("qwen-3-235b - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("cerebras", "qwen-3-235b-a22b-instruct-2507");
+		it("llama3.1-8b - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("cerebras", "llama3.1-8b");
 			const result = await testContextOverflow(model, process.env.CEREBRAS_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -152,7 +152,7 @@ describe("Token Statistics on Abort", () => {
 	});
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras Provider", () => {
-		const llm = getModel("cerebras", "qwen-3-235b-a22b-instruct-2507");
+		const llm = getModel("cerebras", "llama3.1-8b");
 
 		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
 			await testTokensOnAbort(llm);

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -23,6 +23,7 @@ What you get in exchange: a skill system, an extension API, custom agent definit
 - [Sessions](#sessions)
   - [Branching](#branching)
   - [Compaction](#compaction)
+  - [Tab Title](#tab-title)
 - [Settings](#settings)
 - [Context Files](#context-files)
 - [Memory](#memory)
@@ -244,6 +245,16 @@ Long sessions can exhaust context windows. Compaction summarizes older messages 
 **Automatic:** Enabled by default. Triggers on context overflow (recovers and retries) or when approaching the limit (proactive). Configure via `/settings` or `settings.json`.
 
 Compaction is lossy. The full history remains in the JSONL file; use `/tree` to revisit. Customize compaction behavior via [extensions](#extensions). See [docs/compaction.md](docs/compaction.md) for internals.
+
+### Tab Title
+
+After a few tool calls, dreb auto-generates a short terminal tab title describing the session's task. Useful when multiple tabs are open. Fires once per session via a background LLM call; failures are silent.
+
+Disable or adjust the trigger threshold in [settings](docs/settings.md):
+
+```json
+{ "tabTitle": { "enabled": false } }
+```
 
 ---
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -47,6 +47,24 @@ Edit directly or use `/settings` for common options.
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show terminal cursor |
 
+### Tab Title
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `tabTitle.enabled` | boolean | `true` | Auto-generate terminal tab title from session task |
+| `tabTitle.triggerAfter` | number | `3` | Number of tool calls before generating title |
+
+After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a short (≤30 character) terminal tab title, then sets it via OSC 0. Only fires once per session. If the LLM call fails, the default title remains.
+
+```json
+{
+  "tabTitle": {
+    "enabled": true,
+    "triggerAfter": 3
+  }
+}
+```
+
 ### Compaction
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -982,8 +982,4 @@ export class SettingsManager {
 	getTabTitleSettings(): TabTitleSettings | undefined {
 		return this.settings.tabTitle;
 	}
-
-	getTabTitleEnabled(): boolean {
-		return this.settings.tabTitle?.enabled !== false;
-	}
 }

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -102,6 +102,12 @@ export interface Settings {
 	dream?: {
 		archivePath?: string; // Custom archive location for dream backups (default: ~/.dreb/memory-archive/)
 	};
+	tabTitle?: TabTitleSettings;
+}
+
+export interface TabTitleSettings {
+	enabled?: boolean; // default: true — auto-generate terminal tab title from session task
+	triggerAfter?: number; // default: 3 — number of tool calls before generating title
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -971,5 +977,13 @@ export class SettingsManager {
 		this.globalSettings.dream.archivePath = path;
 		this.markModified("dream", "archivePath");
 		this.save();
+	}
+
+	getTabTitleSettings(): TabTitleSettings | undefined {
+		return this.settings.tabTitle;
+	}
+
+	getTabTitleEnabled(): boolean {
+		return this.settings.tabTitle?.enabled !== false;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -107,6 +107,7 @@ import { ToolExecutionComponent } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.js";
+import { TabTitleGenerator } from "./tab-title.js";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -252,6 +253,9 @@ export class InteractiveMode {
 	// Buddy companion
 	private buddyController: BuddyController;
 	private buddyComponent: BuddyComponent | null = null;
+
+	// Tab title auto-generation
+	private tabTitleGenerator: TabTitleGenerator | undefined = undefined;
 
 	// Convenience accessors
 	private get agent() {
@@ -600,6 +604,9 @@ export class InteractiveMode {
 		// Set terminal title
 		this.updateTerminalTitle();
 
+		// Initialize tab title auto-generation
+		this.initTabTitleGenerator();
+
 		// Subscribe to agent events
 		this.subscribeToAgent();
 
@@ -636,6 +643,24 @@ export class InteractiveMode {
 		} else {
 			this.ui.terminal.setTitle(`dreb - ${cwdBasename}`);
 		}
+	}
+
+	/**
+	 * Initialize the tab title auto-generator. Sets up a TabTitleGenerator that
+	 * will fire a background LLM call after a threshold of tool calls to produce
+	 * a concise, task-descriptive terminal tab title.
+	 */
+	private initTabTitleGenerator(): void {
+		const settings = this.settingsManager.getTabTitleSettings();
+		if (settings?.enabled === false) return;
+
+		this.tabTitleGenerator = new TabTitleGenerator(settings, {
+			setTitle: (title) => this.ui.terminal.setTitle(title),
+			getMessages: () => this.session.state.messages,
+			getModel: () => this.session.model,
+			getModelRegistry: () => this.session.modelRegistry,
+			getProvider: () => this.session.model?.provider,
+		});
 	}
 
 	/**
@@ -2494,6 +2519,8 @@ export class InteractiveMode {
 				}
 				// Buddy context + reaction for tool execution
 				this.buddyController.handleEvent(event);
+				// Tab title auto-generation
+				this.tabTitleGenerator?.onToolEnd();
 				break;
 			}
 

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -79,7 +79,10 @@ export class TabTitleGenerator {
 	}
 
 	private async generateTitle(): Promise<void> {
-		const model = await this.resolveModel();
+		// Single timeout bounds the entire pipeline (model probing + API key + LLM call)
+		const signal = AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS);
+
+		const model = await this.resolveModel(signal);
 		if (!model) return;
 
 		const registry = this.deps.getModelRegistry();
@@ -96,7 +99,7 @@ export class TabTitleGenerator {
 		const response = await completeSimple(model, context, {
 			apiKey,
 			maxRetryDelayMs: 0,
-			signal: AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS),
+			signal,
 		});
 
 		const title = this.sanitizeTitle(response);
@@ -105,7 +108,7 @@ export class TabTitleGenerator {
 		}
 	}
 
-	private async resolveModel(): Promise<Model<Api> | undefined> {
+	private async resolveModel(signal?: AbortSignal): Promise<Model<Api> | undefined> {
 		// Try to get the Explore agent's model fallback list
 		const exploreModels = this.getExploreAgentModels();
 		const parentModel = this.deps.getModel();
@@ -118,6 +121,7 @@ export class TabTitleGenerator {
 				parentProvider,
 				registry,
 				parentModel?.id,
+				signal,
 			);
 			if (resolution.ok) {
 				// Find the resolved model in registry

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -1,0 +1,194 @@
+/**
+ * Auto-generates a terminal tab title from session context after a threshold
+ * number of tool calls. Uses a lightweight single-shot LLM call to produce a
+ * concise ≤30 character title, then sets it via the terminal's OSC 0 escape.
+ *
+ * Fires at most once per session. Failures are swallowed silently.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Api, Context, Model } from "@dreb/ai";
+import { completeSimple } from "@dreb/ai";
+import { getPackageDir } from "../../config.js";
+import type { ModelRegistry } from "../../core/model-registry.js";
+import type { TabTitleSettings } from "../../core/settings-manager.js";
+import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/tools/subagent.js";
+
+const DEFAULT_TRIGGER_AFTER = 3;
+const MAX_TITLE_LENGTH = 30;
+
+const TITLE_PROMPT =
+	"Summarize this session's task in ≤30 characters for a terminal tab title. " +
+	"Output ONLY the title text, nothing else. No quotes, no explanation.";
+
+export interface TabTitleDeps {
+	/** Set the terminal tab title (OSC 0). */
+	setTitle: (title: string) => void;
+	/** Get the current session messages (for context). */
+	getMessages: () => Array<{ role: string; content?: unknown }>;
+	/** Get the current model (parent session model — used as fallback). */
+	getModel: () => Model<Api> | undefined;
+	/** Get model registry for API key resolution. */
+	getModelRegistry: () => ModelRegistry;
+	/** Get the parent provider name. */
+	getProvider: () => string | undefined;
+}
+
+export class TabTitleGenerator {
+	private toolCallCount = 0;
+	private fired = false;
+	private readonly threshold: number;
+
+	constructor(
+		private readonly settings: TabTitleSettings | undefined,
+		private readonly deps: TabTitleDeps,
+	) {
+		this.threshold = settings?.triggerAfter ?? DEFAULT_TRIGGER_AFTER;
+	}
+
+	/** Whether this generator is enabled. */
+	get enabled(): boolean {
+		return this.settings?.enabled !== false;
+	}
+
+	/**
+	 * Called on each tool_execution_end event. Increments the counter and fires
+	 * the title generation when threshold is reached.
+	 */
+	onToolEnd(): void {
+		if (this.fired || !this.enabled) return;
+
+		this.toolCallCount++;
+		if (this.toolCallCount >= this.threshold) {
+			this.fired = true;
+			// Fire-and-forget — never surfaces errors to the user
+			this.generateTitle().catch(() => {});
+		}
+	}
+
+	/** Exposed for testing — the current tool call count. */
+	get currentCount(): number {
+		return this.toolCallCount;
+	}
+
+	/** Exposed for testing — whether the title has been generated. */
+	get hasFired(): boolean {
+		return this.fired;
+	}
+
+	private async generateTitle(): Promise<void> {
+		const model = await this.resolveModel();
+		if (!model) return;
+
+		const registry = this.deps.getModelRegistry();
+		const apiKey = await registry.getApiKey(model);
+
+		const userContext = this.buildContext();
+		if (!userContext) return;
+
+		const context: Context = {
+			systemPrompt: TITLE_PROMPT,
+			messages: [{ role: "user", content: userContext, timestamp: Date.now() }],
+		};
+
+		const response = await completeSimple(model, context, {
+			apiKey,
+			maxRetryDelayMs: 0,
+		});
+
+		const title = this.sanitizeTitle(response);
+		if (title) {
+			this.deps.setTitle(`dreb - ${title}`);
+		}
+	}
+
+	private async resolveModel(): Promise<Model<Api> | undefined> {
+		// Try to get the Explore agent's model fallback list
+		const exploreModels = this.getExploreAgentModels();
+		const parentModel = this.deps.getModel();
+		const parentProvider = this.deps.getProvider();
+		const registry = this.deps.getModelRegistry();
+
+		if (exploreModels) {
+			const resolution = await resolveModelForSubagentSpawn(
+				exploreModels,
+				parentProvider,
+				registry,
+				parentModel?.id,
+			);
+			if (resolution.ok) {
+				// Find the resolved model in registry
+				const available = registry.getAvailable();
+				const found = available.find((m) => m.id === resolution.modelId);
+				if (found) return found;
+			}
+		}
+
+		// Fall back to parent session model
+		return parentModel;
+	}
+
+	private getExploreAgentModels(): string | string[] | undefined {
+		try {
+			const agentFile = join(getPackageDir(), "agents", "explore.md");
+			const content = readFileSync(agentFile, "utf-8");
+			const parsed = parseAgentFrontmatter(content);
+			if (parsed.ok && parsed.config.model) {
+				return parsed.config.model;
+			}
+		} catch {
+			// Fall through to parent model
+		}
+		return undefined;
+	}
+
+	private buildContext(): string | undefined {
+		const messages = this.deps.getMessages();
+		if (messages.length === 0) return undefined;
+
+		// Extract the first user message for context
+		const firstUser = messages.find((m) => m.role === "user");
+		if (!firstUser) return undefined;
+
+		const content =
+			typeof firstUser.content === "string"
+				? firstUser.content
+				: Array.isArray(firstUser.content)
+					? firstUser.content
+							.filter((c: any) => c.type === "text")
+							.map((c: any) => c.text)
+							.join("\n")
+					: "";
+
+		if (!content) return undefined;
+
+		// Truncate long messages — the LLM only needs a summary
+		const truncated = content.length > 500 ? `${content.slice(0, 500)}...` : content;
+		return `Session task:\n${truncated}`;
+	}
+
+	/** Clean up LLM response to a usable tab title. */
+	private sanitizeTitle(response: unknown): string | undefined {
+		if (!response || typeof response !== "object") return undefined;
+
+		const msg = response as { content?: Array<{ type: string; text?: string }> };
+		if (!msg.content || !Array.isArray(msg.content)) return undefined;
+
+		const textPart = msg.content.find((c) => c.type === "text");
+		if (!textPart?.text) return undefined;
+
+		let title = textPart.text.trim();
+		// Strip surrounding quotes if present
+		if ((title.startsWith('"') && title.endsWith('"')) || (title.startsWith("'") && title.endsWith("'"))) {
+			title = title.slice(1, -1).trim();
+		}
+		// Remove newlines
+		title = title.replace(/[\r\n]+/g, " ").trim();
+		// Truncate to max length
+		if (title.length > MAX_TITLE_LENGTH) {
+			title = title.slice(0, MAX_TITLE_LENGTH);
+		}
+		return title || undefined;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -17,6 +17,7 @@ import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/
 
 const DEFAULT_TRIGGER_AFTER = 3;
 const MAX_TITLE_LENGTH = 30;
+const TITLE_GENERATION_TIMEOUT_MS = 60_000;
 
 const TITLE_PROMPT =
 	"Summarize this session's task in ≤30 characters for a terminal tab title. " +
@@ -95,6 +96,7 @@ export class TabTitleGenerator {
 		const response = await completeSimple(model, context, {
 			apiKey,
 			maxRetryDelayMs: 0,
+			signal: AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS),
 		});
 
 		const title = this.sanitizeTitle(response);

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -210,10 +210,10 @@ describe("TabTitleGenerator", () => {
 			// Should not throw
 			gen.onToolEnd();
 
-			// Wait a tick for the async error to be swallowed
-			await new Promise((r) => setTimeout(r, 50));
-
-			expect(gen.hasFired).toBe(true);
+			// Flush microtask queue to let the rejected promise chain settle
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 
@@ -223,9 +223,9 @@ describe("TabTitleGenerator", () => {
 
 			gen.onToolEnd();
 
-			await new Promise((r) => setTimeout(r, 50));
-
-			expect(gen.hasFired).toBe(true);
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 
@@ -235,9 +235,9 @@ describe("TabTitleGenerator", () => {
 
 			gen.onToolEnd();
 
-			await new Promise((r) => setTimeout(r, 50));
-
-			expect(gen.hasFired).toBe(true);
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 	});
@@ -325,8 +325,21 @@ describe("TabTitleGenerator", () => {
 			expect(titleContent.length).toBeLessThanOrEqual(30);
 		});
 
-		it("strips surrounding quotes from LLM response", async () => {
+		it("strips surrounding double quotes from LLM response", async () => {
 			mockCompleteSimple.mockResolvedValue(makeAssistantResponse('"Fix auth bug"') as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+			});
+		});
+
+		it("strips surrounding single quotes from LLM response", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("'Fix auth bug'") as any);
 
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
@@ -359,8 +372,9 @@ describe("TabTitleGenerator", () => {
 
 			gen.onToolEnd();
 
-			await new Promise((r) => setTimeout(r, 50));
-
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -407,6 +407,7 @@ describe("TabTitleGenerator", () => {
 					"test-provider",
 					expect.anything(),
 					"test-model",
+					expect.any(AbortSignal),
 				);
 			});
 		});

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TabTitleSettings } from "../src/core/settings-manager.js";
+import { type TabTitleDeps, TabTitleGenerator } from "../src/modes/interactive/tab-title.js";
+
+// Mock @dreb/ai
+vi.mock("@dreb/ai", () => ({
+	completeSimple: vi.fn(),
+}));
+
+// Mock config to avoid filesystem access
+vi.mock("../../coding-agent/src/config.js", () => ({
+	getPackageDir: () => "/mock/package",
+}));
+
+// Mock fs.readFileSync for agent file reading
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		readFileSync: vi.fn((...args: any[]) => {
+			const filePath = args[0] as string;
+			if (filePath.includes("/mock/package/agents/explore.md")) {
+				return "---\nname: Explore\nmodel: mock-model\n---\nExplore agent";
+			}
+			return actual.readFileSync(...(args as Parameters<typeof actual.readFileSync>));
+		}),
+	};
+});
+
+// Mock subagent to avoid filesystem access
+vi.mock("../src/core/tools/subagent.js", () => ({
+	parseAgentFrontmatter: vi.fn(),
+	resolveModelForSubagentSpawn: vi.fn(),
+}));
+
+// Mock model-registry
+vi.mock("../src/core/model-registry.js", () => ({}));
+
+import { completeSimple } from "@dreb/ai";
+import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../src/core/tools/subagent.js";
+
+const mockCompleteSimple = vi.mocked(completeSimple);
+const mockResolveModel = vi.mocked(resolveModelForSubagentSpawn);
+const mockParseAgent = vi.mocked(parseAgentFrontmatter);
+
+const MOCK_MODEL = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-completions" as any,
+	provider: "test-provider",
+	baseUrl: "https://api.test.com/v1",
+	reasoning: false,
+	input: ["text"] as ("text" | "image")[],
+	cost: { input: 0.5, output: 1.5, cacheRead: 0.25, cacheWrite: 0.5 },
+	contextWindow: 128000,
+	maxTokens: 4096,
+};
+
+function createMockDeps(overrides: Partial<TabTitleDeps> = {}): TabTitleDeps {
+	return {
+		setTitle: vi.fn(),
+		getMessages: () => [
+			{ role: "user", content: "Fix the authentication bug in login.ts" },
+			{ role: "assistant", content: [{ type: "text", text: "I'll look into that." }] },
+		],
+		getModel: () => MOCK_MODEL,
+		getModelRegistry: () =>
+			({
+				getApiKey: vi.fn().mockResolvedValue("test-key"),
+				getAvailable: () => [MOCK_MODEL],
+			}) as any,
+		getProvider: () => "test-provider",
+		...overrides,
+	};
+}
+
+function makeAssistantResponse(text: string) {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		usage: { inputTokens: 10, outputTokens: 5 },
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("TabTitleGenerator", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Default: resolve to parent model (no explore agent file)
+		mockParseAgent.mockReturnValue({ ok: false, error: "not found" });
+		mockResolveModel.mockResolvedValue({
+			ok: false,
+			error: "no models",
+			skippedModels: [],
+		});
+		mockCompleteSimple.mockResolvedValue(makeAssistantResponse("Fix auth bug") as any);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("threshold logic", () => {
+		it("does not fire before threshold is reached", () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator(undefined, deps);
+
+			gen.onToolEnd();
+			gen.onToolEnd();
+
+			expect(deps.setTitle).not.toHaveBeenCalled();
+			expect(gen.hasFired).toBe(false);
+			expect(gen.currentCount).toBe(2);
+		});
+
+		it("fires exactly at the default threshold (3)", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator(undefined, deps);
+
+			gen.onToolEnd();
+			gen.onToolEnd();
+			gen.onToolEnd();
+
+			// Wait for async generation
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			expect(gen.hasFired).toBe(true);
+			expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+		});
+
+		it("respects custom triggerAfter setting", async () => {
+			const deps = createMockDeps();
+			const settings: TabTitleSettings = { triggerAfter: 5 };
+			const gen = new TabTitleGenerator(settings, deps);
+
+			// Call 4 times — should not fire
+			for (let i = 0; i < 4; i++) gen.onToolEnd();
+			expect(gen.hasFired).toBe(false);
+
+			// 5th call triggers
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			expect(gen.hasFired).toBe(true);
+		});
+	});
+
+	describe("once-only semantics", () => {
+		it("does not fire again after first generation", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalledTimes(1);
+			});
+
+			// Additional tool calls should not fire again
+			gen.onToolEnd();
+			gen.onToolEnd();
+			gen.onToolEnd();
+
+			// Still only called once
+			expect(deps.setTitle).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("disabled setting", () => {
+		it("skips entirely when tabTitle.enabled is false", () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ enabled: false }, deps);
+
+			expect(gen.enabled).toBe(false);
+
+			for (let i = 0; i < 10; i++) gen.onToolEnd();
+
+			expect(gen.hasFired).toBe(false);
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+
+		it("is enabled by default (undefined settings)", () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator(undefined, deps);
+			expect(gen.enabled).toBe(true);
+		});
+
+		it("is enabled when enabled is explicitly true", () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ enabled: true }, deps);
+			expect(gen.enabled).toBe(true);
+		});
+	});
+
+	describe("failure handling", () => {
+		it("swallows LLM errors silently", async () => {
+			mockCompleteSimple.mockRejectedValue(new Error("API timeout"));
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			// Should not throw
+			gen.onToolEnd();
+
+			// Wait a tick for the async error to be swallowed
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(gen.hasFired).toBe(true);
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+
+		it("handles null/undefined model gracefully", async () => {
+			const deps = createMockDeps({ getModel: () => undefined });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(gen.hasFired).toBe(true);
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+
+		it("handles empty messages gracefully", async () => {
+			const deps = createMockDeps({ getMessages: () => [] });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(gen.hasFired).toBe(true);
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("prompt construction", () => {
+		it("includes first user message in context", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const callArgs = mockCompleteSimple.mock.calls[0];
+			const context = callArgs[1] as any;
+			expect(context.messages[0].content).toContain("Fix the authentication bug in login.ts");
+		});
+
+		it("handles array content in user messages", async () => {
+			const deps = createMockDeps({
+				getMessages: () => [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Refactor the parser" },
+							{ type: "image", source: { data: "abc" } },
+						],
+					},
+				],
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const callArgs = mockCompleteSimple.mock.calls[0];
+			const context = callArgs[1] as any;
+			expect(context.messages[0].content).toContain("Refactor the parser");
+		});
+
+		it("truncates very long user messages", async () => {
+			const longMessage = "x".repeat(1000);
+			const deps = createMockDeps({
+				getMessages: () => [{ role: "user", content: longMessage }],
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const callArgs = mockCompleteSimple.mock.calls[0];
+			const context = callArgs[1] as any;
+			// Should be truncated to 500 + "..."
+			expect(context.messages[0].content.length).toBeLessThan(600);
+			expect(context.messages[0].content).toContain("...");
+		});
+	});
+
+	describe("title sanitization", () => {
+		it("truncates titles longer than 30 characters", async () => {
+			mockCompleteSimple.mockResolvedValue(
+				makeAssistantResponse("This is a very long title that exceeds the limit") as any,
+			);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			const title = (deps.setTitle as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			// "dreb - " is 7 chars, title content should be ≤30
+			const titleContent = title.replace("dreb - ", "");
+			expect(titleContent.length).toBeLessThanOrEqual(30);
+		});
+
+		it("strips surrounding quotes from LLM response", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse('"Fix auth bug"') as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+			});
+		});
+
+		it("removes newlines from title", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("Fix auth\nbug") as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+			});
+		});
+
+		it("handles empty LLM response gracefully", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("") as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("model resolution", () => {
+		it("uses Explore agent model when available", async () => {
+			mockParseAgent.mockReturnValue({
+				ok: true,
+				config: {
+					name: "Explore",
+					description: "test",
+					model: ["cheap/model", "fallback/model"],
+					systemPrompt: "",
+				},
+			});
+			mockResolveModel.mockResolvedValue({
+				ok: true,
+				modelId: "test-model",
+				skippedModels: [],
+			});
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockResolveModel).toHaveBeenCalledWith(
+					["cheap/model", "fallback/model"],
+					"test-provider",
+					expect.anything(),
+					"test-model",
+				);
+			});
+		});
+
+		it("falls back to parent model when Explore resolution fails", async () => {
+			mockParseAgent.mockReturnValue({ ok: false, error: "not found" });
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			// Should still have been called with the parent model
+			const callArgs = mockCompleteSimple.mock.calls[0];
+			expect((callArgs[0] as any).id).toBe("test-model");
+		});
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.19.3",
+  "version": "2.20.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.19.3",
+	"version": "2.20.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #221

Auto-set terminal tab title based on session task. After a configurable number of tool calls, fires a single background LLM call to summarize the session's task into a short terminal tab title, then sets it via OSC 0.

Implementation plan posted as a comment below.
