### PR TITLE
subagent: accept absolute paths for cwd parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3362,6 +3362,13 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3595,121 +3602,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@vitest/expect": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"tinyrainbow": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/mocker": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "3.2.4",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.17"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/runner": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "3.2.4",
-				"pathe": "^2.0.3",
-				"strip-literal": "^3.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/snapshot": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"magic-string": "^0.30.17",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/spy": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyspy": "^4.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"loupe": "^3.1.4",
-				"tinyrainbow": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
 		},
 		"node_modules/@xterm/headless": {
 			"version": "5.5.0",
@@ -4026,16 +3918,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/cac": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4080,23 +3962,6 @@
 				"node": "^18.12.0 || >= 20.9.0"
 			}
 		},
-		"node_modules/chai": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assertion-error": "^2.0.1",
-				"check-error": "^2.1.1",
-				"deep-eql": "^5.0.1",
-				"loupe": "^3.1.0",
-				"pathval": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4123,16 +3988,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/check-error": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
 			}
 		},
 		"node_modules/chownr": {
@@ -4325,6 +4180,13 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -4427,16 +4289,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/deep-eql": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/deep-extend": {
@@ -4616,13 +4468,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -5798,13 +5643,6 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
-		"node_modules/js-tokens": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -5882,13 +5720,6 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
-		},
-		"node_modules/loupe": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
 			"version": "11.2.7",
@@ -6246,6 +6077,17 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6492,16 +6334,6 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/pathval": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.16"
-			}
 		},
 		"node_modules/pend": {
 			"version": "1.2.0",
@@ -7510,19 +7342,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/strip-literal": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^9.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/strnum": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -7740,13 +7559,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/tinyexec": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7793,36 +7605,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/tinypool": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
-			}
-		},
-		"node_modules/tinyrainbow": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tinyspy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -8387,29 +8169,6 @@
 				}
 			}
 		},
-		"node_modules/vite-node": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cac": "^6.7.14",
-				"debug": "^4.4.1",
-				"es-module-lexer": "^1.7.0",
-				"pathe": "^2.0.3",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"bin": {
-				"vite-node": "vite-node.mjs"
-			},
-			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/vite/node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8429,92 +8188,6 @@
 			}
 		},
 		"node_modules/vite/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/vitest": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/chai": "^5.2.2",
-				"@vitest/expect": "3.2.4",
-				"@vitest/mocker": "3.2.4",
-				"@vitest/pretty-format": "^3.2.4",
-				"@vitest/runner": "3.2.4",
-				"@vitest/snapshot": "3.2.4",
-				"@vitest/spy": "3.2.4",
-				"@vitest/utils": "3.2.4",
-				"chai": "^5.2.0",
-				"debug": "^4.4.1",
-				"expect-type": "^1.2.1",
-				"magic-string": "^0.30.17",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.2",
-				"std-env": "^3.9.0",
-				"tinybench": "^2.9.0",
-				"tinyexec": "^0.3.2",
-				"tinyglobby": "^0.2.14",
-				"tinypool": "^1.1.1",
-				"tinyrainbow": "^2.0.0",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-				"vite-node": "3.2.4",
-				"why-is-node-running": "^2.3.0"
-			},
-			"bin": {
-				"vitest": "vitest.mjs"
-			},
-			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@edge-runtime/vm": "*",
-				"@types/debug": "^4.1.12",
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.2.4",
-				"@vitest/ui": "3.2.4",
-				"happy-dom": "*",
-				"jsdom": "*"
-			},
-			"peerDependenciesMeta": {
-				"@edge-runtime/vm": {
-					"optional": true
-				},
-				"@types/debug": {
-					"optional": true
-				},
-				"@types/node": {
-					"optional": true
-				},
-				"@vitest/browser": {
-					"optional": true
-				},
-				"@vitest/ui": {
-					"optional": true
-				},
-				"happy-dom": {
-					"optional": true
-				},
-				"jsdom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
@@ -8771,7 +8444,7 @@
 			"devDependencies": {
 				"@types/node": "^24.3.0",
 				"typescript": "^5.7.3",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -8785,10 +8458,270 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"packages/agent/node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/agent/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/agent/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/agent/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/agent/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/agent/node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/agent/node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"packages/agent/node_modules/undici-types": {
 			"version": "7.16.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/agent/node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"packages/agent/node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
@@ -8815,7 +8748,7 @@
 			"devDependencies": {
 				"@types/node": "^24.3.0",
 				"canvas": "^3.2.0",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -8827,6 +8760,129 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/ai/node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"packages/ai/node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/ai/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"packages/ai/node_modules/chalk": {
@@ -8841,10 +8897,147 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"packages/ai/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/ai/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/ai/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/ai/node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/ai/node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"packages/ai/node_modules/undici-types": {
 			"version": "7.16.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/ai/node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
@@ -8895,7 +9088,7 @@
 				"@types/proper-lockfile": "^4.1.4",
 				"shx": "^0.4.0",
 				"typescript": "^5.7.3",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=20.6.0"
@@ -8944,6 +9137,102 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"packages/coding-agent/node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/coding-agent/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/coding-agent/node_modules/chalk": {
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -8956,10 +9245,174 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"packages/coding-agent/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/coding-agent/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/coding-agent/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/coding-agent/node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/coding-agent/node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"packages/coding-agent/node_modules/undici-types": {
 			"version": "7.16.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/coding-agent/node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"packages/coding-agent/node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
@@ -8987,7 +9440,7 @@
 				"shx": "^0.4.0",
 				"tree-sitter-gdscript": "^6.1.0",
 				"typescript": "^5.9.2",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=22.0.0"
@@ -9003,12 +9456,272 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"packages/semantic-search/node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/semantic-search/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/semantic-search/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/semantic-search/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/semantic-search/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/semantic-search/node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/semantic-search/node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"packages/semantic-search/node_modules/undici-types": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/semantic-search/node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"packages/semantic-search/node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
@@ -9023,7 +9736,7 @@
 			"devDependencies": {
 				"@types/node": "^24.3.0",
 				"typescript": "^5.9.2",
-				"vitest": "^3.2.4"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -9037,10 +9750,270 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"packages/telegram/node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"packages/telegram/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/telegram/node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/telegram/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/telegram/node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/telegram/node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"packages/telegram/node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"packages/telegram/node_modules/undici-types": {
 			"version": "7.16.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"packages/telegram/node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"packages/telegram/node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8436,7 +8436,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8725,7 +8725,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9041,7 +9041,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9416,7 +9416,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9725,7 +9725,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -10017,7 +10017,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.21.1",
+			"version": "2.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"sync-version": "bash scripts/sync-version.sh",
 		"build": "bash scripts/sync-version.sh && cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../semantic-search && npm run build && cd ../coding-agent && npm run build && cd ../telegram && npm run build",
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
-		"check": "biome check --write --error-on-warnings . && tsgo --noEmit",
+		"check": "npm run verify-git-hooks && biome check --write --error-on-warnings . && tsgo --noEmit",
+		"verify-git-hooks": "node scripts/verify-git-hooks.js",
 		"verify-workspace-links": "node scripts/verify-workspace-links.js",
 		"test": "npm run test --workspaces --if-present",
 		"prepare": "husky"

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added stream drop detection and retry across all providers. When a provider stream ends without its terminal event (e.g. `message_delta`, `finishReason`, `response.completed`), the agent loop retries up to `streamRetries` times with exponential backoff. Configurable via `AgentOptions.streamRetries` (default: 3) and `AgentOptions.streamRetryBaseDelayMs` (default: 1000ms).
+- Added `stream_retry` event type emitted before each retry attempt, carrying `attempt`, `maxAttempts`, `error`, and `discardedPartial`.
 - Added `onWarning` option to `AgentOptions` — forwarded to providers via `StreamOptions.onWarning` for non-fatal streaming warnings ([#115](https://github.com/aebrer/dreb/issues/115))
 
 ## [0.62.0] - 2026-03-23

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -130,6 +130,7 @@ The last message in context must be `user` or `toolResult` (not `assistant`).
 | `message_start` | Any message begins (user, assistant, toolResult) |
 | `message_update` | **Assistant only.** Includes `assistantMessageEvent` with delta |
 | `message_end` | Message completes |
+| `stream_retry` | Provider stream dropped; retrying after discarding partial response |
 | `tool_execution_start` | Tool begins |
 | `tool_execution_update` | Tool streams progress |
 | `tool_execution_end` | Tool completes |
@@ -187,6 +188,13 @@ const agent = new Agent({
 
   // Forward non-fatal provider warnings (e.g. malformed SSE/JSON) to the caller
   onWarning: (code, message) => console.warn(`[${code}] ${message}`),
+
+  // Stream drop retry: number of retries when a provider stream ends without
+  // its terminal event (default: 3). Set to 0 to disable.
+  streamRetries: 3,
+
+  // Base delay for exponential backoff between stream retries in ms (default: 1000)
+  streamRetryBaseDelayMs: 1000,
 
   // Custom thinking budgets for token-based providers
   thinkingBudgets: {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -42,6 +42,6 @@
 	"devDependencies": {
 		"@types/node": "^24.3.0",
 		"typescript": "^5.7.3",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.8"
 	}
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -266,7 +266,11 @@ async function runLoop(
 function isStreamDropError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	const msg = error.message;
-	return msg.includes("Stream ended without") || msg.includes("connection likely dropped");
+	return (
+		msg.includes("Stream ended without") ||
+		msg.includes("connection likely dropped") ||
+		msg.includes("WebSocket stream closed before")
+	);
 }
 
 /**
@@ -373,9 +377,6 @@ async function streamAssistantResponse(
 			});
 		} catch (error) {
 			if (isStreamDropError(error) && attempt < maxRetries && !signal?.aborted) {
-				if (addedPartial && partialMessage) {
-					await emit({ type: "message_end", message: { ...(partialMessage as AssistantMessage) } });
-				}
 				await emit({
 					type: "stream_retry",
 					attempt: attempt + 1,
@@ -475,9 +476,6 @@ async function streamAssistantResponse(
 		}
 
 		if (shouldRetry) {
-			if (addedPartial && partialMessage) {
-				await emit({ type: "message_end", message: { ...partialMessage } });
-			}
 			await emit({
 				type: "stream_retry",
 				attempt: attempt + 1,

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -266,10 +266,7 @@ async function runLoop(
 function isStreamDropError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	const msg = error.message;
-	return (
-		msg.includes("Stream ended without") ||
-		msg.includes("connection likely dropped")
-	);
+	return msg.includes("Stream ended without") || msg.includes("connection likely dropped");
 }
 
 /**
@@ -376,6 +373,9 @@ async function streamAssistantResponse(
 			});
 		} catch (error) {
 			if (isStreamDropError(error) && attempt < maxRetries && !signal?.aborted) {
+				if (addedPartial && partialMessage) {
+					await emit({ type: "message_end", message: { ...(partialMessage as AssistantMessage) } });
+				}
 				await emit({
 					type: "stream_retry",
 					attempt: attempt + 1,
@@ -390,7 +390,12 @@ async function streamAssistantResponse(
 				partialMessage = null;
 				continue;
 			}
-			return finalizeMessage(createErrorMessage(error));
+			const surfacedError = isStreamDropError(error)
+				? new Error("Stream dropped repeatedly — connection likely unstable")
+				: error instanceof Error
+					? error
+					: new Error(String(error));
+			return finalizeMessage(createErrorMessage(surfacedError));
 		}
 
 		let shouldRetry = false;
@@ -438,6 +443,15 @@ async function streamAssistantResponse(
 						) {
 							shouldRetry = true;
 							retryError = result.errorMessage;
+						} else if (
+							result.stopReason === "error" &&
+							result.errorMessage &&
+							isStreamDropError(new Error(result.errorMessage))
+						) {
+							// Final attempt exhausted — surface friendly message
+							return finalizeMessage(
+								createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")),
+							);
 						} else {
 							return finalizeMessage(result);
 						}
@@ -451,11 +465,19 @@ async function streamAssistantResponse(
 				shouldRetry = true;
 				retryError = error instanceof Error ? error.message : String(error);
 			} else {
-				return finalizeMessage(createErrorMessage(error));
+				const surfacedError = isStreamDropError(error)
+					? new Error("Stream dropped repeatedly — connection likely unstable")
+					: error instanceof Error
+						? error
+						: new Error(String(error));
+				return finalizeMessage(createErrorMessage(surfacedError));
 			}
 		}
 
 		if (shouldRetry) {
+			if (addedPartial && partialMessage) {
+				await emit({ type: "message_end", message: { ...partialMessage } });
+			}
 			await emit({
 				type: "stream_retry",
 				attempt: attempt + 1,
@@ -475,9 +497,7 @@ async function streamAssistantResponse(
 	}
 
 	// All retries exhausted — surface the error
-	return finalizeMessage(
-		createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")),
-	);
+	return finalizeMessage(createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")));
 }
 
 interface ToolExecutionResult {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -264,8 +264,7 @@ async function runLoop(
  * Only these errors trigger automatic retry — all other errors propagate as-is.
  */
 function isStreamDropError(error: unknown): boolean {
-	if (!(error instanceof Error)) return false;
-	const msg = error.message;
+	const msg = error instanceof Error ? error.message : typeof error === "string" ? error : "";
 	return (
 		msg.includes("Stream ended without") ||
 		msg.includes("connection likely dropped") ||
@@ -366,6 +365,14 @@ async function streamAssistantResponse(
 
 	const maxRetries = config.streamRetries ?? 3;
 	const retryBaseDelay = config.streamRetryBaseDelayMs ?? 1000;
+	const clonePartialForDebug = (): AssistantMessage | undefined => {
+		if (!partialMessage) return undefined;
+		return {
+			...partialMessage,
+			content: partialMessage.content.map((block) => ({ ...block })),
+			usage: { ...partialMessage.usage, cost: { ...partialMessage.usage.cost } },
+		};
+	};
 
 	for (let attempt = 0; attempt <= maxRetries; attempt++) {
 		let response: Awaited<ReturnType<StreamFn>>;
@@ -382,6 +389,7 @@ async function streamAssistantResponse(
 					attempt: attempt + 1,
 					maxAttempts: maxRetries,
 					error: error instanceof Error ? error.message : String(error),
+					discardedPartial: clonePartialForDebug(),
 				});
 				await sleep(retryBaseDelay * 2 ** attempt, signal);
 				if (addedPartial) {
@@ -435,20 +443,12 @@ async function streamAssistantResponse(
 					case "error": {
 						const result = await response.result();
 						// Check if this is a stream-drop error that should be retried
-						if (
-							result.stopReason === "error" &&
-							result.errorMessage &&
-							isStreamDropError(new Error(result.errorMessage)) &&
-							attempt < maxRetries &&
-							!signal?.aborted
-						) {
+						const isDrop = result.stopReason === "error" && isStreamDropError(result.errorMessage);
+						if (isDrop && attempt < maxRetries && !signal?.aborted) {
 							shouldRetry = true;
-							retryError = result.errorMessage;
-						} else if (
-							result.stopReason === "error" &&
-							result.errorMessage &&
-							isStreamDropError(new Error(result.errorMessage))
-						) {
+							retryError =
+								result.errorMessage ?? "Stream ended without terminal event — connection likely dropped";
+						} else if (isDrop) {
 							// Final attempt exhausted — surface friendly message
 							return finalizeMessage(
 								createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")),
@@ -481,6 +481,7 @@ async function streamAssistantResponse(
 				attempt: attempt + 1,
 				maxAttempts: maxRetries,
 				error: retryError,
+				discardedPartial: clonePartialForDebug(),
 			});
 			await sleep(retryBaseDelay * 2 ** attempt, signal);
 			if (addedPartial) {
@@ -494,7 +495,6 @@ async function streamAssistantResponse(
 		return finalizeMessage(await response.result());
 	}
 
-	// All retries exhausted — surface the error
 	return finalizeMessage(createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")));
 }
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -260,6 +260,40 @@ async function runLoop(
 }
 
 /**
+ * Check if an error is a stream-drop error (connection dropped before terminal event).
+ * Only these errors trigger automatic retry — all other errors propagate as-is.
+ */
+function isStreamDropError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const msg = error.message;
+	return (
+		msg.includes("Stream ended without") ||
+		msg.includes("connection likely dropped")
+	);
+}
+
+/**
+ * Sleep for a duration, aborting early if the signal fires.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		if (signal?.aborted) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				resolve();
+			},
+			{ once: true },
+		);
+	});
+}
+
+/**
  * Stream an assistant response from the LLM.
  * This is where AgentMessage[] gets transformed to Message[] for the LLM.
  */
@@ -329,57 +363,121 @@ async function streamAssistantResponse(
 		timestamp: partialMessage?.timestamp ?? Date.now(),
 	});
 
-	let response: Awaited<ReturnType<StreamFn>>;
-	try {
-		response = await streamFunction(config.model, llmContext, {
-			...config,
-			apiKey: resolvedApiKey,
-			signal,
-		});
-	} catch (error) {
-		return finalizeMessage(createErrorMessage(error));
-	}
+	const maxRetries = config.streamRetries ?? 3;
+	const retryBaseDelay = config.streamRetryBaseDelayMs ?? 1000;
 
-	try {
-		for await (const event of response) {
-			switch (event.type) {
-				case "start":
-					partialMessage = event.partial;
-					context.messages.push(partialMessage);
-					addedPartial = true;
-					await emit({ type: "message_start", message: { ...partialMessage } });
-					break;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		let response: Awaited<ReturnType<StreamFn>>;
+		try {
+			response = await streamFunction(config.model, llmContext, {
+				...config,
+				apiKey: resolvedApiKey,
+				signal,
+			});
+		} catch (error) {
+			if (isStreamDropError(error) && attempt < maxRetries && !signal?.aborted) {
+				await emit({
+					type: "stream_retry",
+					attempt: attempt + 1,
+					maxAttempts: maxRetries,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				await sleep(retryBaseDelay * 2 ** attempt, signal);
+				if (addedPartial) {
+					context.messages.pop();
+					addedPartial = false;
+				}
+				partialMessage = null;
+				continue;
+			}
+			return finalizeMessage(createErrorMessage(error));
+		}
 
-				case "text_start":
-				case "text_delta":
-				case "text_end":
-				case "thinking_start":
-				case "thinking_delta":
-				case "thinking_end":
-				case "toolcall_start":
-				case "toolcall_delta":
-				case "toolcall_end":
-					if (partialMessage) {
+		let shouldRetry = false;
+		let retryError = "";
+		try {
+			for await (const event of response) {
+				switch (event.type) {
+					case "start":
 						partialMessage = event.partial;
-						context.messages[context.messages.length - 1] = partialMessage;
-						await emit({
-							type: "message_update",
-							assistantMessageEvent: event,
-							message: { ...partialMessage },
-						});
-					}
-					break;
+						context.messages.push(partialMessage);
+						addedPartial = true;
+						await emit({ type: "message_start", message: { ...partialMessage } });
+						break;
 
-				case "done":
-				case "error":
-					return finalizeMessage(await response.result());
+					case "text_start":
+					case "text_delta":
+					case "text_end":
+					case "thinking_start":
+					case "thinking_delta":
+					case "thinking_end":
+					case "toolcall_start":
+					case "toolcall_delta":
+					case "toolcall_end":
+						if (partialMessage) {
+							partialMessage = event.partial;
+							context.messages[context.messages.length - 1] = partialMessage;
+							await emit({
+								type: "message_update",
+								assistantMessageEvent: event,
+								message: { ...partialMessage },
+							});
+						}
+						break;
+
+					case "done":
+					case "error": {
+						const result = await response.result();
+						// Check if this is a stream-drop error that should be retried
+						if (
+							result.stopReason === "error" &&
+							result.errorMessage &&
+							isStreamDropError(new Error(result.errorMessage)) &&
+							attempt < maxRetries &&
+							!signal?.aborted
+						) {
+							shouldRetry = true;
+							retryError = result.errorMessage;
+						} else {
+							return finalizeMessage(result);
+						}
+						break;
+					}
+				}
+				if (shouldRetry) break;
+			}
+		} catch (error) {
+			if (isStreamDropError(error) && attempt < maxRetries && !signal?.aborted) {
+				shouldRetry = true;
+				retryError = error instanceof Error ? error.message : String(error);
+			} else {
+				return finalizeMessage(createErrorMessage(error));
 			}
 		}
-	} catch (error) {
-		return finalizeMessage(createErrorMessage(error));
+
+		if (shouldRetry) {
+			await emit({
+				type: "stream_retry",
+				attempt: attempt + 1,
+				maxAttempts: maxRetries,
+				error: retryError,
+			});
+			await sleep(retryBaseDelay * 2 ** attempt, signal);
+			if (addedPartial) {
+				context.messages.pop();
+				addedPartial = false;
+			}
+			partialMessage = null;
+			continue;
+		}
+
+		return finalizeMessage(await response.result());
 	}
 
-	return finalizeMessage(await response.result());
+	// All retries exhausted — surface the error
+	return finalizeMessage(
+		createErrorMessage(new Error("Stream dropped repeatedly — connection likely unstable")),
+	);
 }
 
 interface ToolExecutionResult {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -106,6 +106,18 @@ export interface AgentOptions {
 	/** Tool execution mode. Default: "parallel" */
 	toolExecution?: ToolExecutionMode;
 
+	/**
+	 * Maximum number of times to retry when a stream drops mid-response.
+	 * Default: 3
+	 */
+	streamRetries?: number;
+
+	/**
+	 * Base delay in milliseconds for exponential backoff between stream retries.
+	 * Default: 1000
+	 */
+	streamRetryBaseDelayMs?: number;
+
 	/** Called before a tool is executed, after arguments have been validated. */
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 
@@ -155,6 +167,8 @@ export class Agent {
 	private _thinkingBudgets?: ThinkingBudgets;
 	private _transport: Transport;
 	private _maxRetryDelayMs?: number;
+	private _streamRetries?: number;
+	private _streamRetryBaseDelayMs?: number;
 	private _toolExecution: ToolExecutionMode;
 	private _beforeToolCall?: (
 		context: BeforeToolCallContext,
@@ -180,6 +194,8 @@ export class Agent {
 		this._thinkingBudgets = opts.thinkingBudgets;
 		this._transport = opts.transport ?? "sse";
 		this._maxRetryDelayMs = opts.maxRetryDelayMs;
+		this._streamRetries = opts.streamRetries;
+		this._streamRetryBaseDelayMs = opts.streamRetryBaseDelayMs;
 		this._toolExecution = opts.toolExecution ?? "parallel";
 		this._beforeToolCall = opts.beforeToolCall;
 		this._shouldContinue = opts.shouldContinue;
@@ -556,6 +572,8 @@ export class Agent {
 			transport: this._transport,
 			thinkingBudgets: this._thinkingBudgets,
 			maxRetryDelayMs: this._maxRetryDelayMs,
+			streamRetries: this._streamRetries,
+			streamRetryBaseDelayMs: this._streamRetryBaseDelayMs,
 			onWarning: this._onWarning,
 			toolExecution: this._toolExecution,
 			beforeToolCall: this._beforeToolCall,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -202,6 +202,23 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	shouldContinue?: () => boolean;
 
 	/**
+	 * Maximum number of times to retry when a stream drops mid-response.
+	 * Retries only trigger on detected stream-drop errors (connection dropped before
+	 * the provider sent its terminal completion event). Other errors are not retried.
+	 *
+	 * Default: 3
+	 */
+	streamRetries?: number;
+
+	/**
+	 * Base delay in milliseconds for exponential backoff between stream retries.
+	 * Actual delay is `baseDelay * 2^attempt` (e.g., 1000, 2000, 4000).
+	 *
+	 * Default: 1000
+	 */
+	streamRetryBaseDelayMs?: number;
+
+	/**
 	 * Called before a tool is executed, after arguments have been validated.
 	 *
 	 * Return `{ block: true }` to prevent execution. The loop emits an error tool result instead.
@@ -325,4 +342,6 @@ export type AgentEvent =
 	// Tool execution lifecycle
 	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
-	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };
+	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean }
+	// Stream reliability
+	| { type: "stream_retry"; attempt: number; maxAttempts: number; error: string };

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -344,4 +344,11 @@ export type AgentEvent =
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
 	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean }
 	// Stream reliability
-	| { type: "stream_retry"; attempt: number; maxAttempts: number; error: string };
+	| {
+			type: "stream_retry";
+			attempt: number;
+			maxAttempts: number;
+			error: string;
+			/** Partial assistant message discarded before retry, for debugging/instrumentation only. */
+			discardedPartial?: AssistantMessage;
+	  };

--- a/packages/agent/test/stream-retry.test.ts
+++ b/packages/agent/test/stream-retry.test.ts
@@ -1,5 +1,6 @@
 import { type AssistantMessage, type AssistantMessageEvent, EventStream, type Message, type Model } from "@dreb/ai";
 import { describe, expect, it } from "vitest";
+import { Agent } from "../src/agent.js";
 import { agentLoop } from "../src/agent-loop.js";
 import type { AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.js";
 
@@ -129,13 +130,17 @@ function createNonRetryableStreamFn() {
 	};
 }
 
-async function collectEvents(streamFn: () => MockAssistantStream, config: AgentLoopConfig): Promise<AgentEvent[]> {
+async function collectEvents(
+	streamFn: () => MockAssistantStream,
+	config: AgentLoopConfig,
+	signal?: AbortSignal,
+): Promise<AgentEvent[]> {
 	const events: AgentEvent[] = [];
 	const loop = agentLoop(
 		[createPrompt("test")],
 		{ systemPrompt: "", messages: [], tools: [] },
 		config,
-		undefined,
+		signal,
 		streamFn as any,
 	);
 	for await (const event of loop) {
@@ -163,6 +168,10 @@ describe("stream retry on dropped connections", () => {
 			type: "stream_retry",
 			attempt: 1,
 			maxAttempts: 3,
+			error: "Stream ended without message_delta — connection likely dropped",
+			discardedPartial: {
+				content: [{ type: "thinking", thinking: "partial thinking..." }],
+			},
 		});
 
 		// Should have successfully completed (not errored)
@@ -273,6 +282,85 @@ describe("stream retry on dropped connections", () => {
 		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
 		if (lastMsgEnd.type === "message_end") {
 			expect((lastMsgEnd.message as AssistantMessage).stopReason).toBe("error");
+		}
+	});
+
+	it("forwards Agent stream retry options into the loop", async () => {
+		let attempts = 0;
+		const streamFn = () => {
+			attempts++;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const errorMsg = createAssistantMessage(
+					[{ type: "text", text: `partial ${attempts}` }],
+					"error",
+					"Stream ended without message_delta — connection likely dropped",
+				);
+				stream.push({ type: "start", partial: errorMsg });
+				stream.push({ type: "error", reason: "error", error: errorMsg });
+			});
+			return stream;
+		};
+		const agent = new Agent({
+			initialState: { model: createModel(), systemPrompt: "", tools: [] },
+			streamFn: streamFn as any,
+			streamRetries: 1,
+			streamRetryBaseDelayMs: 10,
+		});
+		const events: AgentEvent[] = [];
+		agent.subscribe((event) => events.push(event));
+
+		await agent.prompt("test");
+
+		expect(attempts).toBe(2);
+		expect(events.filter((e) => e.type === "stream_retry")).toHaveLength(1);
+		const messageEnd = events.findLast((e) => e.type === "message_end");
+		expect(messageEnd?.type).toBe("message_end");
+		if (messageEnd?.type === "message_end") {
+			expect((messageEnd.message as AssistantMessage).errorMessage).toContain("Stream dropped repeatedly");
+		}
+	});
+
+	it("aborts promptly during retry backoff", async () => {
+		const controller = new AbortController();
+		let attempts = 0;
+		const streamFn = (_model: Model<any>, _context: unknown, options?: { signal?: AbortSignal }) => {
+			attempts++;
+			if (options?.signal?.aborted) {
+				throw new Error("Request was aborted");
+			}
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const errorMsg = createAssistantMessage(
+					[{ type: "text", text: "partial before abort" }],
+					"error",
+					"Stream ended without message_delta — connection likely dropped",
+				);
+				stream.push({ type: "start", partial: errorMsg });
+				stream.push({ type: "error", reason: "error", error: errorMsg });
+			});
+			return stream;
+		};
+		setTimeout(() => controller.abort(), 20);
+
+		const events = await Promise.race([
+			collectEvents(
+				streamFn as any,
+				createConfig({
+					streamRetries: 3,
+					streamRetryBaseDelayMs: 5000,
+				}),
+				controller.signal,
+			),
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Timed out waiting for abort")), 1000)),
+		]);
+
+		expect(attempts).toBe(2);
+		expect(events.filter((e) => e.type === "stream_retry")).toHaveLength(1);
+		const messageEnd = events.findLast((e) => e.type === "message_end");
+		expect(messageEnd?.type).toBe("message_end");
+		if (messageEnd?.type === "message_end") {
+			expect((messageEnd.message as AssistantMessage).stopReason).toBe("aborted");
 		}
 	});
 });

--- a/packages/agent/test/stream-retry.test.ts
+++ b/packages/agent/test/stream-retry.test.ts
@@ -1,0 +1,273 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+} from "@dreb/ai";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.js";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.js";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+	errorMessage?: string,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason,
+		errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function createConfig(overrides: Partial<AgentLoopConfig> = {}): AgentLoopConfig {
+	return {
+		model: createModel(),
+		convertToLlm: (msgs: AgentMessage[]) => msgs as Message[],
+		...overrides,
+	};
+}
+
+function createPrompt(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Create a stream function that simulates stream drops (pushes an error event
+ * with a stream-drop error message) N times, then succeeds.
+ *
+ * This mirrors what actual providers do: detect the missing terminal event,
+ * set stopReason to "error", and push an error event to the stream.
+ */
+function createFailingStreamFn(failCount: number, successMessage: AssistantMessage) {
+	let attempts = 0;
+	return () => {
+		attempts++;
+		const stream = new MockAssistantStream();
+		if (attempts <= failCount) {
+			// Simulate provider detecting a stream drop:
+			// 1. Push start with partial content
+			// 2. Push error event (like providers do when terminal event is missing)
+			setTimeout(() => {
+				const errorMsg = createAssistantMessage(
+					[{ type: "thinking", thinking: "partial thinking..." }],
+					"error",
+					"Stream ended without message_delta — connection likely dropped",
+				);
+				stream.push({ type: "start", partial: errorMsg });
+				stream.push({ type: "error", reason: "error", error: errorMsg });
+				stream.end();
+			}, 0);
+		} else {
+			// Success
+			setTimeout(() => {
+				stream.push({ type: "start", partial: successMessage });
+				stream.push({ type: "done", reason: "stop", message: successMessage });
+				stream.end();
+			}, 0);
+		}
+		return stream;
+	};
+}
+
+/**
+ * Create a stream function that always fails with a non-retryable error.
+ */
+function createNonRetryableStreamFn() {
+	return () => {
+		const stream = new MockAssistantStream();
+		setTimeout(() => {
+			const errorMsg = createAssistantMessage(
+				[],
+				"error",
+				"401 Unauthorized — invalid API key",
+			);
+			stream.push({ type: "error", reason: "error", error: errorMsg });
+			stream.end();
+		}, 0);
+		return stream;
+	};
+}
+
+async function collectEvents(streamFn: () => MockAssistantStream, config: AgentLoopConfig): Promise<AgentEvent[]> {
+	const events: AgentEvent[] = [];
+	const loop = agentLoop(
+		[createPrompt("test")],
+		{ systemPrompt: "", messages: [], tools: [] },
+		config,
+		undefined,
+		streamFn as any,
+	);
+	for await (const event of loop) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("stream retry on dropped connections", () => {
+	it("retries on stream drop and succeeds on second attempt", async () => {
+		const successMsg = createAssistantMessage([{ type: "text", text: "Hello!" }]);
+		const streamFn = createFailingStreamFn(1, successMsg);
+		const events = await collectEvents(streamFn, createConfig({
+			streamRetries: 3,
+			streamRetryBaseDelayMs: 10,
+		}));
+
+		// Should have a stream_retry event
+		const retryEvents = events.filter((e) => e.type === "stream_retry");
+		expect(retryEvents).toHaveLength(1);
+		expect(retryEvents[0]).toMatchObject({
+			type: "stream_retry",
+			attempt: 1,
+			maxAttempts: 3,
+		});
+
+		// Should have successfully completed (not errored)
+		const endEvents = events.filter((e) => e.type === "agent_end");
+		expect(endEvents).toHaveLength(1);
+
+		// The final assistant message should have stopReason "stop", not "error"
+		const msgEndEvents = events.filter((e) => e.type === "message_end");
+		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
+		expect(lastMsgEnd.type).toBe("message_end");
+		if (lastMsgEnd.type === "message_end") {
+			const msg = lastMsgEnd.message as AssistantMessage;
+			expect(msg.stopReason).toBe("stop");
+			expect(msg.content).toEqual([{ type: "text", text: "Hello!" }]);
+		}
+	});
+
+	it("retries multiple times and eventually succeeds", async () => {
+		const successMsg = createAssistantMessage([{ type: "text", text: "Finally!" }]);
+		const streamFn = createFailingStreamFn(3, successMsg);
+		const events = await collectEvents(streamFn, createConfig({
+			streamRetries: 3,
+			streamRetryBaseDelayMs: 10,
+		}));
+
+		const retryEvents = events.filter((e) => e.type === "stream_retry");
+		expect(retryEvents).toHaveLength(3);
+		// Verify attempt numbers increment
+		expect(retryEvents.map((e) => e.type === "stream_retry" && e.attempt)).toEqual([1, 2, 3]);
+
+		// Final message should succeed
+		const msgEndEvents = events.filter((e) => e.type === "message_end");
+		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
+		if (lastMsgEnd.type === "message_end") {
+			expect((lastMsgEnd.message as AssistantMessage).stopReason).toBe("stop");
+		}
+	});
+
+	it("fails after exhausting all retries", async () => {
+		const successMsg = createAssistantMessage([{ type: "text", text: "never reached" }]);
+		const streamFn = createFailingStreamFn(4, successMsg);
+		const events = await collectEvents(streamFn, createConfig({
+			streamRetries: 3,
+			streamRetryBaseDelayMs: 10,
+		}));
+
+		// 3 retries, then the 4th failure is not retried
+		const retryEvents = events.filter((e) => e.type === "stream_retry");
+		expect(retryEvents).toHaveLength(3);
+
+		// Final message should be an error
+		const msgEndEvents = events.filter((e) => e.type === "message_end");
+		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
+		if (lastMsgEnd.type === "message_end") {
+			const msg = lastMsgEnd.message as AssistantMessage;
+			expect(msg.stopReason).toBe("error");
+			expect(msg.errorMessage).toContain("connection likely dropped");
+		}
+	});
+
+	it("does NOT retry non-stream-drop errors", async () => {
+		const streamFn = createNonRetryableStreamFn();
+		const events = await collectEvents(streamFn, createConfig({
+			streamRetries: 3,
+			streamRetryBaseDelayMs: 10,
+		}));
+
+		// No retry events
+		const retryEvents = events.filter((e) => e.type === "stream_retry");
+		expect(retryEvents).toHaveLength(0);
+
+		// Error surfaced immediately
+		const msgEndEvents = events.filter((e) => e.type === "message_end");
+		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
+		if (lastMsgEnd.type === "message_end") {
+			const msg = lastMsgEnd.message as AssistantMessage;
+			expect(msg.stopReason).toBe("error");
+			expect(msg.errorMessage).toContain("401 Unauthorized");
+		}
+	});
+
+	it("respects streamRetries: 0 to disable retries", async () => {
+		const successMsg = createAssistantMessage([{ type: "text", text: "never reached" }]);
+		const streamFn = createFailingStreamFn(1, successMsg);
+		const events = await collectEvents(streamFn, createConfig({
+			streamRetries: 0,
+			streamRetryBaseDelayMs: 10,
+		}));
+
+		// No retry events
+		const retryEvents = events.filter((e) => e.type === "stream_retry");
+		expect(retryEvents).toHaveLength(0);
+
+		// Error surfaced immediately
+		const msgEndEvents = events.filter((e) => e.type === "message_end");
+		const lastMsgEnd = msgEndEvents[msgEndEvents.length - 1];
+		if (lastMsgEnd.type === "message_end") {
+			expect((lastMsgEnd.message as AssistantMessage).stopReason).toBe("error");
+		}
+	});
+});

--- a/packages/agent/test/stream-retry.test.ts
+++ b/packages/agent/test/stream-retry.test.ts
@@ -1,13 +1,7 @@
-import {
-	type AssistantMessage,
-	type AssistantMessageEvent,
-	EventStream,
-	type Message,
-	type Model,
-} from "@dreb/ai";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, type Message, type Model } from "@dreb/ai";
 import { describe, expect, it } from "vitest";
 import { agentLoop } from "../src/agent-loop.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.js";
+import type { AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.js";
 
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
 	constructor() {
@@ -127,11 +121,7 @@ function createNonRetryableStreamFn() {
 	return () => {
 		const stream = new MockAssistantStream();
 		setTimeout(() => {
-			const errorMsg = createAssistantMessage(
-				[],
-				"error",
-				"401 Unauthorized — invalid API key",
-			);
+			const errorMsg = createAssistantMessage([], "error", "401 Unauthorized — invalid API key");
 			stream.push({ type: "error", reason: "error", error: errorMsg });
 			stream.end();
 		}, 0);
@@ -158,10 +148,13 @@ describe("stream retry on dropped connections", () => {
 	it("retries on stream drop and succeeds on second attempt", async () => {
 		const successMsg = createAssistantMessage([{ type: "text", text: "Hello!" }]);
 		const streamFn = createFailingStreamFn(1, successMsg);
-		const events = await collectEvents(streamFn, createConfig({
-			streamRetries: 3,
-			streamRetryBaseDelayMs: 10,
-		}));
+		const events = await collectEvents(
+			streamFn,
+			createConfig({
+				streamRetries: 3,
+				streamRetryBaseDelayMs: 10,
+			}),
+		);
 
 		// Should have a stream_retry event
 		const retryEvents = events.filter((e) => e.type === "stream_retry");
@@ -190,10 +183,13 @@ describe("stream retry on dropped connections", () => {
 	it("retries multiple times and eventually succeeds", async () => {
 		const successMsg = createAssistantMessage([{ type: "text", text: "Finally!" }]);
 		const streamFn = createFailingStreamFn(3, successMsg);
-		const events = await collectEvents(streamFn, createConfig({
-			streamRetries: 3,
-			streamRetryBaseDelayMs: 10,
-		}));
+		const events = await collectEvents(
+			streamFn,
+			createConfig({
+				streamRetries: 3,
+				streamRetryBaseDelayMs: 10,
+			}),
+		);
 
 		const retryEvents = events.filter((e) => e.type === "stream_retry");
 		expect(retryEvents).toHaveLength(3);
@@ -211,10 +207,13 @@ describe("stream retry on dropped connections", () => {
 	it("fails after exhausting all retries", async () => {
 		const successMsg = createAssistantMessage([{ type: "text", text: "never reached" }]);
 		const streamFn = createFailingStreamFn(4, successMsg);
-		const events = await collectEvents(streamFn, createConfig({
-			streamRetries: 3,
-			streamRetryBaseDelayMs: 10,
-		}));
+		const events = await collectEvents(
+			streamFn,
+			createConfig({
+				streamRetries: 3,
+				streamRetryBaseDelayMs: 10,
+			}),
+		);
 
 		// 3 retries, then the 4th failure is not retried
 		const retryEvents = events.filter((e) => e.type === "stream_retry");
@@ -226,16 +225,19 @@ describe("stream retry on dropped connections", () => {
 		if (lastMsgEnd.type === "message_end") {
 			const msg = lastMsgEnd.message as AssistantMessage;
 			expect(msg.stopReason).toBe("error");
-			expect(msg.errorMessage).toContain("connection likely dropped");
+			expect(msg.errorMessage).toContain("Stream dropped repeatedly");
 		}
 	});
 
 	it("does NOT retry non-stream-drop errors", async () => {
 		const streamFn = createNonRetryableStreamFn();
-		const events = await collectEvents(streamFn, createConfig({
-			streamRetries: 3,
-			streamRetryBaseDelayMs: 10,
-		}));
+		const events = await collectEvents(
+			streamFn,
+			createConfig({
+				streamRetries: 3,
+				streamRetryBaseDelayMs: 10,
+			}),
+		);
 
 		// No retry events
 		const retryEvents = events.filter((e) => e.type === "stream_retry");
@@ -254,10 +256,13 @@ describe("stream retry on dropped connections", () => {
 	it("respects streamRetries: 0 to disable retries", async () => {
 		const successMsg = createAssistantMessage([{ type: "text", text: "never reached" }]);
 		const streamFn = createFailingStreamFn(1, successMsg);
-		const events = await collectEvents(streamFn, createConfig({
-			streamRetries: 0,
-			streamRetryBaseDelayMs: 10,
-		}));
+		const events = await collectEvents(
+			streamFn,
+			createConfig({
+				streamRetries: 0,
+				streamRetryBaseDelayMs: 10,
+			}),
+		);
 
 		// No retry events
 		const retryEvents = events.filter((e) => e.type === "stream_retry");

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -112,6 +112,6 @@
 	"devDependencies": {
 		"@types/node": "^24.3.0",
 		"canvas": "^3.2.0",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.8"
 	}
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -167,6 +167,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 			const command = new ConverseStreamCommand(commandInput);
 
 			const response = await client.send(command, { abortSignal: options.signal });
+			let receivedMessageStop = false;
 
 			for await (const item of response.stream!) {
 				if (item.messageStart) {
@@ -181,6 +182,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				} else if (item.contentBlockStop) {
 					handleContentBlockStop(item.contentBlockStop, blocks, output, stream, options?.onWarning);
 				} else if (item.messageStop) {
+					receivedMessageStop = true;
 					output.stopReason = mapStopReason(item.messageStop.stopReason);
 				} else if (item.metadata) {
 					handleMetadata(item.metadata, model, output);
@@ -199,6 +201,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 
 			if (options.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!receivedMessageStop) {
+				throw new Error("Stream ended without messageStop — connection likely dropped");
 			}
 
 			if (output.stopReason === "error" || output.stopReason === "aborted") {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -258,6 +258,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			}
 			const anthropicStream = client.messages.stream({ ...params, stream: true }, { signal: options?.signal });
 			stream.push({ type: "start", partial: output });
+			let receivedMessageDelta = false;
 
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
@@ -394,6 +395,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 						}
 					}
 				} else if (event.type === "message_delta") {
+					receivedMessageDelta = true;
 					if (event.delta.stop_reason) {
 						output.stopReason = mapStopReason(event.delta.stop_reason);
 					}
@@ -420,6 +422,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!receivedMessageDelta) {
+				throw new Error("Stream ended without message_delta — connection likely dropped");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -504,6 +504,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 				}
 
 				let hasContent = false;
+				let receivedFinishReason = false;
 				let chunkParseErrors = 0;
 				let currentBlock: TextContent | ThinkingContent | null = null;
 				const blocks = output.content;
@@ -685,6 +686,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 							}
 
 							if (candidate?.finishReason) {
+								receivedFinishReason = true;
 								output.stopReason = mapStopReasonString(candidate.finishReason);
 								if (output.content.some((b) => b.type === "toolCall")) {
 									output.stopReason = "toolUse";
@@ -742,6 +744,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 							partial: output,
 						});
 					}
+				}
+
+				if (hasContent && !receivedFinishReason) {
+					throw new Error("Stream ended without finishReason — connection likely dropped");
 				}
 
 				return hasContent;

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -100,6 +100,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
+			let receivedFinishReason = false;
 			for await (const chunk of googleStream) {
 				// Vertex uses the same @google/genai GenerateContentResponse type as Gemini.
 				// responseId is documented there as an output-only identifier for each response.
@@ -217,6 +218,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 				}
 
 				if (candidate?.finishReason) {
+					receivedFinishReason = true;
 					output.stopReason = mapStopReason(candidate.finishReason);
 					if (output.content.some((b) => b.type === "toolCall")) {
 						output.stopReason = "toolUse";
@@ -264,6 +266,10 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!receivedFinishReason) {
+				throw new Error("Stream ended without finishReason — connection likely dropped");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -85,6 +85,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
+			let receivedFinishReason = false;
 			for await (const chunk of googleStream) {
 				// @google/genai documents GenerateContentResponse.responseId as an output-only field
 				// used to identify each response. Keep the first non-empty one from the stream.
@@ -203,6 +204,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 				}
 
 				if (candidate?.finishReason) {
+					receivedFinishReason = true;
 					output.stopReason = mapStopReason(candidate.finishReason);
 					if (output.content.some((b) => b.type === "toolCall")) {
 						output.stopReason = "toolUse";
@@ -250,6 +252,10 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!receivedFinishReason) {
+				throw new Error("Stream ended without finishReason — connection likely dropped");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -285,6 +285,7 @@ async function consumeChatStream(
 		}
 	};
 
+	let receivedFinishReason = false;
 	for await (const event of mistralStream) {
 		const chunk = event.data;
 		// Mistral's streamed CompletionChunk carries an id field. Keep the first non-empty one,
@@ -304,6 +305,7 @@ async function consumeChatStream(
 		if (!choice) continue;
 
 		if (choice.finishReason) {
+			receivedFinishReason = true;
 			output.stopReason = mapChatStopReason(choice.finishReason);
 		}
 
@@ -418,6 +420,10 @@ async function consumeChatStream(
 				partial: output,
 			});
 		}
+	}
+
+	if (!receivedFinishReason) {
+		throw new Error("Stream ended without finishReason — connection likely dropped");
 	}
 
 	finishCurrentBlock(currentBlock);

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -827,7 +827,8 @@ async function* parseWebSocket(
 			return;
 		}
 		if (!failed) {
-			failed = extractWebSocketCloseError(event);
+			const closeError = extractWebSocketCloseError(event);
+			failed = new Error(`WebSocket stream closed before response.completed (${closeError.message})`);
 		}
 		done = true;
 		wake();

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -126,6 +126,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 			};
 
+			let receivedFinishReason = false;
 			for await (const chunk of openaiStream) {
 				if (!chunk || typeof chunk !== "object") continue;
 
@@ -146,6 +147,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 
 				if (choice.finish_reason) {
+					receivedFinishReason = true;
 					const finishReasonResult = mapStopReason(choice.finish_reason);
 					output.stopReason = finishReasonResult.stopReason;
 					if (finishReasonResult.errorMessage) {
@@ -277,6 +279,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			finishCurrentBlock(currentBlock);
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!receivedFinishReason) {
+				throw new Error("Stream ended without finish_reason — connection likely dropped");
 			}
 
 			if (output.stopReason === "aborted") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -302,6 +302,7 @@ export async function processResponsesStream<TApi extends Api>(
 	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
+	let receivedResponseCompleted = false;
 
 	for await (const event of openaiStream) {
 		if (event.type === "response.created") {
@@ -467,6 +468,7 @@ export async function processResponsesStream<TApi extends Api>(
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
 		} else if (event.type === "response.completed") {
+			receivedResponseCompleted = true;
 			const response = event.response;
 			if (response?.id) {
 				output.responseId = response.id;
@@ -508,6 +510,10 @@ export async function processResponsesStream<TApi extends Api>(
 					: "Unknown error (no error details in response)";
 			throw new Error(msg);
 		}
+	}
+
+	if (!receivedResponseCompleted) {
+		throw new Error("Stream ended without response.completed — connection likely dropped");
 	}
 }
 

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -119,9 +119,9 @@ describe("Context overflow error handling", () => {
 	describe("GitHub Copilot (OAuth)", () => {
 		// OpenAI model via Copilot
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should detect overflow via isContextOverflow",
+			"gpt-4.1 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "gpt-4o");
+				const model = getModel("github-copilot", "gpt-4.1");
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -454,37 +454,37 @@ describe("AI Providers Empty Message Tests", () => {
 
 	describe("GitHub Copilot Provider Empty Messages", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty content array",
+			"gpt-4.1 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty string content",
+			"gpt-4.1 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle whitespace-only content",
+			"gpt-4.1 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle empty assistant message in conversation",
+			"gpt-4.1 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/google-stream-drop.test.ts
+++ b/packages/ai/test/google-stream-drop.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@google/genai", () => {
+	class GoogleGenAI {
+		models = {
+			generateContentStream: async function* () {
+				yield {
+					responseId: "google-response-id",
+					candidates: [{ content: { parts: [{ text: "partial" }] } }],
+					usageMetadata: {
+						promptTokenCount: 1,
+						candidatesTokenCount: 1,
+						totalTokenCount: 2,
+					},
+				};
+			},
+		};
+	}
+
+	return {
+		GoogleGenAI,
+		ThinkingLevel: {
+			THINKING_LEVEL_UNSPECIFIED: "THINKING_LEVEL_UNSPECIFIED",
+			MINIMAL: "MINIMAL",
+			LOW: "LOW",
+			MEDIUM: "MEDIUM",
+			HIGH: "HIGH",
+		},
+	};
+});
+
+import { streamGoogle } from "../src/providers/google.js";
+import type { Context, Model } from "../src/types.js";
+
+describe("google stream-drop detection", () => {
+	it("reports a retryable error when the stream ends without finishReason", async () => {
+		const model: Model<"google-generative-ai"> = {
+			id: "gemini-test",
+			name: "Gemini Test",
+			api: "google-generative-ai",
+			provider: "google",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+		};
+		const context: Context = {
+			systemPrompt: "You are helpful.",
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamGoogle(model, context, { apiKey: "test-key" }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Stream ended without finishReason");
+		expect(result.errorMessage).toContain("connection likely dropped");
+	});
+});

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -330,19 +330,19 @@ describe("Tool Results with Images", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle tool result with only image",
+			"gpt-4.1 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle tool result with text and image",
+			"gpt-4.1 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -185,6 +185,65 @@ describe("openai-codex streaming", () => {
 		expect(sawDone).toBe(true);
 	});
 
+	it("reports truncated SSE responses with a retryable stream-drop message", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const truncatedSse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+		].join("\n\n")}\n\n`;
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(truncatedSse));
+				controller.close();
+			},
+		});
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, { apiKey: token }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Stream ended without response.completed");
+		expect(result.errorMessage).toContain("connection likely dropped");
+	});
+
 	it("completes after response.completed even when the SSE body stays open", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-stream-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;

--- a/packages/ai/test/openai-codex-websocket.test.ts
+++ b/packages/ai/test/openai-codex-websocket.test.ts
@@ -192,6 +192,60 @@ describe("openai-codex WebSocket streaming", () => {
 		expect(onWarning).toHaveBeenCalledWith("ws_parse_error", expect.stringContaining("Malformed WebSocket message"));
 	});
 
+	it("reports pre-completion WebSocket closes with a retryable stream-drop message", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
+		process.env.DREB_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		let mockSocket: MockWebSocket | undefined;
+
+		(globalThis as { WebSocket?: unknown }).WebSocket = class extends MockWebSocket {
+			constructor(url: string, opts?: unknown) {
+				super(url, opts);
+				mockSocket = this;
+			}
+		};
+
+		global.fetch = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			return new Response("not found", { status: 404 });
+		}) as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, transport: "websocket" });
+		await vi.waitFor(() => {
+			if (!mockSocket) throw new Error("WebSocket not yet created");
+		});
+		await new Promise((r) => setTimeout(r, 10));
+		mockSocket!.emit("close", { code: 1006, reason: "network dropped" });
+
+		const result = await streamResult.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("WebSocket stream closed before response.completed");
+		expect(result.errorMessage).toContain("WebSocket closed 1006 network dropped");
+	});
+
 	it("uses delta context (previous_response_id) on follow-up WebSocket requests with the same sessionId", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "dreb-codex-ws-"));
 		process.env.DREB_CODING_AGENT_DIR = tempDir;

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -213,10 +213,10 @@ describe("Token Statistics on Abort", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should include token stats when aborted mid-stream",
+			"gpt-4.1 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -230,10 +230,10 @@ describe("Tool Call Without Result Tests", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should filter out tool calls without corresponding tool results",
+			"gpt-4.1 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "gpt-4o");
+				const model = getModel("github-copilot", "gpt-4.1");
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -510,10 +510,10 @@ describe("totalTokens field", () => {
 
 	describe("GitHub Copilot (OAuth)", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should return totalTokens equal to sum of components",
+			"gpt-4.1 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -473,7 +473,7 @@ describe("totalTokens field", () => {
 			"google/gemini-2.0-flash-001 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openrouter", "google/gemini-2.0-flash-001");
+				const llm = findModel("openrouter", "google/gemini-2.0-flash-001")!;
 
 				console.log(`\nOpenRouter / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.OPENROUTER_API_KEY });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -373,28 +373,28 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 
 	describe("GitHub Copilot Provider Unicode Handling", () => {
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle emoji in tool results",
+			"gpt-4.1 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle real-world LinkedIn comment data with emoji",
+			"gpt-4.1 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"gpt-4o - should handle unpaired high surrogate (0xD83D) in tool results",
+			"gpt-4.1 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4o");
+				const llm = getModel("github-copilot", "gpt-4.1");
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Added `sessionDir` setting support in global and project `settings.json` so session storage can be configured without passing `--session-dir` on every invocation ([#2598](https://github.com/badlogic/pi-mono/pull/2598) by [@smcllns](https://github.com/smcllns))
 - Added process-safe rate-limited queue for `web_search` tool — throttles rapid successive searches (including from parallel subagents) using `proper-lockfile` + timestamp file for cross-process coordination. Default minimum spacing is 10 seconds. Configurable via `DREB_WEB_SEARCH_RATE_LIMIT_MS` env var or `search.rate_limit_ms` in config file. Explore agents now have access to `web_search` and `web_fetch`. ([#180](https://github.com/aebrer/dreb/issues/180))
 
+- Subagent `cwd` parameter now accepts absolute paths in addition to relative paths. Relative paths are still resolved under the parent working directory and escaped via `../` guard. ([#228](https://github.com/aebrer/dreb/issues/228))
+- Added TUI handling for `stream_retry` events: stale streaming components are removed, a retry spinner with attempt count is shown, and `agent_end` unconditionally clears retry state. ([#230](https://github.com/aebrer/dreb/issues/230))
+- Added `stream_retry` to the extension event surface so extensions can observe and react to provider stream retries. ([#230](https://github.com/aebrer/dreb/issues/230))
 - Added `/dream` memory consolidation command — backs up all memory directories, merges duplicates, scans session history for unrecorded patterns, prunes stale entries, and validates links. Uses tar.gz archives with retention policy (keep last 10), lockfile-based concurrency protection, and a 10-step LLM pipeline with explicit backup verification. Configurable archive path via `dream.archivePath` setting. ([#99](https://github.com/aebrer/dreb/issues/99))
 
 ### Fixed

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -482,6 +482,17 @@ dreb.on("message_end", async (event, ctx) => {
 });
 ```
 
+#### stream_retry
+
+Fired when a provider stream drops before its terminal event and dreb discards the partial assistant response before retrying.
+
+```typescript
+dreb.on("stream_retry", async (event, ctx) => {
+  // event.attempt, event.maxAttempts, event.error
+  // event.discardedPartial - partial assistant message discarded before retry (debug/instrumentation only)
+});
+```
+
 #### tool_execution_start / tool_execution_update / tool_execution_end
 
 Fired for tool execution lifecycle updates.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -102,7 +102,7 @@
 		"@types/proper-lockfile": "^4.1.4",
 		"shx": "^0.4.0",
 		"typescript": "^5.7.3",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.8"
 	},
 	"keywords": [
 		"coding-agent",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -52,6 +52,7 @@ import {
 	type SessionBeforeSwitchResult,
 	type SessionBeforeTreeResult,
 	type ShutdownHandler,
+	type StreamRetryEvent,
 	type ToolDefinition,
 	type ToolExecutionEndEvent,
 	type ToolExecutionStartEvent,
@@ -989,6 +990,15 @@ export class AgentSession {
 			const extensionEvent: MessageEndEvent = {
 				type: "message_end",
 				message: event.message,
+			};
+			await this._extensionRunner.emit(extensionEvent);
+		} else if (event.type === "stream_retry") {
+			const extensionEvent: StreamRetryEvent = {
+				type: "stream_retry",
+				attempt: event.attempt,
+				maxAttempts: event.maxAttempts,
+				error: event.error,
+				discardedPartial: event.discardedPartial,
 			};
 			await this._extensionRunner.emit(extensionEvent);
 		} else if (event.type === "tool_execution_start") {

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -130,6 +130,7 @@ export type {
 	SetLabelHandler,
 	SetModelHandler,
 	SetThinkingLevelHandler,
+	StreamRetryEvent,
 	TerminalInputHandler,
 	// Events - Tool
 	ToolCallEvent,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -584,6 +584,16 @@ export interface MessageEndEvent {
 	message: AgentMessage;
 }
 
+/** Fired when a dropped stream is discarded and retried. */
+export interface StreamRetryEvent {
+	type: "stream_retry";
+	attempt: number;
+	maxAttempts: number;
+	error: string;
+	/** Partial assistant message discarded before retry, for debugging/instrumentation only. */
+	discardedPartial?: AgentMessage;
+}
+
 /** Fired when a tool starts executing */
 export interface ToolExecutionStartEvent {
 	type: "tool_execution_start";
@@ -854,6 +864,7 @@ export type ExtensionEvent =
 	| MessageStartEvent
 	| MessageUpdateEvent
 	| MessageEndEvent
+	| StreamRetryEvent
 	| ToolExecutionStartEvent
 	| ToolExecutionUpdateEvent
 	| ToolExecutionEndEvent
@@ -1013,6 +1024,7 @@ export interface ExtensionAPI {
 	on(event: "message_start", handler: ExtensionHandler<MessageStartEvent>): void;
 	on(event: "message_update", handler: ExtensionHandler<MessageUpdateEvent>): void;
 	on(event: "message_end", handler: ExtensionHandler<MessageEndEvent>): void;
+	on(event: "stream_retry", handler: ExtensionHandler<StreamRetryEvent>): void;
 	on(event: "tool_execution_start", handler: ExtensionHandler<ToolExecutionStartEvent>): void;
 	on(event: "tool_execution_update", handler: ExtensionHandler<ToolExecutionUpdateEvent>): void;
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -793,14 +793,15 @@ function bgRelease(): void {
 }
 
 /**
- * Resolve a per-task cwd relative to the parent cwd.
- * Rejects absolute paths and relative paths that escape the parent directory.
+ * Resolve a per-task cwd.
+ * Accepts absolute paths as-is. Resolves relative paths against the parent cwd,
+ * rejecting any that escape outside it.
  * Returns a result object with ok=false and an error string on rejection, so callers can surface it to the model.
  */
 function clampCwd(defaultCwd: string, itemCwd?: string): { ok: true; cwd: string } | { ok: false; error: string } {
 	if (!itemCwd) return { ok: true, cwd: defaultCwd };
 	if (itemCwd.startsWith("/")) {
-		return { ok: false, error: `Rejected absolute cwd "${itemCwd}" — must be relative to parent cwd` };
+		return { ok: true, cwd: itemCwd };
 	}
 	const resolved = resolve(defaultCwd, itemCwd);
 	if (resolved !== defaultCwd && !resolved.startsWith(`${defaultCwd}/`)) {
@@ -1043,7 +1044,12 @@ export interface SubagentToolOptions {
 const taskItemSchema = Type.Object({
 	agent: Type.Optional(Type.String({ description: "Agent type name (default: 'Explore')" })),
 	task: Type.String({ description: "The task prompt for this subagent" }),
-	cwd: Type.Optional(Type.String({ description: "Working directory (defaults to parent's cwd)" })),
+	cwd: Type.Optional(
+		Type.String({
+			description:
+				"Working directory (defaults to parent's cwd). Accepts absolute paths or relative paths within parent's cwd.",
+		}),
+	),
 	model: Type.Optional(
 		Type.String({
 			description:

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2400,6 +2400,12 @@ export class InteractiveMode {
 					this.updatePendingMessagesDisplay();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
+					// Defensive: remove stale streaming component if one exists (e.g. missed stream_retry)
+					if (this.streamingComponent) {
+						this.chatContainer.removeChild(this.streamingComponent);
+						this.streamingComponent = undefined;
+						this.streamingMessage = undefined;
+					}
 					this.streamingComponent = new AssistantMessageComponent(
 						undefined,
 						this.hideThinkingBlock,
@@ -2647,6 +2653,35 @@ export class InteractiveMode {
 				if (!event.success) {
 					this.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 				}
+				this.ui.requestRender();
+				break;
+			}
+
+			case "stream_retry": {
+				// Remove the ghost streaming component left from the dropped stream
+				if (this.streamingComponent) {
+					this.chatContainer.removeChild(this.streamingComponent);
+					this.streamingComponent = undefined;
+					this.streamingMessage = undefined;
+				}
+				// Clear any pending tool components from the failed partial
+				for (const [, component] of this.pendingTools.entries()) {
+					this.chatContainer.removeChild(component);
+				}
+				this.pendingTools.clear();
+				// Show retry status
+				this.statusContainer.clear();
+				if (this.loadingAnimation) {
+					this.loadingAnimation.stop();
+					this.loadingAnimation = undefined;
+				}
+				this.retryLoader = new Loader(
+					this.ui,
+					(spinner) => theme.fg("warning", spinner),
+					(text) => theme.fg("muted", text),
+					`Stream dropped, retrying (${event.attempt}/${event.maxAttempts})... (${keyText("app.interrupt")} to cancel)`,
+				);
+				this.statusContainer.addChild(this.retryLoader);
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2679,6 +2679,10 @@ export class InteractiveMode {
 					this.loadingAnimation.stop();
 					this.loadingAnimation = undefined;
 				}
+				if (this.retryLoader) {
+					this.retryLoader.stop();
+					this.retryLoader = undefined;
+				}
 				this.retryLoader = new Loader(
 					this.ui,
 					(spinner) => theme.fg("warning", spinner),

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2538,11 +2538,15 @@ export class InteractiveMode {
 			}
 
 			case "agent_end":
+				if (this.retryLoader) {
+					this.retryLoader.stop();
+					this.retryLoader = undefined;
+				}
 				if (this.loadingAnimation) {
 					this.loadingAnimation.stop();
 					this.loadingAnimation = undefined;
-					this.statusContainer.clear();
 				}
+				this.statusContainer.clear();
 				if (this.streamingComponent) {
 					this.chatContainer.removeChild(this.streamingComponent);
 					this.streamingComponent = undefined;

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -48,6 +48,11 @@ function createAssistantMessage(text: string, overrides?: Partial<AssistantMessa
 
 type SessionWithExtensionEmitHook = {
 	_emitExtensionEvent: (event: AgentEvent) => Promise<void>;
+	_extensionRunner?: {
+		hasHandlers: (eventType: string) => boolean;
+		emit: (event: { type: string; [key: string]: unknown }) => Promise<void>;
+		emitBeforeAgentStart: () => Promise<undefined>;
+	};
 };
 
 describe("AgentSession retry", () => {
@@ -197,6 +202,84 @@ describe("AgentSession retry", () => {
 		expect(callCount).toBe(2);
 		expect(events).toEqual(["start:1", "end:success=true"]);
 		expect(session.isRetrying).toBe(false);
+	});
+
+	it("forwards stream_retry events to extensions with the discarded partial", async () => {
+		let callCount = 0;
+		const model = findModel("anthropic", "sonnet")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamRetries: 1,
+			streamRetryBaseDelayMs: 1,
+			streamFn: () => {
+				callCount++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (callCount === 1) {
+						const msg = createAssistantMessage("partial", {
+							stopReason: "error",
+							errorMessage: "Stream ended without message_delta — connection likely dropped",
+						});
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "error", reason: "error", error: msg });
+						return;
+					}
+					const msg = createAssistantMessage("Success");
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "done", reason: "stop", message: msg });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		const extensionEvents: Array<{ type: string; [key: string]: unknown }> = [];
+		const sessionWithRunner = session as unknown as SessionWithExtensionEmitHook;
+		sessionWithRunner._extensionRunner = {
+			hasHandlers: () => false,
+			emit: async (event) => {
+				extensionEvents.push(event);
+			},
+			emitBeforeAgentStart: async () => undefined,
+		};
+
+		await session.prompt("Test");
+
+		expect(callCount).toBe(2);
+		expect(extensionEvents.map((event) => event.type)).toEqual([
+			"agent_start",
+			"turn_start",
+			"message_start",
+			"message_end",
+			"message_start",
+			"stream_retry",
+			"message_start",
+			"message_end",
+			"turn_end",
+			"agent_end",
+		]);
+		const streamRetry = extensionEvents.find((event) => event.type === "stream_retry");
+		expect(streamRetry).toMatchObject({
+			type: "stream_retry",
+			attempt: 1,
+			maxAttempts: 1,
+			error: "Stream ended without message_delta — connection likely dropped",
+			discardedPartial: { content: [{ type: "text", text: "partial" }] },
+		});
 	});
 
 	it("exhausts max retries and emits failure", async () => {

--- a/packages/coding-agent/test/subagent-background-parallel.test.ts
+++ b/packages/coding-agent/test/subagent-background-parallel.test.ts
@@ -3,10 +3,10 @@ import type { ExtensionContext } from "../src/core/extensions/types.js";
 import { createSubagentToolDefinition, getBackgroundAgents } from "../src/core/tools/subagent.js";
 
 /**
- * Tests for background parallel mode — specifically the skipped-task path
- * when tasks have invalid cwd values that fail clampCwd validation.
+ * Tests for background parallel mode — covering skipped-task paths (invalid relative
+ * escape cwd) and the acceptance of absolute cwd values.
  */
-describe("subagent background parallel — skipped tasks", () => {
+describe("subagent background parallel — cwd handling", () => {
 	const cwd = process.cwd();
 	const dummyCtx = {} as ExtensionContext;
 
@@ -17,15 +17,15 @@ describe("subagent background parallel — skipped tasks", () => {
 		});
 	}
 
-	it("should report skipped tasks when all tasks have invalid absolute cwd", async () => {
+	it("should accept absolute cwd values and launch tasks", async () => {
 		const tool = createTool();
 		const result = await tool.execute(
 			"call-1",
 			{
 				background: true,
 				tasks: [
-					{ task: "task one", cwd: "/tmp/evil" },
-					{ task: "task two", cwd: "/absolute/path" },
+					{ task: "task one", cwd: "/tmp" },
+					{ task: "task two", cwd: cwd }, // absolute path equal to parent cwd
 				],
 			},
 			undefined,
@@ -35,30 +35,42 @@ describe("subagent background parallel — skipped tasks", () => {
 
 		const text = result.content[0].type === "text" ? result.content[0].text : "";
 
-		// Should report 0 launched
-		expect(text).toContain("0 background agents started");
-		// Should report both tasks as failed to launch
-		expect(text).toContain("2 task(s) failed to launch");
-		expect(text).toContain("SKIPPED");
-		expect(text).toContain("task one");
-		expect(text).toContain("task two");
-		// Should NOT say "Each will notify" when nothing was launched
-		expect(text).not.toContain("Each will notify independently");
-		// Should say no agents launched
-		expect(text).toContain("No agents were launched");
-		// agentCount should be 0
-		expect(result.details).toEqual({ mode: "parallel", agentCount: 0 });
+		// Both tasks should launch — no skipped tasks
+		expect(text).toContain("2 background agents started");
+		expect(text).not.toContain("failed to launch");
+		expect(text).not.toContain("SKIPPED");
+		expect(result.details).toEqual({ mode: "parallel", agentCount: 2 });
 	});
 
-	it("should report mix of launched and skipped tasks", async () => {
+	it("should accept an absolute cwd pointing to a different project directory", async () => {
 		const tool = createTool();
 		const result = await tool.execute(
 			"call-2",
 			{
 				background: true,
+				tasks: [{ task: "investigate this project", cwd: "/tmp" }],
+			},
+			undefined,
+			undefined,
+			dummyCtx,
+		);
+
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("1 background agents started");
+		expect(text).not.toContain("SKIPPED");
+		expect(result.details).toEqual({ mode: "parallel", agentCount: 1 });
+	});
+
+	it("should report mix of launched and skipped tasks (relative escape is still rejected)", async () => {
+		const tool = createTool();
+		const result = await tool.execute(
+			"call-3",
+			{
+				background: true,
 				tasks: [
 					{ task: "valid task" }, // no cwd override, uses default — should succeed
-					{ task: "invalid task", cwd: "/absolute/path" }, // should be skipped
+					{ task: "invalid task", cwd: "../../../../../../etc" }, // relative escape — should be skipped
 				],
 			},
 			undefined,
@@ -81,7 +93,7 @@ describe("subagent background parallel — skipped tasks", () => {
 	it("should report escape-cwd tasks as skipped", async () => {
 		const tool = createTool();
 		const result = await tool.execute(
-			"call-3",
+			"call-4",
 			{
 				background: true,
 				tasks: [{ task: "escape attempt", cwd: "../../../../../../etc" }],
@@ -103,7 +115,7 @@ describe("subagent background parallel — skipped tasks", () => {
 	it("should register inherited agent type in background agent registry", async () => {
 		const tool = createTool();
 		const result = await tool.execute(
-			"call-4",
+			"call-5",
 			{
 				agent: "feature-dev",
 				tasks: [{ task: "valid task with inherited agent" }],
@@ -126,7 +138,7 @@ describe("subagent background parallel — skipped tasks", () => {
 	it("should show inherited agent type in launch listing", async () => {
 		const tool = createTool();
 		const result = await tool.execute(
-			"call-5",
+			"call-6",
 			{
 				agent: "feature-dev",
 				tasks: [{ task: "task one" }, { task: "task two" }],

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -52,7 +52,7 @@
 		"shx": "^0.4.0",
 		"tree-sitter-gdscript": "^6.1.0",
 		"typescript": "^5.9.2",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.8"
 	},
 	"keywords": [
 		"semantic-search",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -36,7 +36,7 @@
 	"devDependencies": {
 		"@types/node": "^24.3.0",
 		"typescript": "^5.9.2",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.8"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/telegram/test/bridge-lifecycle.test.ts
+++ b/packages/telegram/test/bridge-lifecycle.test.ts
@@ -65,7 +65,8 @@ describe("ensureBridge", () => {
 	it("creates a new bridge when none exists, using config.workingDir", async () => {
 		const userState = createUserState();
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockImplementation((cfg: Config) => {
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function (cfg: Config) {
 			mockBridge._config = cfg;
 			return mockBridge;
 		});
@@ -83,7 +84,8 @@ describe("ensureBridge", () => {
 		const deadBridge = createMockBridge({ isAlive: false });
 		const userState = createUserState({ bridge: deadBridge as any });
 		const freshBridge = createMockBridge();
-		MockAgentBridge.mockImplementation((cfg: Config) => {
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function (cfg: Config) {
 			freshBridge._config = cfg;
 			return freshBridge;
 		});
@@ -110,7 +112,8 @@ describe("ensureBridge", () => {
 	it("overrides config.workingDir with effectiveCwd when set and different", async () => {
 		const userState = createUserState({ effectiveCwd: "/custom/dir" });
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockImplementation((cfg: Config) => {
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function (cfg: Config) {
 			mockBridge._config = cfg;
 			return mockBridge;
 		});
@@ -123,7 +126,8 @@ describe("ensureBridge", () => {
 	it("uses config.workingDir when effectiveCwd matches it", async () => {
 		const userState = createUserState({ effectiveCwd: "/default/dir" });
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockImplementation((cfg: Config) => {
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function (cfg: Config) {
 			mockBridge._config = cfg;
 			return mockBridge;
 		});
@@ -137,7 +141,10 @@ describe("ensureBridge", () => {
 	it("wires up background_agent_start event handler", async () => {
 		const userState = createUserState();
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockReturnValue(mockBridge);
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function () {
+			return mockBridge;
+		});
 
 		await ensureBridge(config, userState);
 
@@ -158,7 +165,10 @@ describe("ensureBridge", () => {
 	it("wires up background_agent_end event handler", async () => {
 		const userState = createUserState();
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockReturnValue(mockBridge);
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function () {
+			return mockBridge;
+		});
 
 		await ensureBridge(config, userState);
 
@@ -175,7 +185,10 @@ describe("ensureBridge", () => {
 	it("ignores unrelated event types", async () => {
 		const userState = createUserState();
 		const mockBridge = createMockBridge();
-		MockAgentBridge.mockReturnValue(mockBridge);
+		// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+		MockAgentBridge.mockImplementation(function () {
+			return mockBridge;
+		});
 
 		await ensureBridge(config, userState);
 
@@ -205,7 +218,8 @@ describe("ensureBridgeWithSession", () => {
 				effectiveCwd: "/old/dir",
 			});
 
-			MockAgentBridge.mockImplementation((cfg: Config) => {
+			// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+			MockAgentBridge.mockImplementation(function (cfg: Config) {
 				newBridge._config = cfg;
 				return newBridge;
 			});
@@ -236,7 +250,8 @@ describe("ensureBridgeWithSession", () => {
 				effectiveCwd: "/prev/dir",
 			});
 
-			MockAgentBridge.mockImplementation((cfg: Config) => {
+			// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+			MockAgentBridge.mockImplementation(function (cfg: Config) {
 				newBridge._config = cfg;
 				return newBridge;
 			});
@@ -263,7 +278,8 @@ describe("ensureBridgeWithSession", () => {
 				effectiveCwd: null,
 			});
 
-			MockAgentBridge.mockImplementation((cfg: Config) => {
+			// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+			MockAgentBridge.mockImplementation(function (cfg: Config) {
 				newBridge._config = cfg;
 				return newBridge;
 			});
@@ -282,7 +298,8 @@ describe("ensureBridgeWithSession", () => {
 			const mockBridge = createMockBridge({ sessionId: undefined });
 			const userState = createUserState();
 
-			MockAgentBridge.mockImplementation((cfg: Config) => {
+			// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+			MockAgentBridge.mockImplementation(function (cfg: Config) {
 				mockBridge._config = cfg;
 				return mockBridge;
 			});
@@ -338,7 +355,10 @@ describe("ensureBridgeWithSession", () => {
 				newSessionCwd: "/custom/path",
 			});
 
-			MockAgentBridge.mockReturnValue(newBridge);
+			// biome-ignore lint/complexity/useArrowFunction: vitest v4 requires function keyword for constructor mocks
+			MockAgentBridge.mockImplementation(function () {
+				return newBridge;
+			});
 
 			await ensureBridgeWithSession(config, userState);
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.21.1",
+	"version": "2.22.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/scripts/verify-git-hooks.js
+++ b/scripts/verify-git-hooks.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const EXPECTED_HOOKS_PATH = ".husky/_";
+
+function git(args) {
+	try {
+		return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+	} catch {
+		return undefined;
+	}
+}
+
+if (process.env.CI) {
+	console.log("Skipping git hook verification in CI.");
+	process.exit(0);
+}
+
+const gitDir = git(["rev-parse", "--git-dir"]);
+if (!gitDir || !existsSync(gitDir)) {
+	console.log("Skipping git hook verification outside a git checkout.");
+	process.exit(0);
+}
+
+const hooksPath = git(["config", "--local", "--get", "core.hooksPath"]);
+if (hooksPath !== EXPECTED_HOOKS_PATH) {
+	console.error(`Git hooks are not installed for this checkout: core.hooksPath is ${JSON.stringify(hooksPath ?? "")}.`);
+	console.error(`Expected ${JSON.stringify(EXPECTED_HOOKS_PATH)} so .husky/pre-commit runs before commits.`);
+	console.error("Run `npm run prepare` from the repository root to install Husky hooks.");
+	process.exit(1);
+}
+
+console.log(`Git hooks installed (${EXPECTED_HOOKS_PATH}).`);


### PR DESCRIPTION
Closes #228
Also addresses #230

Remove the blanket absolute-path rejection from `clampCwd()` in the `subagent` tool. Absolute paths that exist are now accepted as-is; relative paths continue to resolve against the parent cwd. The relative-escape guard (`../../etc`) is preserved.

Additionally fixes silent stream drop handling in Anthropic and Bedrock providers — detected during review when subagents "completed" with empty output due to dropped connections being reported as clean completions.

Implementation plan posted as a comment below.
