### PR TITLE
Show tool result details in Telegram UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The same agent runtime powers multiple surfaces:
 - **JSON mode** — event stream for scripts and automation.
 - **RPC mode** — strict [JSONL stdin/stdout protocol](packages/coding-agent/docs/rpc.md) for non-Node clients and custom UIs.
 - **SDK** — import `@dreb/coding-agent` and create agent sessions directly in TypeScript.
-- **Telegram** — `@dreb/telegram` runs dreb as a bot with sessions, model controls, file upload/download, and live tool status.
+- **Telegram** — `@dreb/telegram` runs dreb as a bot with sessions, model controls, file upload/download, live tool status, and visible results for user-facing tools.
 
 ## Design philosophy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -6703,9 +6703,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -8763,7 +8763,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8792,7 +8792,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8848,7 +8848,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -8963,7 +8963,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9012,7 +9012,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9044,7 +9044,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.21.0",
+			"version": "2.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -65,7 +65,7 @@ Or use a custom provider (corporate proxy, Bedrock, etc.) — see [Custom provid
 
 Then just talk to dreb. All 11 built-in tools are enabled by default: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, and `wait`. Use `--tools` to restrict to a subset (e.g., `--tools read,grep,find,ls` for read-only). Three additional tools — `search`, `skill`, and `tasks_update` — are always active regardless of `--tools`. `suggest_next` is active by default but excluded when `--tools` is specified. The model uses these to fulfill your requests. Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [packages](#packages).
 
-**Also available:** [`@dreb/telegram`](https://www.npmjs.com/package/@dreb/telegram) — run dreb as a Telegram bot (`npm install -g @dreb/telegram`).
+**Also available:** [`@dreb/telegram`](https://www.npmjs.com/package/@dreb/telegram) — run dreb as a Telegram bot with live tool status and visible results for user-facing tools (`npm install -g @dreb/telegram`).
 
 **Platform notes:** [Windows](docs/windows.md) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -98,7 +98,8 @@ systemctl --user enable --now dreb-telegram
 ## Features
 
 - **Per-user message queue** — one prompt at a time, incoming messages queued
-- **Live tool display** — ephemeral status message shows tools, task lists, subagents
+- **Live tool display** — ephemeral status message shows tools, task lists, subagents, and key parameters
+- **Visible tool results** — permanent messages show user-facing results from tools such as `suggest_next`, `search`, and `wait`
 - **Rate-limited status updates** — debounced to avoid Telegram 429 errors
 - **File upload** — documents, photos, voice, audio, video with 3s batching
 - **File download** — `[[telegram:send:/path]]` markers in assistant text

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/telegram/src/handlers/events.ts
+++ b/packages/telegram/src/handlers/events.ts
@@ -34,6 +34,9 @@ const TOOL_EMOJI: Record<string, string> = {
 	ls: "📂",
 	web_search: "🌐",
 	web_fetch: "🌐",
+	search: "🔍",
+	suggest_next: "💡",
+	wait: "⏳",
 	subagent: "🤖",
 	tasks_update: "📋",
 	skill: "⚡",
@@ -41,6 +44,73 @@ const TOOL_EMOJI: Record<string, string> = {
 
 function toolEmoji(name: string): string {
 	return TOOL_EMOJI[name] || "🔧";
+}
+
+function formatOptionalToolParams(params: Array<[string, unknown]>): string {
+	return params
+		.filter(([, value]) => value !== undefined && value !== null && value !== false && value !== "")
+		.map(([label, value]) => `${label}: ${String(value).slice(0, 120)}`)
+		.join(", ");
+}
+
+function firstTextBlock(result: any): string | undefined {
+	const content = result?.content;
+	if (!Array.isArray(content)) return undefined;
+	for (const block of content) {
+		if (block?.type === "text" && typeof block.text === "string" && block.text.trim()) {
+			return block.text.trim();
+		}
+	}
+	return undefined;
+}
+
+function formatVisibleToolResult(toolName: string, result: any): string | undefined {
+	const details = result?.details;
+	const text = firstTextBlock(result);
+
+	switch (toolName) {
+		case "suggest_next": {
+			const suggestion = typeof details?.suggestion === "string" ? details.suggestion.trim() : undefined;
+			const summary = typeof details?.summary === "string" ? details.summary.trim() : undefined;
+			if (summary && suggestion) return `${summary}\n\n→ ${suggestion}`;
+			if (suggestion) return `→ ${suggestion}`;
+			return text;
+		}
+		case "search": {
+			if (!text) return undefined;
+			const resultCount = typeof details?.resultCount === "number" ? details.resultCount : undefined;
+			const header = resultCount === undefined ? "🔍 *Search results*" : `🔍 *Search results (${resultCount})*`;
+			const stats = details?.indexStats;
+			const footer =
+				stats && typeof stats.files === "number" && typeof stats.chunks === "number"
+					? `\n\n_Index: ${stats.files} files, ${stats.chunks} chunks_`
+					: "";
+			return `${header}\n${text}${footer}`;
+		}
+		case "wait": {
+			const reason =
+				typeof details?.reason === "string" && details.reason.trim() ? details.reason.trim() : undefined;
+			const agents = Array.isArray(details?.runningAgents) ? details.runningAgents : [];
+			const lines = [`⏳ ${reason ? `Waiting: ${reason}` : text || "Waiting…"}`];
+			if (agents.length > 0) {
+				lines.push(
+					"Waiting on:",
+					...agents.map((agent: any) => {
+						const id = typeof agent.agentId === "string" ? agent.agentId.slice(0, 12) : "unknown";
+						const type = typeof agent.agentType === "string" ? agent.agentType : "agent";
+						const task =
+							typeof agent.taskSummary === "string" && agent.taskSummary.trim()
+								? ` — ${agent.taskSummary.trim()}`
+								: "";
+						return `- ${id} ${type}${task}`;
+					}),
+				);
+			}
+			return lines.join("\n");
+		}
+		default:
+			return undefined;
+	}
 }
 
 /** Format a tool call for display */
@@ -67,6 +137,20 @@ function formatTool(name: string, args: Record<string, any>): string {
 			return `${emoji} *web\\_search*: ${args.query || "?"}`;
 		case "web_fetch":
 			return `${emoji} *web\\_fetch*: ${(args.url || "?").slice(0, 80)}`;
+		case "search": {
+			const query = args.query || "?";
+			const options = formatOptionalToolParams([
+				["limit", args.limit],
+				["in", args.restrictToDir],
+				["project", args.searchDir],
+				["rebuild", args.rebuild ? "true" : undefined],
+			]);
+			return `${emoji} *search*: ${String(query).slice(0, 200)}${options ? ` (${options})` : ""}`;
+		}
+		case "suggest_next":
+			return `${emoji} *suggest\\_next*: ${args.command || "?"}`;
+		case "wait":
+			return args.reason ? `${emoji} *wait*: ${String(args.reason).slice(0, 200)}` : `${emoji} *wait*`;
 		case "subagent":
 			return `${emoji} *subagent* (${args.agent || "?"}): ${(args.task || args.tasks?.[0]?.task || "?").slice(0, 200)}`;
 		case "skill":
@@ -101,6 +185,8 @@ export interface EventDisplayState {
 	toolCount: number;
 	/** All text blocks received */
 	textBlocks: string[];
+	/** User-visible tool results sent during the current run/cycle */
+	visibleToolResultCount: number;
 	/** Current task list */
 	tasks: Array<{ id: string; title: string; status: string }>;
 	/** Background agents */
@@ -146,6 +232,7 @@ export function createEventDisplay(
 		toolsSinceText: [],
 		toolCount: 0,
 		textBlocks: [],
+		visibleToolResultCount: 0,
 		tasks: [],
 		backgroundAgents: new Map(),
 		done: false,
@@ -185,6 +272,17 @@ export async function handleAgentEvent(
 		case "tool_execution_end": {
 			// Feed event to buddy controller for context capture + error reactions
 			state.buddyController?.handleEvent(event);
+
+			const output = formatVisibleToolResult(event.toolName, event.result);
+			if (output) {
+				if (state.toolsSinceText.length > 0) {
+					const summary = `📋 *${state.toolsSinceText.length} tools*:\n${state.toolsSinceText.join("\n")}`;
+					send(summary, true);
+					state.toolsSinceText = [];
+				}
+				send(output, true);
+				state.visibleToolResultCount++;
+			}
 			break;
 		}
 
@@ -376,8 +474,12 @@ export async function handleAgentEvent(
 							: "";
 					send(`❌ ${prefix}${errorMsg.errorMessage}${hint}`, true);
 				}
-			} else if (state.textBlocks.length === 0 && state.backgroundAgents.size === 0) {
-				// Only show "(No response)" when truly done — not between agent cycles
+			} else if (
+				state.textBlocks.length === 0 &&
+				state.visibleToolResultCount === 0 &&
+				state.backgroundAgents.size === 0
+			) {
+				// Only show "(No response)" when truly done — not between agent cycles or after visible end-turn tools
 				if (!state.retryInProgress && !errorIsRetryable) {
 					send("(No response)");
 				}
@@ -396,6 +498,7 @@ export async function handleAgentEvent(
 				if (errorIsRetryable) state.pendingRetry = true;
 				// Reset per-cycle state for the next agent loop
 				state.textBlocks = [];
+				state.visibleToolResultCount = 0;
 				state.toolCount = 0;
 				break;
 			}
@@ -404,6 +507,7 @@ export async function handleAgentEvent(
 			// and reset per-cycle state for the next agent loop
 			if (state.backgroundAgents.size > 0) {
 				state.textBlocks = [];
+				state.visibleToolResultCount = 0;
 				state.toolCount = 0;
 				break;
 			}

--- a/packages/telegram/test/events.test.ts
+++ b/packages/telegram/test/events.test.ts
@@ -183,6 +183,19 @@ describe("agent_end", () => {
 		expect(state.textBlocks).toEqual([]);
 		expect(state.toolCount).toBe(0);
 	});
+
+	it("does NOT send no-response after visible tool result output", async () => {
+		const send = vi.fn();
+		const state = makeState({ visibleToolResultCount: 1 });
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "agent_end",
+			messages: [],
+		});
+
+		expect(send).not.toHaveBeenCalledWith("(No response)");
+		expect(state.done).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -241,6 +254,158 @@ describe("auto_retry_end", () => {
 });
 
 // ---------------------------------------------------------------------------
+// tool_execution_end — visible tool results
+// ---------------------------------------------------------------------------
+
+describe("tool_execution_end", () => {
+	it("sends suggest_next summary and suggestion as a permanent long message", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "suggest_next",
+			result: {
+				content: [{ type: "text", text: "Suggestion registered: /compact" }],
+				details: { suggestion: "/compact", summary: "Done with refactor." },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("Done with refactor."), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("→ /compact"), true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends suggest_next suggestion without summary", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "suggest_next",
+			result: {
+				content: [{ type: "text", text: "Suggestion registered: /compact" }],
+				details: { suggestion: "/compact" },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith("→ /compact", true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends suggest_next error text when details are absent", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "suggest_next",
+			isError: true,
+			result: {
+				content: [{ type: "text", text: "Error: command must start with /" }],
+				details: undefined,
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith("Error: command must start with /", true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends search result text via the long-message path", async () => {
+		const send = vi.fn();
+		const state = makeState();
+		const results = "1. packages/telegram/src/handlers/events.ts\\n   scores: bm25=1.00";
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "search",
+			result: {
+				content: [{ type: "text", text: results }],
+				details: { resultCount: 1, indexBuilt: false, indexStats: { files: 10, chunks: 25 } },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("Search results (1)"), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("packages/telegram/src/handlers/events.ts"), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("Index: 10 files, 25 chunks"), true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends search no-results text", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "search",
+			result: {
+				content: [{ type: "text", text: "No results found." }],
+				details: { resultCount: 0, indexBuilt: false },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("No results found."), true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends wait status with running agent context", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "wait",
+			result: {
+				content: [{ type: "text", text: "Waiting…" }],
+				details: {
+					reason: "background agents",
+					runningAgents: [
+						{ agentId: "abc1234567890", agentType: "code-reviewer", taskSummary: "reviewing changes" },
+					],
+				},
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("Waiting: background agents"), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("abc123456789"), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("code-reviewer"), true);
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("reviewing changes"), true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends wait status without running agents", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "wait",
+			result: {
+				content: [{ type: "text", text: "Waiting…" }],
+				details: { reason: undefined, runningAgents: [] },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith("⏳ Waiting…", true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("does not send general tool results that are not allowlisted", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "bash",
+			result: { content: [{ type: "text", text: "stdout" }] },
+		});
+
+		expect(send).not.toHaveBeenCalled();
+		expect(state.visibleToolResultCount).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // tool_execution_start
 // ---------------------------------------------------------------------------
 
@@ -273,6 +438,64 @@ describe("tool_execution_start", () => {
 
 		expect(state.toolCount).toBe(1);
 		expect(state.toolsSinceText).toHaveLength(0);
+	});
+
+	it("formats suggest_next command in toolsSinceText", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_start",
+			toolName: "suggest_next",
+			args: { command: "/skill:mach6-push" },
+		});
+
+		expect(state.toolsSinceText[0]).toContain("suggest\\_next");
+		expect(state.toolsSinceText[0]).toContain("/skill:mach6-push");
+	});
+
+	it("formats search query and options in toolsSinceText", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_start",
+			toolName: "search",
+			args: {
+				query: "AuthMiddleware",
+				limit: 5,
+				restrictToDir: "src/auth",
+				searchDir: "packages/coding-agent",
+				rebuild: true,
+			},
+		});
+
+		expect(state.toolsSinceText[0]).toContain("search");
+		expect(state.toolsSinceText[0]).toContain("AuthMiddleware");
+		expect(state.toolsSinceText[0]).toContain("limit: 5");
+		expect(state.toolsSinceText[0]).toContain("in: src/auth");
+		expect(state.toolsSinceText[0]).toContain("project: packages/coding-agent");
+		expect(state.toolsSinceText[0]).toContain("rebuild: true");
+	});
+
+	it("formats wait reason in toolsSinceText and handles empty args", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_start",
+			toolName: "wait",
+			args: { reason: "background agents" },
+		});
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_start",
+			toolName: "wait",
+			args: {},
+		});
+
+		expect(state.toolsSinceText[0]).toContain("wait");
+		expect(state.toolsSinceText[0]).toContain("background agents");
+		expect(state.toolsSinceText[1]).toContain("wait");
 	});
 });
 

--- a/packages/telegram/test/events.test.ts
+++ b/packages/telegram/test/events.test.ts
@@ -134,7 +134,7 @@ describe("agent_end", () => {
 
 	it("does NOT set done for retryable errors, sets pendingRetry and resets per-cycle state", async () => {
 		const send = vi.fn();
-		const state = makeState({ toolCount: 5, textBlocks: ["some text"] });
+		const state = makeState({ toolCount: 5, textBlocks: ["some text"], visibleToolResultCount: 1 });
 
 		await handleAgentEvent(send, mockApi(), state, {
 			type: "agent_end",
@@ -145,12 +145,13 @@ describe("agent_end", () => {
 		expect(state.pendingRetry).toBe(true);
 		// Per-cycle state is reset
 		expect(state.textBlocks).toEqual([]);
+		expect(state.visibleToolResultCount).toBe(0);
 		expect(state.toolCount).toBe(0);
 	});
 
 	it("does NOT set done for 'ended without' errors (stream termination)", async () => {
 		const send = vi.fn();
-		const state = makeState({ toolCount: 2, textBlocks: ["partial"] });
+		const state = makeState({ toolCount: 2, textBlocks: ["partial"], visibleToolResultCount: 1 });
 
 		await handleAgentEvent(send, mockApi(), state, {
 			type: "agent_end",
@@ -160,12 +161,13 @@ describe("agent_end", () => {
 		expect(state.done).toBe(false);
 		expect(state.pendingRetry).toBe(true);
 		expect(state.textBlocks).toEqual([]);
+		expect(state.visibleToolResultCount).toBe(0);
 		expect(state.toolCount).toBe(0);
 	});
 
 	it("does NOT set done when background agents are still running", async () => {
 		const send = vi.fn();
-		const state = makeState();
+		const state = makeState({ visibleToolResultCount: 1 });
 		state.backgroundAgents.set("bg-1", {
 			agentId: "bg-1",
 			agentType: "researcher",
@@ -181,6 +183,7 @@ describe("agent_end", () => {
 		expect(state.done).toBe(false);
 		// Per-cycle state is reset
 		expect(state.textBlocks).toEqual([]);
+		expect(state.visibleToolResultCount).toBe(0);
 		expect(state.toolCount).toBe(0);
 	});
 
@@ -193,6 +196,28 @@ describe("agent_end", () => {
 			messages: [],
 		});
 
+		expect(send).not.toHaveBeenCalledWith("(No response)");
+		expect(state.done).toBe(true);
+	});
+
+	it("does NOT send no-response after a visible tool result in the same cycle", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "suggest_next",
+			result: {
+				content: [{ type: "text", text: "Suggestion registered: /compact" }],
+				details: { suggestion: "/compact", summary: "Done." },
+			},
+		});
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "agent_end",
+			messages: [],
+		});
+
+		expect(send).toHaveBeenCalledWith(expect.stringContaining("Done."), true);
 		expect(send).not.toHaveBeenCalledWith("(No response)");
 		expect(state.done).toBe(true);
 	});
@@ -311,6 +336,29 @@ describe("tool_execution_end", () => {
 		expect(state.visibleToolResultCount).toBe(1);
 	});
 
+	it("flushes accumulated tool summaries before sending a visible tool result", async () => {
+		const send = vi.fn();
+		const state = makeState({ toolsSinceText: ["🔧 *bash*", "💡 *suggest\\_next*: /compact"] });
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "suggest_next",
+			result: {
+				content: [{ type: "text", text: "Suggestion registered: /compact" }],
+				details: { suggestion: "/compact" },
+			},
+		});
+
+		expect(send).toHaveBeenCalledTimes(2);
+		expect(send.mock.calls[0][0]).toContain("📋 *2 tools*:");
+		expect(send.mock.calls[0][0]).toContain("🔧 *bash*");
+		expect(send.mock.calls[0][0]).toContain("💡 *suggest\\_next*: /compact");
+		expect(send.mock.calls[0][1]).toBe(true);
+		expect(send.mock.calls[1]).toEqual(["→ /compact", true]);
+		expect(state.toolsSinceText).toEqual([]);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
 	it("sends search result text via the long-message path", async () => {
 		const send = vi.fn();
 		const state = makeState();
@@ -387,6 +435,23 @@ describe("tool_execution_end", () => {
 		});
 
 		expect(send).toHaveBeenCalledWith("⏳ Waiting…", true);
+		expect(state.visibleToolResultCount).toBe(1);
+	});
+
+	it("sends wait reason when no background agents are running", async () => {
+		const send = vi.fn();
+		const state = makeState();
+
+		await handleAgentEvent(send, mockApi(), state, {
+			type: "tool_execution_end",
+			toolName: "wait",
+			result: {
+				content: [{ type: "text", text: "Waiting…" }],
+				details: { reason: "compacting context", runningAgents: [] },
+			},
+		});
+
+		expect(send).toHaveBeenCalledWith("⏳ Waiting: compacting context", true);
 		expect(state.visibleToolResultCount).toBe(1);
 	});
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.21.0",
+	"version": "2.21.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #225

Draft PR to make the Telegram frontend surface user-relevant tool result details for `suggest_next`, `search`, and `wait`.

Implementation plan posted as a comment below.
