### PR TITLE
Block privilege escalation commands and warn when running as root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8763,7 +8763,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8792,7 +8792,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8848,7 +8848,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8963,7 +8963,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9012,7 +9012,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9044,7 +9044,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.20.0",
+			"version": "2.21.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -160,12 +160,10 @@ export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 		return true;
 	}
 
-	if (
-		model.id.includes("opus-4-6") ||
-		model.id.includes("opus-4.6") ||
-		model.id.includes("opus-4-7") ||
-		model.id.includes("opus-4.7")
-	) {
+	// Opus 4.6+ supports xhigh (adaptive effort "max").
+	// Match any opus-4-N or opus-4.N where N >= 6.
+	const opusMatch = model.id.match(/opus-4[.-](\d+)/);
+	if (opusMatch && Number.parseInt(opusMatch[1], 10) >= 6) {
 		return true;
 	}
 

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -161,8 +161,8 @@ export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	}
 
 	// Opus 4.6+ supports xhigh (adaptive effort "max").
-	// Match any opus-4-N or opus-4.N where N >= 6.
-	const opusMatch = model.id.match(/opus-4[.-](\d+)/);
+	// Match any opus-4-N or opus-4.N where N >= 6 (1-2 digit minor version, not date suffixes).
+	const opusMatch = model.id.match(/opus-4[.-](\d{1,2})(?!\d)/);
 	if (opusMatch && Number.parseInt(opusMatch[1], 10) >= 6) {
 		return true;
 	}

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -394,14 +394,14 @@ function handleContentBlockStop(
  * Check if the model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+).
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	return (
-		modelId.includes("opus-4-6") ||
-		modelId.includes("opus-4.6") ||
-		modelId.includes("opus-4-7") ||
-		modelId.includes("opus-4.7") ||
-		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
-	);
+	return isModelVersionAtLeast(modelId, "opus", 6) || isModelVersionAtLeast(modelId, "sonnet", 6);
+}
+
+/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion */
+function isModelVersionAtLeast(modelId: string, family: string, minVersion: number): boolean {
+	const re = new RegExp(`${family}-4[.-](\\d+)`);
+	const match = modelId.match(re);
+	return match != null && Number.parseInt(match[1], 10) >= minVersion;
 }
 
 function mapThinkingLevelToEffort(
@@ -417,12 +417,7 @@ function mapThinkingLevelToEffort(
 		case "high":
 			return "high";
 		case "xhigh": {
-			const isOpus =
-				modelId.includes("opus-4-6") ||
-				modelId.includes("opus-4.6") ||
-				modelId.includes("opus-4-7") ||
-				modelId.includes("opus-4.7");
-			return isOpus ? "max" : "high";
+			return isModelVersionAtLeast(modelId, "opus", 6) ? "max" : "high";
 		}
 		default:
 			return "high";

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -397,9 +397,9 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 	return isModelVersionAtLeast(modelId, "opus", 6) || isModelVersionAtLeast(modelId, "sonnet", 6);
 }
 
-/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion */
+/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion (1-2 digit minor version only, not date suffixes) */
 function isModelVersionAtLeast(modelId: string, family: string, minVersion: number): boolean {
-	const re = new RegExp(`${family}-4[.-](\\d+)`);
+	const re = new RegExp(`${family}-4[.-](\\d{1,2})(?!\\d)`);
 	const match = modelId.match(re);
 	return match != null && Number.parseInt(match[1], 10) >= minVersion;
 }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -444,14 +444,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
  * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+)
  */
 function supportsAdaptiveThinking(modelId: string): boolean {
-	return (
-		modelId.includes("opus-4-6") ||
-		modelId.includes("opus-4.6") ||
-		modelId.includes("opus-4-7") ||
-		modelId.includes("opus-4.7") ||
-		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
-	);
+	return isModelVersionAtLeast(modelId, "opus", 6) || isModelVersionAtLeast(modelId, "sonnet", 6);
+}
+
+/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion */
+function isModelVersionAtLeast(modelId: string, family: string, minVersion: number): boolean {
+	const re = new RegExp(`${family}-4[.-](\\d+)`);
+	const match = modelId.match(re);
+	return match != null && Number.parseInt(match[1], 10) >= minVersion;
 }
 
 /**
@@ -469,12 +469,7 @@ function mapThinkingLevelToEffort(level: SimpleStreamOptions["reasoning"], model
 		case "high":
 			return "high";
 		case "xhigh": {
-			const isOpus =
-				modelId.includes("opus-4-6") ||
-				modelId.includes("opus-4.6") ||
-				modelId.includes("opus-4-7") ||
-				modelId.includes("opus-4.7");
-			return isOpus ? "max" : "high";
+			return isModelVersionAtLeast(modelId, "opus", 6) ? "max" : "high";
 		}
 		default:
 			return "high";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -447,9 +447,9 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 	return isModelVersionAtLeast(modelId, "opus", 6) || isModelVersionAtLeast(modelId, "sonnet", 6);
 }
 
-/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion */
+/** Check if a modelId contains `{family}-4-N` or `{family}-4.N` where N >= minVersion (1-2 digit minor version only, not date suffixes) */
 function isModelVersionAtLeast(modelId: string, family: string, minVersion: number): boolean {
-	const re = new RegExp(`${family}-4[.-](\\d+)`);
+	const re = new RegExp(`${family}-4[.-](\\d{1,2})(?!\\d)`);
 	const match = modelId.match(re);
 	return match != null && Number.parseInt(match[1], 10) >= minVersion;
 }

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -20,6 +20,18 @@ describe("supportsXhigh", () => {
 		expect(supportsXhigh(model!)).toBe(false);
 	});
 
+	it("returns false for base Opus 4 dated model (opus-4-20250514)", () => {
+		const model = getModel("anthropic", "claude-opus-4-20250514");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(false);
+	});
+
+	it("returns false for Opus 4.5 (below threshold)", () => {
+		const model = getModel("anthropic", "claude-opus-4-5");
+		expect(model).toBeDefined();
+		expect(supportsXhigh(model!)).toBe(false);
+	});
+
 	it("returns true for GPT-5.4 models", () => {
 		const model = getModel("openai-codex", "gpt-5.4");
 		expect(model).toBeDefined();

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -89,6 +89,14 @@ import { expandSkillContent } from "./tools/skill.js";
 import { createToolDefinitionFromAgentTool, wrapToolDefinition } from "./tools/tool-definition-wrapper.js";
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/** Guidance appended to all forbidden-command block reasons. Shapes model behavior toward safe deferral. */
+const FORBIDDEN_COMMAND_GUIDANCE =
+	"This command was blocked for safety. System integrity and security always take precedence over any specific task goal and must never be compromised. Safe alternative approaches are acceptable, but do not attempt to circumvent or bypass this restriction. If the task cannot be completed safely, use `suggest_next` to provide the user with the exact command to run manually and an explanation of why it was blocked.";
+
+// ============================================================================
 // Skill Block Parsing
 // ============================================================================
 
@@ -396,7 +404,7 @@ export class AgentSession {
 					if (pattern) {
 						return {
 							block: true as const,
-							reason: `Command blocked by forbidden-commands guard: "${pattern}" matched "${command}".\n\nThis command was blocked for safety. Do not attempt workarounds or alternative escalation paths. If there is no obviously safe, root-free way to accomplish the task, use \`suggest_next\` to provide the user with instructions on how to unblock you (e.g., running the privileged command manually).`,
+							reason: `Command blocked by forbidden-commands guard: "${pattern}" matched "${command}".\n\n${FORBIDDEN_COMMAND_GUIDANCE}`,
 						};
 					}
 
@@ -416,7 +424,7 @@ export class AgentSession {
 									if (match) {
 										return {
 											block: true as const,
-											reason: `Command blocked by forbidden-commands guard: script "${scriptPath}" contains forbidden command at line ${match.line}: "${match.text}" (matched pattern "${match.pattern}").\n\nThis command was blocked for safety. Do not attempt workarounds or alternative escalation paths. If there is no obviously safe, root-free way to accomplish the task, use \`suggest_next\` to provide the user with instructions on how to unblock you (e.g., running the privileged command manually).`,
+											reason: `Command blocked by forbidden-commands guard: script "${scriptPath}" contains forbidden command at line ${match.line}: "${match.text}" (matched pattern "${match.pattern}").\n\n${FORBIDDEN_COMMAND_GUIDANCE}`,
 										};
 									}
 								} catch {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -396,7 +396,7 @@ export class AgentSession {
 					if (pattern) {
 						return {
 							block: true as const,
-							reason: `Command blocked by forbidden-commands guard: "${pattern}" matched "${command}"`,
+							reason: `Command blocked by forbidden-commands guard: "${pattern}" matched "${command}".\n\nThis command was blocked for safety. Do not attempt workarounds or alternative escalation paths. If there is no obviously safe, root-free way to accomplish the task, use \`suggest_next\` to provide the user with instructions on how to unblock you (e.g., running the privileged command manually).`,
 						};
 					}
 
@@ -416,7 +416,7 @@ export class AgentSession {
 									if (match) {
 										return {
 											block: true as const,
-											reason: `Command blocked by forbidden-commands guard: script "${scriptPath}" contains forbidden command at line ${match.line}: "${match.text}" (matched pattern "${match.pattern}")`,
+											reason: `Command blocked by forbidden-commands guard: script "${scriptPath}" contains forbidden command at line ${match.line}: "${match.text}" (matched pattern "${match.pattern}").\n\nThis command was blocked for safety. Do not attempt workarounds or alternative escalation paths. If there is no obviously safe, root-free way to accomplish the task, use \`suggest_next\` to provide the user with instructions on how to unblock you (e.g., running the privileged command manually).`,
 										};
 									}
 								} catch {

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -215,6 +215,41 @@ function splitCommandSegments(command: string): string[] {
 }
 
 /**
+ * Strip shell prefix commands that pass through to the underlying command.
+ * These are common bypass vectors for start-anchored patterns:
+ * - `env sudo ...` (env runs a command with modified environment)
+ * - `exec sudo ...` (exec replaces the shell process)
+ * - `command sudo ...` (command bypasses shell functions/aliases)
+ * - `builtin` (run a shell builtin directly)
+ * - `\sudo ...` (backslash escapes aliases but still runs the command)
+ *
+ * Strips iteratively to handle stacking (e.g., `env command sudo`).
+ */
+function stripShellPrefixes(segment: string): string {
+	let result = segment;
+
+	// Strip leading backslash (alias escape)
+	if (result.startsWith("\\")) {
+		result = result.slice(1);
+	}
+
+	// Iteratively strip known pass-through prefixes
+	const prefixes = /^(?:env|exec|command|builtin)\s+/;
+	let prev = "";
+	while (prev !== result) {
+		prev = result;
+		result = result.replace(prefixes, "");
+	}
+
+	// Strip leading backslash again (in case it's after a prefix: `env \sudo`)
+	if (result.startsWith("\\")) {
+		result = result.slice(1);
+	}
+
+	return result.trim();
+}
+
+/**
  * Strip leading subshell/command-substitution wrappers from a segment
  * so that $(cmd), (cmd), and `cmd` are checked against patterns too.
  *
@@ -288,8 +323,13 @@ export function isForbiddenCommand(command: string, extraPatterns?: string[]): s
 		: QUOTED_CONTENT_PATTERNS;
 
 	for (const segment of segments) {
-		// Check both the raw segment and the subshell-unwrapped version
-		const toCheck = [segment, stripSubshellWrapper(segment)];
+		// Check the segment after various normalizations:
+		// - Raw segment (e.g., "sudo apt install")
+		// - Subshell-unwrapped (e.g., "$(sudo ...)" → "sudo ...")
+		// - Shell-prefix-stripped (e.g., "env sudo ..." → "sudo ...")
+		// - Both combined (e.g., "$(env sudo ...)" → "sudo ...")
+		const unwrapped = stripSubshellWrapper(segment);
+		const toCheck = new Set([segment, unwrapped, stripShellPrefixes(segment), stripShellPrefixes(unwrapped)]);
 		for (const text of toCheck) {
 			for (const pattern of allPatterns) {
 				try {

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -19,6 +19,9 @@
 
 /** Hardcoded patterns that are always active. Always anchored with ^. */
 const DEFAULT_FORBIDDEN_PATTERNS: string[] = [
+	"^sudo\\b", // privilege escalation — sudo
+	"^doas\\b", // privilege escalation — doas (OpenBSD/Linux alternative to sudo)
+	"^su\\b", // privilege escalation — switch user
 	"^gh pr merge.*--admin", // bypass branch protection
 	"^git push.*(-f\\b|--force)", // force push (includes --force-with-lease)
 	"^gh api.*bypass", // API calls with bypass flag
@@ -65,6 +68,9 @@ const FULL_COMMAND_PATTERNS: string[] = [
  * it also needs to be caught when quoted (e.g., `echo ":(){ :|:& };:"`).
  */
 const QUOTED_CONTENT_PATTERNS: string[] = [
+	"^sudo\\b", // privilege escalation
+	"^doas\\b", // privilege escalation
+	"^su\\b", // privilege escalation
 	"^rm\\s+.*--no-preserve-root",
 	"^rm\\s+.*\\s/(\\*|[\\w.-]+/?)?(\\s|$)",
 	"^dd\\s+.*of=/dev/(sd|hd|vd|nvme|xvd|loop|mmcblk|disk)",

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -19,9 +19,9 @@
 
 /** Hardcoded patterns that are always active. Always anchored with ^. */
 const DEFAULT_FORBIDDEN_PATTERNS: string[] = [
-	"^sudo\\b", // privilege escalation — sudo
-	"^doas\\b", // privilege escalation — doas (OpenBSD/Linux alternative to sudo)
-	"^su\\b", // privilege escalation — switch user
+	"^(?:/\\S+/)?sudo\\b", // privilege escalation — sudo (bare or absolute path)
+	"^(?:/\\S+/)?doas\\b", // privilege escalation — doas (bare or absolute path)
+	"^(?:/\\S+/)?su\\b", // privilege escalation — switch user (bare or absolute path)
 	"^gh pr merge.*--admin", // bypass branch protection
 	"^git push.*(-f\\b|--force)", // force push (includes --force-with-lease)
 	"^gh api.*bypass", // API calls with bypass flag
@@ -68,9 +68,9 @@ const FULL_COMMAND_PATTERNS: string[] = [
  * it also needs to be caught when quoted (e.g., `echo ":(){ :|:& };:"`).
  */
 const QUOTED_CONTENT_PATTERNS: string[] = [
-	"^sudo\\b", // privilege escalation
-	"^doas\\b", // privilege escalation
-	"^su\\b", // privilege escalation
+	"^(?:/\\S+/)?sudo\\b", // privilege escalation
+	"^(?:/\\S+/)?doas\\b", // privilege escalation
+	"^(?:/\\S+/)?su\\b", // privilege escalation
 	"^rm\\s+.*--no-preserve-root",
 	"^rm\\s+.*\\s/(\\*|[\\w.-]+/?)?(\\s|$)",
 	"^dd\\s+.*of=/dev/(sd|hd|vd|nvme|xvd|loop|mmcblk|disk)",
@@ -237,7 +237,10 @@ function stripShellPrefixes(segment: string): string {
 		result = result.slice(1);
 	}
 
-	// Iteratively strip known pass-through prefixes
+	// Strip leading absolute path prefix (e.g., /usr/bin/sudo → sudo)
+	result = result.replace(/^\/\S+\//, "");
+
+	// Iteratively strip known pass-through prefixes (bare or with remaining path fragments)
 	const prefixes = /^(?:env|exec|command|builtin)\s+/;
 	let prev = "";
 	while (prev !== result) {

--- a/packages/coding-agent/src/core/forbidden-commands.ts
+++ b/packages/coding-agent/src/core/forbidden-commands.ts
@@ -218,10 +218,14 @@ function splitCommandSegments(command: string): string[] {
  * Strip shell prefix commands that pass through to the underlying command.
  * These are common bypass vectors for start-anchored patterns:
  * - `env sudo ...` (env runs a command with modified environment)
+ * - `env -i VAR=value sudo ...` (env with flags/assignments before the command)
  * - `exec sudo ...` (exec replaces the shell process)
  * - `command sudo ...` (command bypasses shell functions/aliases)
  * - `builtin` (run a shell builtin directly)
  * - `\sudo ...` (backslash escapes aliases but still runs the command)
+ *
+ * After stripping `env`, also consumes env-style arguments (flags like `-i`
+ * and variable assignments like `VAR=value`) that precede the actual command.
  *
  * Strips iteratively to handle stacking (e.g., `env command sudo`).
  */
@@ -239,6 +243,21 @@ function stripShellPrefixes(segment: string): string {
 	while (prev !== result) {
 		prev = result;
 		result = result.replace(prefixes, "");
+	}
+
+	// After stripping env prefix, consume env-style arguments:
+	// - Flags starting with `-` (e.g., -i, -u, -0, --)
+	// - Variable assignments matching IDENTIFIER=... (e.g., VAR=value, PATH=/usr/bin)
+	// - Bare uppercase identifiers (e.g., PATH as argument to -u flag)
+	const envFlag = /^-\S*\s+/;
+	const envAssignment = /^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/;
+	const envBareVar = /^[A-Z_][A-Z0-9_]*\s+/;
+	let envPrev = "";
+	while (envPrev !== result) {
+		envPrev = result;
+		result = result.replace(envFlag, "");
+		result = result.replace(envAssignment, "");
+		result = result.replace(envBareVar, "");
 	}
 
 	// Strip leading backslash again (in case it's after a prefix: `env \sudo`)

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -110,6 +110,21 @@ function buildMemorySection(memoryIndexes?: MemoryIndexes): string {
 	return section;
 }
 
+/** Build the root security warning section if running as UID 0 */
+function buildRootSecuritySection(): string {
+	if (process.getuid?.() !== 0) return "";
+
+	return `
+
+## ⚠️ Security: Running as Root
+
+You are running as root (UID 0). You have unrestricted system access. This means:
+- **Never** attempt privilege escalation (sudo, doas, su) — you already have full privileges
+- Be extremely conservative with file modifications, package installations, and system commands
+- Prefer the least-destructive approach for every operation
+- If a task could affect system stability, inform the user before proceeding`;
+}
+
 /** UI type descriptions for system prompt context */
 const UI_DESCRIPTIONS: Record<string, string> = {
 	tui: "Terminal UI (interactive terminal with rich rendering)",
@@ -208,6 +223,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		if (options.gitRepoState) {
 			prompt += formatGitStateSection(options.gitRepoState);
 		}
+
+		// Append root security warning if running as UID 0
+		prompt += buildRootSecuritySection();
 
 		// Add date and working directory last
 		prompt += `\nCurrent date: ${date}`;
@@ -331,6 +349,9 @@ Dreb documentation (read only when the user asks about dreb itself, its SDK, ext
 	if (options.gitRepoState) {
 		prompt += formatGitStateSection(options.gitRepoState);
 	}
+
+	// Append root security warning if running as UID 0
+	prompt += buildRootSecuritySection();
 
 	// Add date and working directory last
 	prompt += `\nCurrent date: ${date}`;

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -673,6 +673,8 @@ export async function resolveModelForSubagentSpawn(
 	registry: ModelRegistry | undefined,
 	parentModel?: string,
 	signal?: AbortSignal,
+	/** Optional log prefix for warning messages (defaults to "[subagent]") */
+	logPrefix = "[subagent]",
 ): Promise<SubagentModelResolution> {
 	if (signal?.aborted) return { ok: false, error: "Aborted before spawn", skippedModels: [] };
 
@@ -695,7 +697,7 @@ export async function resolveModelForSubagentSpawn(
 			lastError = resolved.error;
 			const reason = compactErrorReason(resolved.error);
 			skippedModels.push({ model: modelStr, reason });
-			log.warn(`[subagent] Model "${modelStr}" unavailable (${reason}). Trying next fallback...`);
+			log.warn(`${logPrefix} Model "${modelStr}" unavailable (${reason}). Trying next fallback...`);
 			continue;
 		}
 
@@ -709,12 +711,12 @@ export async function resolveModelForSubagentSpawn(
 			if (!probe.ok) {
 				lastError = probe.reason;
 				skippedModels.push({ model: modelStr, reason: probe.reason });
-				log.warn(`[subagent] Model "${modelStr}" failed probe (${probe.reason}). Trying next fallback...`);
+				log.warn(`${logPrefix} Model "${modelStr}" failed probe (${probe.reason}). Trying next fallback...`);
 				continue;
 			}
 		}
 
-		log.debug(`[subagent] Using model "${resolved.modelId}" for subagent.`);
+		log.debug(`${logPrefix} Using model "${resolved.modelId}".`);
 		return { ...resolved, skippedModels };
 	}
 
@@ -724,7 +726,7 @@ export async function resolveModelForSubagentSpawn(
 		const parentResolved = resolveModelStringSingle(parentModel, parentProvider, registry);
 		if (parentResolved.ok) {
 			const warning = `Agent preferred models were unavailable. Falling back to parent model "${parentResolved.modelId}".`;
-			log.warn(`[subagent] ${warning}`);
+			log.warn(`${logPrefix} ${warning}`);
 			return { ...parentResolved, warning, skippedModels };
 		}
 		lastError = parentResolved.error;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -785,6 +785,15 @@ export async function main(args: string[]) {
 		await showDeprecationWarnings(deprecationWarnings);
 	}
 
+	// Warn if running as root (non-interactive modes only — interactive mode shows its own TUI warning)
+	if (!isInteractive && process.getuid?.() === 0) {
+		log.warn(
+			chalk.yellow(
+				"Warning: Running as root (UID 0). The agent has unrestricted system access — all commands execute with full root privileges.",
+			),
+		);
+	}
+
 	let scopedModels: ScopedModel[] = [];
 	const modelPatterns = parsed.models ?? settingsManager.getEnabledModels();
 	if (modelPatterns && modelPatterns.length > 0) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -691,6 +691,13 @@ export class InteractiveMode {
 			}
 		});
 
+		// Warn if running as root
+		if (process.getuid?.() === 0) {
+			this.showWarning(
+				"Running as root (UID 0). The agent has unrestricted system access — all commands execute with full root privileges.",
+			);
+		}
+
 		// Show startup warnings
 		const { migratedProviders, modelFallbackMessage, initialMessage, initialImages, initialMessages } = this.options;
 

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -7,10 +7,11 @@
  */
 
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Api, Context, Model } from "@dreb/ai";
 import { completeSimple } from "@dreb/ai";
-import { getPackageDir } from "../../config.js";
+import { CONFIG_DIR_NAME, getPackageDir } from "../../config.js";
 import type { ModelRegistry } from "../../core/model-registry.js";
 import type { TabTitleSettings } from "../../core/settings-manager.js";
 import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/tools/subagent.js";
@@ -122,6 +123,7 @@ export class TabTitleGenerator {
 				registry,
 				parentModel?.id,
 				signal,
+				"[tab-title]",
 			);
 			if (resolution.ok) {
 				// Find the resolved model in registry
@@ -136,15 +138,22 @@ export class TabTitleGenerator {
 	}
 
 	private getExploreAgentModels(): string | string[] | undefined {
-		try {
-			const agentFile = join(getPackageDir(), "agents", "explore.md");
-			const content = readFileSync(agentFile, "utf-8");
-			const parsed = parseAgentFrontmatter(content);
-			if (parsed.ok && parsed.config.model) {
-				return parsed.config.model;
-			}
-		} catch {
-			// Fall through to parent model
+		// Resolution order mirrors discoverAgentTypes: user override > project > package.
+		// First match with a valid model wins.
+		const candidates = [
+			join(homedir(), CONFIG_DIR_NAME, "agents", "explore.md"),
+			join(process.cwd(), ".dreb", "agents", "explore.md"),
+			join(getPackageDir(), "agents", "explore.md"),
+		];
+
+		for (const agentFile of candidates) {
+			try {
+				const content = readFileSync(agentFile, "utf-8");
+				const parsed = parseAgentFrontmatter(content);
+				if (parsed.ok && parsed.config.model) {
+					return parsed.config.model;
+				}
+			} catch {}
 		}
 		return undefined;
 	}

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -59,9 +59,9 @@ describe("isForbiddenCommand", () => {
 	});
 
 	describe("privilege escalation (sudo, doas, su)", () => {
-		const SUDO_PATTERN = "^sudo\\b";
-		const DOAS_PATTERN = "^doas\\b";
-		const SU_PATTERN = "^su\\b";
+		const SUDO_PATTERN = "^(?:/\\S+/)?sudo\\b";
+		const DOAS_PATTERN = "^(?:/\\S+/)?doas\\b";
+		const SU_PATTERN = "^(?:/\\S+/)?su\\b";
 
 		// sudo
 		it("blocks sudo at start of command", () => {
@@ -261,6 +261,39 @@ describe("isForbiddenCommand", () => {
 
 		it("allows command with non-forbidden commands", () => {
 			expect(isForbiddenCommand("command ls -la")).toBeUndefined();
+		});
+
+		// Absolute path bypass prevention
+		it("blocks /usr/bin/sudo (absolute path)", () => {
+			expect(isForbiddenCommand("/usr/bin/sudo apt-get install python3")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks /bin/su (absolute path)", () => {
+			expect(isForbiddenCommand("/bin/su -")).toBe(SU_PATTERN);
+		});
+
+		it("blocks /usr/bin/doas (absolute path)", () => {
+			expect(isForbiddenCommand("/usr/bin/doas reboot")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks /usr/local/bin/sudo (deep absolute path)", () => {
+			expect(isForbiddenCommand("/usr/local/bin/sudo rm -rf /tmp/test")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks /usr/bin/env sudo (absolute path env bypass)", () => {
+			expect(isForbiddenCommand("/usr/bin/env sudo bash")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks /usr/bin/env with flags before sudo (absolute path env args bypass)", () => {
+			expect(isForbiddenCommand("/usr/bin/env -i sudo rm -rf /")).toBe(SUDO_PATTERN);
+		});
+
+		it("allows /usr/bin/sum (absolute path, word boundary)", () => {
+			expect(isForbiddenCommand("/usr/bin/sum file.txt")).toBeUndefined();
+		});
+
+		it("allows /usr/bin/env with non-forbidden command (absolute path)", () => {
+			expect(isForbiddenCommand("/usr/bin/env NODE_ENV=production node app.js")).toBeUndefined();
 		});
 	});
 

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -58,6 +58,107 @@ describe("isForbiddenCommand", () => {
 		});
 	});
 
+	describe("privilege escalation (sudo, doas, su)", () => {
+		const SUDO_PATTERN = "^sudo\\b";
+		const DOAS_PATTERN = "^doas\\b";
+		const SU_PATTERN = "^su\\b";
+
+		// sudo
+		it("blocks sudo at start of command", () => {
+			expect(isForbiddenCommand("sudo apt install foo")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks sudo with flags", () => {
+			expect(isForbiddenCommand("sudo -u root cat /etc/shadow")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks sudo after shell operator", () => {
+			expect(isForbiddenCommand("echo hello && sudo rm -rf /tmp/test")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks sudo after pipe", () => {
+			expect(isForbiddenCommand("echo password | sudo -S apt install foo")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks sudo after semicolon", () => {
+			expect(isForbiddenCommand("cd /tmp; sudo cat /etc/passwd")).toBe(SUDO_PATTERN);
+		});
+
+		// doas
+		it("blocks doas at start of command", () => {
+			expect(isForbiddenCommand("doas apt install foo")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks doas with flags", () => {
+			expect(isForbiddenCommand("doas -u root cat /etc/shadow")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks doas after shell operator", () => {
+			expect(isForbiddenCommand("echo hello && doas rm -rf /tmp/test")).toBe(DOAS_PATTERN);
+		});
+
+		// su
+		it("blocks su at start of command", () => {
+			expect(isForbiddenCommand("su -c 'whoami'")).toBe(SU_PATTERN);
+		});
+
+		it("blocks su with username", () => {
+			expect(isForbiddenCommand("su root -c 'cat /etc/shadow'")).toBe(SU_PATTERN);
+		});
+
+		it("blocks su - (switch to root)", () => {
+			expect(isForbiddenCommand("su -")).toBe(SU_PATTERN);
+		});
+
+		it("blocks su after shell operator", () => {
+			expect(isForbiddenCommand("echo hello && su -c 'whoami'")).toBe(SU_PATTERN);
+		});
+
+		// Word boundary — false positive avoidance
+		it("allows commands starting with 'su' prefix (sum)", () => {
+			expect(isForbiddenCommand("sum file.txt")).toBeUndefined();
+		});
+
+		it("allows commands starting with 'su' prefix (suspend)", () => {
+			expect(isForbiddenCommand("suspend")).toBeUndefined();
+		});
+
+		it("allows commands starting with 'su' prefix (subl)", () => {
+			expect(isForbiddenCommand("subl file.txt")).toBeUndefined();
+		});
+
+		it("allows commands starting with 'sudo' prefix but not sudo (sudoedit-like)", () => {
+			// sudoedit is actually a sudo alias, but tests word boundary behavior
+			expect(isForbiddenCommand("sudoku")).toBeUndefined();
+		});
+
+		it("allows commands starting with 'doas' prefix (doasomething)", () => {
+			expect(isForbiddenCommand("doasomething --flag")).toBeUndefined();
+		});
+
+		// Quoted content — evasion prevention
+		it("blocks sudo in quoted content (echo evasion)", () => {
+			expect(isForbiddenCommand('echo "sudo rm -rf /" | bash')).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks doas in quoted content (echo evasion)", () => {
+			expect(isForbiddenCommand('echo "doas rm -rf /" | bash')).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks su in quoted content (echo evasion)", () => {
+			expect(isForbiddenCommand('echo "su -c whoami" | bash')).toBe(SU_PATTERN);
+		});
+
+		// Subshell wrappers
+		it("blocks sudo inside subshell", () => {
+			expect(isForbiddenCommand("$(sudo cat /etc/shadow)")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks doas inside subshell", () => {
+			expect(isForbiddenCommand("$(doas cat /etc/shadow)")).toBe(DOAS_PATTERN);
+		});
+	});
+
 	describe("HUSKY=0 (bypass pre-commit hooks)", () => {
 		const HUSKY_PATTERN = "^(?:export\\s+)?HUSKY=0";
 

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -136,6 +136,10 @@ describe("isForbiddenCommand", () => {
 			expect(isForbiddenCommand("doasomething --flag")).toBeUndefined();
 		});
 
+		it("allows commands starting with 'su' prefix (superior)", () => {
+			expect(isForbiddenCommand("superior --flag")).toBeUndefined();
+		});
+
 		// Quoted content — evasion prevention
 		it("blocks sudo in quoted content (echo evasion)", () => {
 			expect(isForbiddenCommand('echo "sudo rm -rf /" | bash')).toBe(SUDO_PATTERN);
@@ -193,6 +197,62 @@ describe("isForbiddenCommand", () => {
 
 		it("blocks prefix bypass after shell operator", () => {
 			expect(isForbiddenCommand("echo hello && env sudo rm -rf /")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env with flags before sudo (env -i sudo)", () => {
+			expect(isForbiddenCommand("env -i sudo rm -rf /")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env with variable assignment before sudo", () => {
+			expect(isForbiddenCommand("env VAR=value sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env with multiple assignments before sudo", () => {
+			expect(isForbiddenCommand("env TERM=dumb PATH=/usr/bin sudo bash")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env with flag and assignment before doas", () => {
+			expect(isForbiddenCommand("env -i TERM=dumb doas apt install pkg")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks env with -u flag before su", () => {
+			expect(isForbiddenCommand("env -u PATH su -c 'whoami'")).toBe(SU_PATTERN);
+		});
+
+		it("blocks builtin sudo (builtin prefix bypass)", () => {
+			expect(isForbiddenCommand("builtin sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("allows builtin with non-forbidden commands", () => {
+			expect(isForbiddenCommand("builtin echo hello")).toBeUndefined();
+		});
+
+		it("blocks exec doas (exec prefix bypass)", () => {
+			expect(isForbiddenCommand("exec doas cat /etc/shadow")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks command doas (command prefix bypass)", () => {
+			expect(isForbiddenCommand("command doas apt install pkg")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks backslash-escaped doas (alias bypass)", () => {
+			expect(isForbiddenCommand("\\doas apt install pkg")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks env su (env prefix bypass)", () => {
+			expect(isForbiddenCommand("env su -c 'whoami'")).toBe(SU_PATTERN);
+		});
+
+		it("blocks exec su (exec prefix bypass)", () => {
+			expect(isForbiddenCommand("exec su -")).toBe(SU_PATTERN);
+		});
+
+		it("blocks backslash-escaped su (alias bypass)", () => {
+			expect(isForbiddenCommand("\\su -c 'cat /etc/shadow'")).toBe(SU_PATTERN);
+		});
+
+		it("blocks su inside subshell", () => {
+			expect(isForbiddenCommand("$(su -c 'whoami')")).toBe(SU_PATTERN);
 		});
 
 		it("allows env with non-forbidden commands", () => {

--- a/packages/coding-agent/test/forbidden-commands.test.ts
+++ b/packages/coding-agent/test/forbidden-commands.test.ts
@@ -157,6 +157,51 @@ describe("isForbiddenCommand", () => {
 		it("blocks doas inside subshell", () => {
 			expect(isForbiddenCommand("$(doas cat /etc/shadow)")).toBe(DOAS_PATTERN);
 		});
+
+		// Shell prefix bypass prevention
+		it("blocks env sudo (env prefix bypass)", () => {
+			expect(isForbiddenCommand("env sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks exec sudo (exec prefix bypass)", () => {
+			expect(isForbiddenCommand("exec sudo bash")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks command sudo (command prefix bypass)", () => {
+			expect(isForbiddenCommand("command sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks backslash-escaped sudo (alias bypass)", () => {
+			expect(isForbiddenCommand("\\sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env doas (env prefix bypass)", () => {
+			expect(isForbiddenCommand("env doas apt install pkg")).toBe(DOAS_PATTERN);
+		});
+
+		it("blocks stacked prefixes (env command sudo)", () => {
+			expect(isForbiddenCommand("env command sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks env backslash sudo", () => {
+			expect(isForbiddenCommand("env \\sudo apt install pkg")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks prefix bypass inside subshell", () => {
+			expect(isForbiddenCommand("$(env sudo cat /etc/shadow)")).toBe(SUDO_PATTERN);
+		});
+
+		it("blocks prefix bypass after shell operator", () => {
+			expect(isForbiddenCommand("echo hello && env sudo rm -rf /")).toBe(SUDO_PATTERN);
+		});
+
+		it("allows env with non-forbidden commands", () => {
+			expect(isForbiddenCommand("env NODE_ENV=production node app.js")).toBeUndefined();
+		});
+
+		it("allows command with non-forbidden commands", () => {
+			expect(isForbiddenCommand("command ls -la")).toBeUndefined();
+		});
 	});
 
 	describe("HUSKY=0 (bypass pre-commit hooks)", () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import type { GitRepoState } from "../src/core/git-repo-state.js";
 import { buildSystemPrompt } from "../src/core/system-prompt.js";
 
@@ -244,6 +244,83 @@ describe("buildSystemPrompt", () => {
 			expect(stateIdx).toBeGreaterThan(-1);
 			expect(dateIdx).toBeGreaterThan(-1);
 			expect(stateIdx).toBeLessThan(dateIdx);
+		});
+	});
+
+	describe("root security warning", () => {
+		const originalGetuid = process.getuid;
+
+		afterEach(() => {
+			// Restore original getuid
+			process.getuid = originalGetuid;
+		});
+
+		test("includes root security section when running as root", () => {
+			process.getuid = () => 0;
+
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("## ⚠️ Security: Running as Root");
+			expect(prompt).toContain("running as root (UID 0)");
+			expect(prompt).toContain("Never");
+			expect(prompt).toContain("privilege escalation");
+		});
+
+		test("does not include root security section when not root", () => {
+			process.getuid = () => 1000;
+
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("Security: Running as Root");
+		});
+
+		test("does not include root security section when getuid is unavailable (Windows)", () => {
+			process.getuid = undefined as unknown as () => number;
+
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("Security: Running as Root");
+		});
+
+		test("root section appears before date in default prompt", () => {
+			process.getuid = () => 0;
+
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			const secIdx = prompt.indexOf("Security: Running as Root");
+			const dateIdx = prompt.indexOf("Current date:");
+			expect(secIdx).toBeGreaterThan(-1);
+			expect(dateIdx).toBeGreaterThan(-1);
+			expect(secIdx).toBeLessThan(dateIdx);
+		});
+
+		test("root section works with custom prompt", () => {
+			process.getuid = () => 0;
+
+			const prompt = buildSystemPrompt({
+				customPrompt: "Custom system prompt.",
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("Custom system prompt.");
+			expect(prompt).toContain("Security: Running as Root");
 		});
 	});
 });

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -10,9 +10,15 @@ vi.mock("@dreb/ai", () => ({
 // Mock config to avoid filesystem access
 vi.mock("../../coding-agent/src/config.js", () => ({
 	getPackageDir: () => "/mock/package",
+	CONFIG_DIR_NAME: ".dreb",
 }));
 
-// Mock fs.readFileSync for agent file reading
+// Mock fs.readFileSync for agent file reading.
+// getExploreAgentModels() checks user (~/.dreb/agents/), project (.dreb/agents/),
+// and package dirs in priority order. The mock readFileSync returns content for the
+// package path; real reads of other paths succeed or throw ENOENT naturally.
+// parseAgentFrontmatter is separately mocked, so real file reads still go through
+// the mock parser which returns { ok: false } by default (blocking user overrides).
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
 	return {
@@ -408,6 +414,7 @@ describe("TabTitleGenerator", () => {
 					expect.anything(),
 					"test-model",
 					expect.any(AbortSignal),
+					"[tab-title]",
 				);
 			});
 		});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.20.0",
+	"version": "2.21.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #218

Block privilege escalation commands (`sudo`, `doas`, `su`) in the forbidden-commands guard, warn when running as root, and provide de-escalation guidance to the agent when commands are blocked.

Implementation plan posted as a comment below.
