### PR TITLE
Fix spurious search warning and conflated abort message in background subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See the full coding-agent docs in [packages/coding-agent](packages/coding-agent/
 
 ### Tools and interaction
 
-dreb ships with 11 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, and `wait`. Three more tools are always active: `search` for semantic codebase search, `skill` for loading workflows, and `tasks_update` for visible task tracking. `suggest_next` (ghost text command suggestions, Tab to accept) is active by default but excluded when `--tools` is specified.
+dreb ships with 12 built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `wait`, and `search` (semantic codebase search). Two more tools are always active: `skill` for loading workflows, and `tasks_update` for visible task tracking. `suggest_next` (ghost text command suggestions, Tab to accept) is active by default but excluded when `--tools` is specified.
 
 Interactive mode adds slash commands such as `/model`, `/settings`, `/resume`, `/tree`, `/fork`, `/compact`, `/dream`, `/buddy`, `/export`, `/reload`, `/hotkeys`, and `/changelog`. The message queue lets you steer a running agent or queue follow-up work without waiting for the current turn to finish.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8436,7 +8436,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8725,7 +8725,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9041,7 +9041,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9416,7 +9416,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9725,7 +9725,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -10017,7 +10017,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.22.0",
+			"version": "2.22.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -598,10 +598,9 @@ cat README.md | dreb -p "Summarize this text"
 | `--tools <list>` | Comma-separated list of tools to enable (default: all) |
 | `--no-tools` | Disable all built-in tools (extension tools still work) |
 
-Available built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `wait`
+Available built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, `web_search`, `web_fetch`, `subagent`, `wait`, `search`
 
-Four additional tools are always active but don't appear in `--tools`:
-- `search` — [semantic codebase search](#semantic-search) using natural language queries
+Three additional tools are always active but don't appear in `--tools`:
 - `skill` — invokes [skills](#skills) programmatically
 - `tasks_update` — session [task tracking](#task-tracking) with TUI panel
 - `suggest_next` — suggests a next command shown as ghost text (Tab to accept)

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -220,7 +220,7 @@ ${chalk.bold("Options:")}
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching
   --no-tools                     Disable all built-in tools
   --tools <tools>                Comma-separated list of tools to enable (default: all)
-                                 Available: read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent, wait
+                                 Available: read, bash, edit, write, grep, find, ls, web_search, web_fetch, subagent, wait, search
   --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
@@ -328,5 +328,6 @@ ${chalk.bold("Available Tools (default: all):")}
   web_fetch  - Fetch URL content
   subagent   - Delegate tasks to independent subagents
   wait       - Do nothing and end your turn (explicit no-op)
+  search     - Semantic codebase search using natural language
 `);
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -620,7 +620,7 @@ export class AgentSession {
 		if (cancelled) {
 			parts.push("This agent was cancelled by the user.");
 		}
-		if (result.exitCode !== 0) {
+		if (!cancelled && result.exitCode !== 0) {
 			parts.push(`Error: ${result.errorMessage || "unknown"}`);
 		}
 		if (result.output) {

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -68,6 +68,8 @@ export {
 	isSearchAvailable,
 	type SearchToolDetails,
 	type SearchToolInput,
+	searchTool,
+	searchToolDefinition,
 } from "./search.js";
 export {
 	createSkillTool,
@@ -172,7 +174,7 @@ import {
 	readTool,
 	readToolDefinition,
 } from "./read.js";
-import { createSearchTool, createSearchToolDefinition, isSearchAvailable } from "./search.js";
+import { createSearchTool, createSearchToolDefinition, searchTool, searchToolDefinition } from "./search.js";
 import { createSkillTool, createSkillToolDefinition, type SkillToolOptions } from "./skill.js";
 import {
 	createSubagentTool,
@@ -222,6 +224,7 @@ export const allTools = {
 	subagent: subagentTool,
 	tmp_read: tmpReadTool,
 	wait: waitTool,
+	search: searchTool,
 };
 
 export const allToolDefinitions = {
@@ -237,6 +240,7 @@ export const allToolDefinitions = {
 	subagent: subagentToolDefinition,
 	tmp_read: tmpReadToolDefinition,
 	wait: waitToolDefinition,
+	search: searchToolDefinition,
 };
 
 export type ToolName = keyof typeof allTools;
@@ -282,10 +286,8 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 		subagent: createSubagentToolDefinition(cwd, options?.subagent),
 		tmp_read: createTmpReadToolDefinition(options?.read),
 		wait: createWaitToolDefinition({ getRunningAgents: getRunningBackgroundAgents }),
+		search: createSearchToolDefinition(cwd),
 	};
-	if (isSearchAvailable()) {
-		tools.search = createSearchToolDefinition(cwd);
-	}
 	if (options?.skill) {
 		tools.skill = createSkillToolDefinition(cwd, options.skill);
 	}
@@ -325,10 +327,8 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 		subagent: createSubagentTool(cwd, options?.subagent),
 		tmp_read: wrapToolDefinition(createTmpReadToolDefinition(options?.read)),
 		wait: wrapToolDefinition(createWaitToolDefinition({ getRunningAgents: getRunningBackgroundAgents })),
+		search: createSearchTool(cwd),
 	};
-	if (isSearchAvailable()) {
-		tools.search = createSearchTool(cwd);
-	}
 	if (options?.skill) {
 		tools.skill = createSkillTool(cwd, options.skill);
 	}

--- a/packages/coding-agent/src/core/tools/search.ts
+++ b/packages/coding-agent/src/core/tools/search.ts
@@ -254,3 +254,7 @@ export function createSearchToolDefinition(cwd: string): ToolDefinition<typeof s
 export function createSearchTool(cwd: string): AgentTool<typeof searchSchema> {
 	return wrapToolDefinition(createSearchToolDefinition(cwd));
 }
+
+/** Default search tool using process.cwd() for backwards compatibility. */
+export const searchToolDefinition = createSearchToolDefinition(process.cwd());
+export const searchTool = createSearchTool(process.cwd());

--- a/packages/coding-agent/test/agent-session-guardrails.test.ts
+++ b/packages/coding-agent/test/agent-session-guardrails.test.ts
@@ -490,6 +490,59 @@ describe("AgentSession background agent guardrails", () => {
 
 			promptSpy.mockRestore();
 		});
+
+		it("does not include error message when agent is cancelled by user (even with exitCode !== 0)", () => {
+			const sessionAny = session as any;
+			const appendSpy = vi.spyOn(agent, "appendMessage");
+
+			sessionAny._handleBackgroundComplete(
+				"bg-aborted",
+				{
+					agent: "test",
+					task: "test task",
+					exitCode: 1,
+					output: "",
+					stderr: "Warning: Unknown tool search.",
+					errorMessage: "Warning: Unknown tool search.",
+				},
+				true, // cancelled = true (user pressed ESC)
+			);
+
+			expect(appendSpy).toHaveBeenCalledTimes(1);
+			const msg = appendSpy.mock.calls[0][0] as any;
+			const text = msg.content[0].text;
+			expect(text).toContain("cancelled by the user");
+			expect(text).not.toContain("Error:");
+			expect(text).not.toContain("Unknown tool search");
+
+			appendSpy.mockRestore();
+		});
+
+		it("still shows error message for non-cancelled agents that fail", () => {
+			const sessionAny = session as any;
+			const promptSpy = vi.spyOn(agent, "prompt").mockResolvedValue(undefined as any);
+
+			sessionAny._handleBackgroundComplete(
+				"bg-failed",
+				{
+					agent: "test",
+					task: "test task",
+					exitCode: 1,
+					output: "",
+					stderr: "some real error",
+					errorMessage: "some real error",
+				},
+				false, // NOT cancelled — genuine failure
+			);
+
+			expect(promptSpy).toHaveBeenCalledTimes(1);
+			const promptMsg = promptSpy.mock.calls[0][0] as any;
+			const text = promptMsg.content[0].text;
+			expect(text).toContain("Error: some real error");
+			expect(text).not.toContain("cancelled by the user");
+
+			promptSpy.mockRestore();
+		});
 	});
 
 	describe("Guardrail cleanup on dispose", () => {

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -7,7 +7,7 @@ import { bashTool, createBashTool, createLocalBashOperations } from "../src/core
 import { editTool } from "../src/core/tools/edit.js";
 import { createFindTool, findTool } from "../src/core/tools/find.js";
 import { createGrepTool, type GrepOperations, grepTool } from "../src/core/tools/grep.js";
-import { allToolDefinitions, allTools } from "../src/core/tools/index.js";
+import { allToolDefinitions, allTools, createAllToolDefinitions, createAllTools } from "../src/core/tools/index.js";
 import { lsTool } from "../src/core/tools/ls.js";
 import { readTool } from "../src/core/tools/read.js";
 import { writeTool } from "../src/core/tools/write.js";
@@ -937,5 +937,15 @@ describe("allTools / allToolDefinitions", () => {
 		const tool = allTools.search;
 		expect(typeof tool.execute).toBe("function");
 		expect(tool.name).toBe("search");
+	});
+
+	it("createAllToolDefinitions includes search unconditionally", () => {
+		const tools = createAllToolDefinitions("/tmp");
+		expect(tools.search).toBeDefined();
+	});
+
+	it("createAllTools includes search unconditionally", () => {
+		const tools = createAllTools("/tmp");
+		expect(tools.search).toBeDefined();
 	});
 });

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -7,6 +7,7 @@ import { bashTool, createBashTool, createLocalBashOperations } from "../src/core
 import { editTool } from "../src/core/tools/edit.js";
 import { createFindTool, findTool } from "../src/core/tools/find.js";
 import { createGrepTool, type GrepOperations, grepTool } from "../src/core/tools/grep.js";
+import { allToolDefinitions, allTools } from "../src/core/tools/index.js";
 import { lsTool } from "../src/core/tools/ls.js";
 import { readTool } from "../src/core/tools/read.js";
 import { writeTool } from "../src/core/tools/write.js";
@@ -918,5 +919,23 @@ describe("edit tool CRLF handling", () => {
 
 		const content = readFileSync(testFile, "utf-8");
 		expect(content).toBe("\uFEFFfirst\r\nREPLACED\r\nthird\r\n");
+	});
+});
+
+describe("allTools / allToolDefinitions", () => {
+	it("includes search in allTools", () => {
+		expect("search" in allTools).toBe(true);
+		expect(allTools.search).toBeDefined();
+	});
+
+	it("includes search in allToolDefinitions", () => {
+		expect("search" in allToolDefinitions).toBe(true);
+		expect(allToolDefinitions.search).toBeDefined();
+	});
+
+	it("allTools.search has expected tool shape", () => {
+		const tool = allTools.search;
+		expect(typeof tool.execute).toBe("function");
+		expect(tool.name).toBe("search");
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #211

Fix two related UX bugs triggered by background subagent aborts:
1. `search` is not in `allTools`, so `--tools search` triggers a spurious warning that surfaces in abort output
2. `_handleBackgroundComplete` shows stderr error noise alongside "cancelled by user", conflating abort with failure

Implementation plan posted as a comment below.
