### PR TITLE
Copy selector modal for /copy command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8436,7 +8436,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8725,7 +8725,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9041,7 +9041,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9416,7 +9416,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9725,7 +9725,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -10017,7 +10017,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.22.1",
+			"version": "2.23.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,11 +30,15 @@
 - Added process-safe rate-limited queue for `web_search` tool — throttles rapid successive searches (including from parallel subagents) using `proper-lockfile` + timestamp file for cross-process coordination. Default minimum spacing is 10 seconds. Configurable via `DREB_WEB_SEARCH_RATE_LIMIT_MS` env var or `search.rate_limit_ms` in config file. Explore agents now have access to `web_search` and `web_fetch`. ([#180](https://github.com/aebrer/dreb/issues/180))
 
 - Subagent `cwd` parameter now accepts absolute paths in addition to relative paths. Relative paths are still resolved under the parent working directory and escaped via `../` guard. ([#228](https://github.com/aebrer/dreb/issues/228))
+
+- `/copy` now opens a multi-select message picker instead of copying only the last assistant message. All message types are listed (user, assistant, tool results, bash executions, branch/compaction summaries, custom). Navigate with arrow keys, toggle selection with Space, select-all with Ctrl+A, confirm with Enter. Copies source text without wrap-induced line breaks. Status message distinguishes between native clipboard and OSC 52 (SSH/mosh) delivery. New `app.clipboard.copyMessages` keybinding (Ctrl+Shift+C) opens the picker directly. ([#217](https://github.com/aebrer/dreb/issues/217))
 - Added TUI handling for `stream_retry` events: stale streaming components are removed, a retry spinner with attempt count is shown, and `agent_end` unconditionally clears retry state. ([#230](https://github.com/aebrer/dreb/issues/230))
 - Added `stream_retry` to the extension event surface so extensions can observe and react to provider stream retries. ([#230](https://github.com/aebrer/dreb/issues/230))
 - Added `/dream` memory consolidation command — backs up all memory directories, merges duplicates, scans session history for unrecorded patterns, prunes stale entries, and validates links. Uses tar.gz archives with retention policy (keep last 10), lockfile-based concurrency protection, and a 10-step LLM pipeline with explicit backup verification. Configurable archive path via `dream.archivePath` setting. ([#99](https://github.com/aebrer/dreb/issues/99))
 
 ### Fixed
+
+- Fixed ghost whitespace appearing after the TUI content shrinks (e.g., closing the copy selector, filtering slash-command autocomplete, editor line deletion). The differential renderer now triggers a full screen redraw when content shrinks instead of clearing extra lines individually, which some terminals would not collapse. ([#217](https://github.com/aebrer/dreb/issues/217))
 
 - Added missing `ajv` direct dependency; previously relied on transitive install via `@mariozechner/pi-ai` which broke standalone installs ([#2252](https://github.com/badlogic/pi-mono/issues/2252))
 - Fixed `/export` HTML backgrounds to honor `theme.export.pageBg`, `cardBg`, and `infoBg` instead of always deriving them from `userMessageBg` ([#2565](https://github.com/badlogic/pi-mono/issues/2565))

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -165,7 +165,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/tree` | Jump to any point in the session and continue from there |
 | `/fork` | Create a new session from the current branch |
 | `/compact [prompt]` | Manually compact context, optional custom instructions |
-| `/copy` | Copy last assistant message to clipboard |
+| `/copy` | Open multi-select message picker to copy any messages to clipboard |
 | `/dream` | Consolidate and prune memories — backs up, merges duplicates, scans sessions for patterns |
 | `/export [file]` | Export session to HTML file |
 | `/buddy` | Terminal companion — hatch, pet, reroll, set model, or hide. See [docs/buddy.md](docs/buddy.md) |

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -88,6 +88,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.suspend` | `ctrl+z` | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
+| `app.clipboard.copyMessages` | `ctrl+shift+c` | Open copy message selector |
 | `app.tasks.toggle` | *(none)* | Toggle task tracking panel visibility |
 
 ### Sessions

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -26,6 +26,7 @@ export interface AppKeybindings {
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
+	"app.clipboard.copyMessages": true;
 	"app.session.new": true;
 	"app.session.tree": true;
 	"app.session.fork": true;
@@ -89,6 +90,10 @@ export const KEYBINDINGS = {
 	"app.clipboard.pasteImage": {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard",
+	},
+	"app.clipboard.copyMessages": {
+		defaultKeys: "ctrl+shift+c",
+		description: "Open copy message selector",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },
 	"app.session.tree": { defaultKeys: [], description: "Open session tree" },

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -342,7 +342,7 @@ export {
 	type ThemeColor,
 } from "./modes/interactive/theme/theme.js";
 // Clipboard utilities
-export { copyToClipboard } from "./utils/clipboard.js";
+export { type ClipboardResult, copyToClipboard } from "./utils/clipboard.js";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.js";
 // Shell utilities
 export { getShellConfig } from "./utils/shell.js";

--- a/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
@@ -15,13 +15,14 @@ class CopyMessageList implements Component {
 	private items: CopyMessageItem[];
 	private selectedIndex: number; // cursor position
 	private selected: Set<number>; // set of selected item array positions
-	private maxVisible: number = 15;
+	private maxVisible: number;
 
 	public onCopy?: (selectedIndices: number[]) => void;
 	public onCancel?: () => void;
 
-	constructor(items: CopyMessageItem[]) {
+	constructor(items: CopyMessageItem[], maxVisible: number = 15) {
 		this.items = items;
+		this.maxVisible = maxVisible;
 		// Bottom-anchored: start at the last (most recent) item
 		this.selectedIndex = Math.max(0, items.length - 1);
 		this.selected = new Set();
@@ -142,7 +143,12 @@ class CopyMessageList implements Component {
 export class CopySelectorComponent extends Container {
 	private messageList: CopyMessageList;
 
-	constructor(items: CopyMessageItem[], onCopy: (selectedIndices: number[]) => void, onCancel: () => void) {
+	constructor(
+		items: CopyMessageItem[],
+		onCopy: (selectedIndices: number[]) => void,
+		onCancel: () => void,
+		maxVisible?: number,
+	) {
 		super();
 
 		// Add header
@@ -156,7 +162,7 @@ export class CopySelectorComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Create message list
-		this.messageList = new CopyMessageList(items);
+		this.messageList = new CopyMessageList(items, maxVisible);
 		this.messageList.onCopy = onCopy;
 		this.messageList.onCancel = onCancel;
 		this.addChild(this.messageList);

--- a/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
@@ -17,7 +17,7 @@ class CopyMessageList implements Component {
 	private selected: Set<number>; // set of selected item array positions
 	private maxVisible: number;
 
-	public onCopy?: (selectedIndices: number[]) => void;
+	public onCopy?: (selectedIndices: number[]) => void | Promise<void>;
 	public onCancel?: () => void;
 
 	constructor(items: CopyMessageItem[], maxVisible: number = 15) {
@@ -129,7 +129,12 @@ class CopyMessageList implements Component {
 				const selectedIndices = Array.from(this.selected)
 					.map((i) => this.items[i].index)
 					.sort((a, b) => a - b);
-				this.onCopy(selectedIndices);
+				const result = this.onCopy(selectedIndices);
+				if (result instanceof Promise) {
+					result.catch(() => {
+						// Errors from the async copy callback are handled by the caller
+					});
+				}
 			}
 		}
 		// Escape/Ctrl+C - cancel
@@ -149,7 +154,7 @@ export class CopySelectorComponent extends Container {
 
 	constructor(
 		items: CopyMessageItem[],
-		onCopy: (selectedIndices: number[]) => void,
+		onCopy: (selectedIndices: number[]) => void | Promise<void>,
 		onCancel: () => void,
 		maxVisible?: number,
 	) {

--- a/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
@@ -28,6 +28,10 @@ class CopyMessageList implements Component {
 		this.selected = new Set();
 	}
 
+	getMaxVisible(): number {
+		return this.maxVisible;
+	}
+
 	invalidate(): void {}
 
 	render(width: number): string[] {

--- a/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
@@ -1,0 +1,177 @@
+import { type Component, Container, getKeybindings, matchesKey, Spacer, Text, truncateToWidth } from "@dreb/tui";
+import { theme } from "../theme/theme.js";
+import { DynamicBorder } from "./dynamic-border.js";
+
+export interface CopyMessageItem {
+	index: number; // Original index in messages array (for chronological ordering on copy)
+	roleLabel: string; // e.g. "You", "Assistant", "Tool: read", "Bash"
+	preview: string; // Single-line preview text (no ANSI)
+}
+
+/**
+ * Inner list component with multi-select support.
+ */
+class CopyMessageList implements Component {
+	private items: CopyMessageItem[];
+	private selectedIndex: number; // cursor position
+	private selected: Set<number>; // set of selected item array positions
+	private maxVisible: number = 15;
+
+	public onCopy?: (selectedIndices: number[]) => void;
+	public onCancel?: () => void;
+
+	constructor(items: CopyMessageItem[]) {
+		this.items = items;
+		// Bottom-anchored: start at the last (most recent) item
+		this.selectedIndex = Math.max(0, items.length - 1);
+		this.selected = new Set();
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+
+		if (this.items.length === 0) {
+			lines.push(theme.fg("muted", "  No messages found"));
+			return lines;
+		}
+
+		// Calculate consistent role label width
+		const minRoleLabelWidth = 10;
+		const maxRoleLabelWidth = Math.max(minRoleLabelWidth, ...this.items.map((item) => item.roleLabel.length));
+
+		// Calculate visible range centered on selectedIndex
+		const startIndex = Math.max(
+			0,
+			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.items.length - this.maxVisible),
+		);
+		const endIndex = Math.min(startIndex + this.maxVisible, this.items.length);
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.items[i];
+			const isCursor = i === this.selectedIndex;
+			const isSelected = this.selected.has(i);
+
+			// Build line: {cursor}{checkbox} {roleLabel}  {preview}
+			const cursor = isCursor ? theme.fg("accent", "› ") : "  ";
+			const checkbox = isSelected ? theme.fg("accent", "[×]") : theme.fg("muted", "[ ]");
+			const paddedRole = item.roleLabel.padEnd(maxRoleLabelWidth);
+			const roleStr = theme.fg("muted", paddedRole);
+
+			// Calculate remaining width for preview
+			// cursor(2) + checkbox(3) + space(1) + role(maxRoleLabelWidth) + gap(2)
+			const prefixWidth = 2 + 3 + 1 + maxRoleLabelWidth + 2;
+			const previewWidth = Math.max(10, width - prefixWidth);
+			const truncatedPreview = truncateToWidth(item.preview, previewWidth);
+			const previewStr = isCursor ? theme.bold(truncatedPreview) : truncatedPreview;
+
+			lines.push(`${cursor}${checkbox} ${roleStr}  ${previewStr}`);
+		}
+
+		// Scroll indicator if items overflow viewport
+		if (startIndex > 0 || endIndex < this.items.length) {
+			const scrollInfo = theme.fg("muted", `  (${this.selectedIndex + 1}/${this.items.length})`);
+			lines.push(scrollInfo);
+		}
+
+		return lines;
+	}
+
+	handleInput(keyData: string): void {
+		const kb = getKeybindings();
+
+		// Up arrow - move cursor up, wrap at top to bottom
+		if (kb.matches(keyData, "tui.select.up")) {
+			this.selectedIndex = this.selectedIndex === 0 ? this.items.length - 1 : this.selectedIndex - 1;
+		}
+		// Down arrow - move cursor down, wrap at bottom to top
+		else if (kb.matches(keyData, "tui.select.down")) {
+			this.selectedIndex = this.selectedIndex === this.items.length - 1 ? 0 : this.selectedIndex + 1;
+		}
+		// Page Up - jump up by maxVisible
+		else if (kb.matches(keyData, "tui.select.pageUp")) {
+			this.selectedIndex = Math.max(0, this.selectedIndex - this.maxVisible);
+		}
+		// Page Down - jump down by maxVisible
+		else if (kb.matches(keyData, "tui.select.pageDown")) {
+			this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + this.maxVisible);
+		}
+		// Space - toggle selection on current item
+		else if (matchesKey(keyData, "space")) {
+			if (this.selected.has(this.selectedIndex)) {
+				this.selected.delete(this.selectedIndex);
+			} else {
+				this.selected.add(this.selectedIndex);
+			}
+		}
+		// Ctrl+A - toggle all
+		else if (matchesKey(keyData, "ctrl+a")) {
+			if (this.selected.size === this.items.length) {
+				// All selected → deselect all
+				this.selected.clear();
+			} else {
+				// Select all
+				for (let i = 0; i < this.items.length; i++) {
+					this.selected.add(i);
+				}
+			}
+		}
+		// Enter - confirm copy
+		else if (kb.matches(keyData, "tui.select.confirm")) {
+			if (this.onCopy) {
+				// Return original indices sorted chronologically
+				const selectedIndices = Array.from(this.selected)
+					.map((i) => this.items[i].index)
+					.sort((a, b) => a - b);
+				this.onCopy(selectedIndices);
+			}
+		}
+		// Escape/Ctrl+C - cancel
+		else if (kb.matches(keyData, "tui.select.cancel")) {
+			if (this.onCancel) {
+				this.onCancel();
+			}
+		}
+	}
+}
+
+/**
+ * Outer container that wraps the list with header and controls.
+ */
+export class CopySelectorComponent extends Container {
+	private messageList: CopyMessageList;
+
+	constructor(items: CopyMessageItem[], onCopy: (selectedIndices: number[]) => void, onCancel: () => void) {
+		super();
+
+		// Add header
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.bold("Copy Messages"), 1, 0));
+		this.addChild(
+			new Text(theme.fg("muted", "↑↓ Navigate · Space Toggle · Ctrl+A All · Enter Copy · Esc Cancel"), 1, 0),
+		);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+
+		// Create message list
+		this.messageList = new CopyMessageList(items);
+		this.messageList.onCopy = onCopy;
+		this.messageList.onCancel = onCancel;
+		this.addChild(this.messageList);
+
+		// Bottom border
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+
+		// Auto-cancel if no items
+		if (items.length === 0) {
+			setTimeout(() => onCancel(), 100);
+		}
+	}
+
+	getMessageList(): CopyMessageList {
+		return this.messageList;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -78,6 +78,7 @@ import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/cha
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.js";
 import { parseGitUrl } from "../../utils/git.js";
+import { extractCopyableText, getMessagePreview, getMessageRoleLabel } from "../../utils/message-text.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
@@ -86,6 +87,7 @@ import { BorderedLoader } from "./components/bordered-loader.js";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.js";
 import { BuddyComponent } from "./components/buddy-component.js";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.js";
+import { type CopyMessageItem, CopySelectorComponent } from "./components/copy-selector.js";
 import { CustomEditor } from "./components/custom-editor.js";
 import { CustomMessageComponent } from "./components/custom-message.js";
 import { DaxnutsComponent } from "./components/daxnuts.js";
@@ -2114,6 +2116,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.session.tree", () => this.showTreeSelector());
 		this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());
 		this.defaultEditor.onAction("app.session.resume", () => this.showSessionSelector());
+		this.defaultEditor.onAction("app.clipboard.copyMessages", () => this.showCopySelector());
 
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;
@@ -4342,18 +4345,61 @@ export class InteractiveMode {
 	}
 
 	private async handleCopyCommand(): Promise<void> {
-		const text = this.session.getLastAssistantText();
-		if (!text) {
-			this.showError("No agent messages to copy yet.");
+		this.showCopySelector();
+	}
+
+	private showCopySelector(): void {
+		const messages = this.session.messages;
+
+		if (messages.length === 0) {
+			this.showStatus("No messages to copy");
 			return;
 		}
 
-		try {
-			await copyToClipboard(text);
-			this.showStatus("Copied last agent message to clipboard");
-		} catch (error) {
-			this.showError(error instanceof Error ? error.message : String(error));
-		}
+		// Build items from session messages
+		const items: CopyMessageItem[] = messages.map((msg, index) => ({
+			index,
+			roleLabel: getMessageRoleLabel(msg),
+			preview: getMessagePreview(msg),
+		}));
+
+		this.showSelector((done) => {
+			const selector = new CopySelectorComponent(
+				items,
+				async (selectedIndices) => {
+					done();
+					if (selectedIndices.length === 0) {
+						this.showWarning("No messages selected");
+						return;
+					}
+
+					// Extract text from selected messages in chronological order
+					const selectedTexts = selectedIndices
+						.map((i) => extractCopyableText(messages[i]))
+						.filter((text) => text.length > 0);
+
+					if (selectedTexts.length === 0) {
+						this.showWarning("Selected messages have no copyable text");
+						return;
+					}
+
+					const combined = selectedTexts.join("\n\n---\n\n");
+
+					try {
+						await copyToClipboard(combined);
+						const count = selectedTexts.length;
+						this.showStatus(`Copied ${count} message${count === 1 ? "" : "s"} to clipboard`);
+					} catch (error) {
+						this.showError(error instanceof Error ? error.message : String(error));
+					}
+				},
+				() => {
+					done();
+					this.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector.getMessageList() };
+		});
 	}
 
 	private handleNameCommand(text: string): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4363,11 +4363,28 @@ export class InteractiveMode {
 			preview: getMessagePreview(msg),
 		}));
 
+		// Hide buddy while selector is open to free vertical space
+		const hadBuddy = this.buddyComponent !== null;
+		if (hadBuddy) {
+			this.widgetContainerBelow.clear();
+			this.ui.requestRender();
+		}
+
+		// Calculate max visible items based on terminal height
+		// Reserve lines for: header(4) + borders(2) + spacers(2) + scroll indicator(1) + footer(1) + padding(2) = ~12 lines overhead
+		const terminalRows = this.ui.terminal.rows;
+		const overhead = 12;
+		const maxVisible = Math.max(3, Math.min(15, terminalRows - overhead));
+
 		this.showSelector((done) => {
 			const selector = new CopySelectorComponent(
 				items,
 				async (selectedIndices) => {
 					done();
+					// Restore buddy
+					if (hadBuddy) this.renderWidgets();
+					this.ui.requestRender();
+
 					if (selectedIndices.length === 0) {
 						this.showWarning("No messages selected");
 						return;
@@ -4395,8 +4412,11 @@ export class InteractiveMode {
 				},
 				() => {
 					done();
+					// Restore buddy
+					if (hadBuddy) this.renderWidgets();
 					this.ui.requestRender();
 				},
+				maxVisible,
 			);
 			return { component: selector, focus: selector.getMessageList() };
 		});

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4402,12 +4402,12 @@ export class InteractiveMode {
 
 					const combined = selectedTexts.join("\n\n---\n\n");
 
-					try {
-						await copyToClipboard(combined);
-						const count = selectedTexts.length;
+					const result = await copyToClipboard(combined);
+					const count = selectedTexts.length;
+					if (result.method === "osc52") {
+						this.showStatus(`Sent ${count} message${count === 1 ? "" : "s"} to terminal clipboard (OSC 52)`);
+					} else {
 						this.showStatus(`Copied ${count} message${count === 1 ? "" : "s"} to clipboard`);
-					} catch (error) {
-						this.showError(error instanceof Error ? error.message : String(error));
 					}
 				},
 				() => {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4383,8 +4383,7 @@ export class InteractiveMode {
 					done();
 					// Restore buddy
 					if (hadBuddy) this.renderWidgets();
-					// Force full redraw — content shrinks dramatically when selector closes
-					this.ui.requestRender(true);
+					this.ui.requestRender();
 
 					if (selectedIndices.length === 0) {
 						this.showWarning("No messages selected");
@@ -4415,8 +4414,7 @@ export class InteractiveMode {
 					done();
 					// Restore buddy
 					if (hadBuddy) this.renderWidgets();
-					// Force full redraw — content shrinks dramatically when selector closes
-					this.ui.requestRender(true);
+					this.ui.requestRender();
 				},
 				maxVisible,
 			);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4383,7 +4383,8 @@ export class InteractiveMode {
 					done();
 					// Restore buddy
 					if (hadBuddy) this.renderWidgets();
-					this.ui.requestRender();
+					// Force full redraw — content shrinks dramatically when selector closes
+					this.ui.requestRender(true);
 
 					if (selectedIndices.length === 0) {
 						this.showWarning("No messages selected");
@@ -4414,7 +4415,8 @@ export class InteractiveMode {
 					done();
 					// Restore buddy
 					if (hadBuddy) this.renderWidgets();
-					this.ui.requestRender();
+					// Force full redraw — content shrinks dramatically when selector closes
+					this.ui.requestRender(true);
 				},
 				maxVisible,
 			);

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -65,13 +65,17 @@ export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 					execSync("which wl-copy", { stdio: "ignore" });
 					// wl-copy with execSync hangs due to fork behavior; use spawn instead
 					const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"] });
+					proc.on("error", () => {
+						// Spawn failed after which check (TOCTOU, permissions, etc.)
+					});
 					proc.stdin.on("error", () => {
 						// Ignore EPIPE errors if wl-copy exits early
 					});
 					proc.stdin.write(text);
 					proc.stdin.end();
 					proc.unref();
-					return { method: "platform" };
+					// Can't confirm wl-copy succeeded before unref — report osc52 (already emitted above)
+					return { method: "osc52" };
 				} catch {
 					/* wl-copy unavailable or failed — fall back to X11 if available */
 					if (hasX11Display) {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -18,7 +18,9 @@ function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
 	}
 }
 
-export async function copyToClipboard(text: string): Promise<void> {
+export type ClipboardResult = { method: "native" | "platform" | "osc52" };
+
+export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 	// Always emit OSC 52 - works over SSH/mosh, harmless locally
 	const encoded = Buffer.from(text).toString("base64");
 	process.stdout.write(`\x1b]52;c;${encoded}\x07`);
@@ -26,7 +28,7 @@ export async function copyToClipboard(text: string): Promise<void> {
 	try {
 		if (clipboard) {
 			await clipboard.setText(text);
-			return;
+			return { method: "native" };
 		}
 	} catch {
 		/* Native clipboard module threw — fall through to platform-specific tools */
@@ -39,14 +41,16 @@ export async function copyToClipboard(text: string): Promise<void> {
 	try {
 		if (p === "darwin") {
 			execSync("pbcopy", options);
+			return { method: "platform" };
 		} else if (p === "win32") {
 			execSync("clip", options);
+			return { method: "platform" };
 		} else {
 			// Linux. Try Termux, Wayland, or X11 clipboard tools.
 			if (process.env.TERMUX_VERSION) {
 				try {
 					execSync("termux-clipboard-set", options);
-					return;
+					return { method: "platform" };
 				} catch {
 					/* termux-clipboard-set unavailable — fall back to Wayland or X11 tools */
 				}
@@ -67,17 +71,22 @@ export async function copyToClipboard(text: string): Promise<void> {
 					proc.stdin.write(text);
 					proc.stdin.end();
 					proc.unref();
+					return { method: "platform" };
 				} catch {
 					/* wl-copy unavailable or failed — fall back to X11 if available */
 					if (hasX11Display) {
 						copyToX11Clipboard(options);
+						return { method: "platform" };
 					}
 				}
 			} else if (hasX11Display) {
 				copyToX11Clipboard(options);
+				return { method: "platform" };
 			}
 		}
 	} catch {
 		/* Platform clipboard tools failed — OSC 52 already emitted above as fallback */
 	}
+
+	return { method: "osc52" };
 }

--- a/packages/coding-agent/src/utils/message-text.ts
+++ b/packages/coding-agent/src/utils/message-text.ts
@@ -1,0 +1,140 @@
+/**
+ * Utilities for extracting copyable plain text from AgentMessages.
+ * Used by the copy selector modal to present message content for clipboard copy.
+ */
+
+import type { AgentMessage } from "@dreb/agent-core";
+import type { AssistantMessage, TextContent, ToolResultMessage, UserMessage } from "@dreb/ai";
+import type {
+	BashExecutionMessage,
+	BranchSummaryMessage,
+	CompactionSummaryMessage,
+	CustomMessage,
+} from "../core/messages.js";
+
+/**
+ * Extract copyable plain text from any AgentMessage.
+ * Returns the original source text without any terminal wrapping or ANSI codes.
+ * Returns empty string for messages with no meaningful text content (e.g., image-only).
+ */
+export function extractCopyableText(message: AgentMessage): string {
+	switch (message.role) {
+		case "user":
+			return extractUserText(message);
+		case "assistant":
+			return extractAssistantText(message);
+		case "toolResult":
+			return extractToolResultText(message);
+		case "bashExecution":
+			return extractBashText(message);
+		case "branchSummary":
+			return (message as BranchSummaryMessage).summary;
+		case "compactionSummary":
+			return (message as CompactionSummaryMessage).summary;
+		case "custom":
+			return extractCustomText(message as CustomMessage);
+		default:
+			return "";
+	}
+}
+
+/**
+ * Get a short label for a message's role (used in the copy selector UI).
+ */
+export function getMessageRoleLabel(message: AgentMessage): string {
+	switch (message.role) {
+		case "user":
+			return "You";
+		case "assistant":
+			return "Assistant";
+		case "toolResult":
+			return `Tool: ${(message as ToolResultMessage).toolName}`;
+		case "bashExecution":
+			return "Bash";
+		case "branchSummary":
+			return "Branch";
+		case "compactionSummary":
+			return "Summary";
+		case "custom":
+			return `Custom: ${(message as CustomMessage).customType}`;
+		default:
+			return "Unknown";
+	}
+}
+
+/**
+ * Get a single-line preview of a message's content (for display in selector).
+ * Returns plain text, no ANSI, truncated to ~200 chars. Caller handles width truncation.
+ */
+export function getMessagePreview(message: AgentMessage): string {
+	const text = extractCopyableText(message);
+	if (!text) {
+		return "[no text content]";
+	}
+	// Normalize to single line: replace newlines with spaces, collapse whitespace
+	const singleLine = text.replace(/\n/g, " ").replace(/\s+/g, " ").trim();
+	if (singleLine.length <= 200) {
+		return singleLine;
+	}
+	return singleLine.slice(0, 200);
+}
+
+// --- Internal helpers ---
+
+function extractTextBlocks(content: (TextContent | { type: string })[]): string {
+	return content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+function extractUserText(message: UserMessage): string {
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+	return extractTextBlocks(message.content);
+}
+
+function extractAssistantText(message: AssistantMessage): string {
+	const parts: string[] = [];
+
+	// Collect text blocks
+	const textParts = message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text);
+
+	if (textParts.length > 0) {
+		parts.push(textParts.join("\n"));
+	}
+
+	// Collect thinking blocks with header
+	for (const block of message.content) {
+		if (block.type === "thinking" && "thinking" in block) {
+			parts.push(`[thinking]\n${block.thinking}`);
+		}
+	}
+
+	return parts.join("\n");
+}
+
+function extractToolResultText(message: ToolResultMessage): string {
+	const textContent = extractTextBlocks(message.content);
+	if (!textContent) {
+		return "";
+	}
+	return `[${message.toolName}]\n${textContent}`;
+}
+
+function extractBashText(message: BashExecutionMessage): string {
+	return `$ ${message.command}\n${message.output}`;
+}
+
+function extractCustomText(message: CustomMessage): string {
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+	if (Array.isArray(message.content)) {
+		return extractTextBlocks(message.content);
+	}
+	return "";
+}

--- a/packages/coding-agent/test/copy-selector-integration.test.ts
+++ b/packages/coding-agent/test/copy-selector-integration.test.ts
@@ -71,6 +71,8 @@ function createFakeContext(messages: AgentMessage[]) {
 	const captured: CapturedSelector = {};
 	const statusMessages: string[] = [];
 	const warningMessages: string[] = [];
+	let capturedDone: ReturnType<typeof vi.fn> | undefined;
+	let capturedMaxVisible: number | undefined;
 
 	const fakeThis: any = {
 		session: { messages },
@@ -92,6 +94,7 @@ function createFakeContext(messages: AgentMessage[]) {
 		showError: vi.fn(),
 		showSelector: vi.fn((create: (done: () => void) => any) => {
 			const done = vi.fn();
+			capturedDone = done;
 			const result = create(done);
 			// Extract the onCopy and onCancel from the CopySelectorComponent
 			// The component is passed callbacks in its constructor
@@ -99,10 +102,18 @@ function createFakeContext(messages: AgentMessage[]) {
 			const messageList = result.focus;
 			captured.onCopy = messageList.onCopy;
 			captured.onCancel = messageList.onCancel;
+			capturedMaxVisible = messageList.getMaxVisible();
 		}),
 	};
 
-	return { fakeThis, captured, statusMessages, warningMessages };
+	return {
+		fakeThis,
+		captured,
+		statusMessages,
+		warningMessages,
+		getDone: () => capturedDone,
+		getMaxVisible: () => capturedMaxVisible,
+	};
 }
 
 describe("InteractiveMode.showCopySelector", () => {
@@ -129,85 +140,92 @@ describe("InteractiveMode.showCopySelector", () => {
 
 	test("empty selection on confirm shows warning", async () => {
 		const messages = [makeUserMessage("Hello")];
-		const { fakeThis, captured, warningMessages } = createFakeContext(messages);
+		const { fakeThis, captured, warningMessages, getDone } = createFakeContext(messages);
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(warningMessages).toContain("No messages selected");
 		expect(mockCopyToClipboard).not.toHaveBeenCalled();
 	});
 
 	test("all-image selection shows no copyable text warning", async () => {
 		const messages = [makeImageOnlyMessage(), makeImageOnlyMessage()];
-		const { fakeThis, captured, warningMessages } = createFakeContext(messages);
+		const { fakeThis, captured, warningMessages, getDone } = createFakeContext(messages);
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([0, 1]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(warningMessages).toContain("Selected messages have no copyable text");
 		expect(mockCopyToClipboard).not.toHaveBeenCalled();
 	});
 
 	test("successful copy with native method shows 'Copied' status", async () => {
 		const messages = [makeUserMessage("Hello"), makeAssistantMessage("World")];
-		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
 		mockCopyToClipboard.mockResolvedValue({ method: "native" });
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([0, 1]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(mockCopyToClipboard).toHaveBeenCalledWith("Hello\n\n---\n\nWorld");
 		expect(statusMessages).toContain("Copied 2 messages to clipboard");
 	});
 
 	test("successful copy with platform method shows 'Copied' status", async () => {
 		const messages = [makeUserMessage("Single message")];
-		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
 		mockCopyToClipboard.mockResolvedValue({ method: "platform" });
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([0]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(statusMessages).toContain("Copied 1 message to clipboard");
 	});
 
 	test("osc52 fallback shows 'Sent to terminal clipboard' status", async () => {
 		const messages = [makeUserMessage("Hello"), makeAssistantMessage("World")];
-		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
 		mockCopyToClipboard.mockResolvedValue({ method: "osc52" });
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([0, 1]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(statusMessages).toContain("Sent 2 messages to terminal clipboard (OSC 52)");
 	});
 
 	test("singular message count in status", async () => {
 		const messages = [makeUserMessage("One")];
-		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
 		mockCopyToClipboard.mockResolvedValue({ method: "osc52" });
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		await captured.onCopy!([0]);
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(statusMessages).toContain("Sent 1 message to terminal clipboard (OSC 52)");
 	});
 
 	test("cancel callback restores UI without copying", async () => {
 		const messages = [makeUserMessage("Hello")];
-		const { fakeThis, captured } = createFakeContext(messages);
+		const { fakeThis, captured, getDone } = createFakeContext(messages);
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		captured.onCancel!();
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(mockCopyToClipboard).not.toHaveBeenCalled();
 		expect(fakeThis.ui.requestRender).toHaveBeenCalled();
 	});
 
 	test("buddy is hidden during selector and restored on confirm", async () => {
 		const messages = [makeUserMessage("Hello")];
-		const { fakeThis, captured } = createFakeContext(messages);
+		const { fakeThis, captured, getDone } = createFakeContext(messages);
 		fakeThis.buddyComponent = {}; // non-null = buddy exists
 		mockCopyToClipboard.mockResolvedValue({ method: "native" });
 
@@ -216,37 +234,59 @@ describe("InteractiveMode.showCopySelector", () => {
 		expect(fakeThis.widgetContainerBelow.clear).toHaveBeenCalled();
 
 		await captured.onCopy!([0]);
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(fakeThis.renderWidgets).toHaveBeenCalled();
 	});
 
 	test("buddy is hidden during selector and restored on cancel", () => {
 		const messages = [makeUserMessage("Hello")];
-		const { fakeThis, captured } = createFakeContext(messages);
+		const { fakeThis, captured, getDone } = createFakeContext(messages);
 		fakeThis.buddyComponent = {}; // non-null = buddy exists
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 		captured.onCancel!();
 
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(fakeThis.widgetContainerBelow.clear).toHaveBeenCalled();
 		expect(fakeThis.renderWidgets).toHaveBeenCalled();
 	});
 
-	test("maxVisible is clamped between 3 and 15 based on terminal rows", () => {
-		// Small terminal: rows=15, overhead=12 → maxVisible=3 (floor)
+	test("maxVisible is clamped to floor of 3 for small terminals", () => {
 		const messages = [makeUserMessage("Hello")];
-		const { fakeThis } = createFakeContext(messages);
-		fakeThis.ui.terminal.rows = 15;
+		const { fakeThis, getMaxVisible } = createFakeContext(messages);
+		fakeThis.ui.terminal.rows = 15; // 15 - 12 = 3 (floor clamp)
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
 
-		// Verify selector was called (we can't directly read maxVisible, but
-		// we verify it doesn't crash with a small terminal)
 		expect(fakeThis.showSelector).toHaveBeenCalledTimes(1);
+		expect(getMaxVisible()).toBe(3);
+	});
+
+	test("maxVisible is clamped to ceiling of 15 for large terminals", () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, getMaxVisible } = createFakeContext(messages);
+		fakeThis.ui.terminal.rows = 100; // 100 - 12 = 88, clamped to 15
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		expect(fakeThis.showSelector).toHaveBeenCalledTimes(1);
+		expect(getMaxVisible()).toBe(15);
+	});
+
+	test("maxVisible passes through for mid-size terminals", () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, getMaxVisible } = createFakeContext(messages);
+		fakeThis.ui.terminal.rows = 22; // 22 - 12 = 10 (passthrough)
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		expect(fakeThis.showSelector).toHaveBeenCalledTimes(1);
+		expect(getMaxVisible()).toBe(10);
 	});
 
 	test("skips image-only messages but copies text messages", async () => {
 		const messages = [makeUserMessage("Text message"), makeImageOnlyMessage(), makeAssistantMessage("Reply")];
-		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
 		mockCopyToClipboard.mockResolvedValue({ method: "native" });
 
 		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
@@ -254,6 +294,7 @@ describe("InteractiveMode.showCopySelector", () => {
 		await captured.onCopy!([0, 1, 2]);
 
 		// Only 2 texts should be joined (image-only filtered out)
+		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(mockCopyToClipboard).toHaveBeenCalledWith("Text message\n\n---\n\nReply");
 		expect(statusMessages).toContain("Copied 2 messages to clipboard");
 	});

--- a/packages/coding-agent/test/copy-selector-integration.test.ts
+++ b/packages/coding-agent/test/copy-selector-integration.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for InteractiveMode.showCopySelector().
+ * Tests the wiring between the selector component, session messages, and clipboard.
+ */
+
+import type { AgentMessage } from "@dreb/agent-core";
+import type { AssistantMessage, UserMessage } from "@dreb/ai";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+// Mock clipboard to control its return value
+vi.mock("../src/utils/clipboard.js", () => ({
+	copyToClipboard: vi.fn(async () => ({ method: "native" })),
+}));
+
+import { copyToClipboard } from "../src/utils/clipboard.js";
+
+const mockCopyToClipboard = vi.mocked(copyToClipboard);
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+// --- Test message helpers ---
+
+function makeUserMessage(content: string): UserMessage {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function makeImageOnlyMessage(): UserMessage {
+	return {
+		role: "user",
+		content: [{ type: "image", data: "base64data", mimeType: "image/png" }],
+		timestamp: Date.now(),
+	};
+}
+
+// --- Fake `this` context ---
+
+interface CapturedSelector {
+	onCopy?: (indices: number[]) => void;
+	onCancel?: () => void;
+}
+
+function createFakeContext(messages: AgentMessage[]) {
+	const captured: CapturedSelector = {};
+	const statusMessages: string[] = [];
+	const warningMessages: string[] = [];
+
+	const fakeThis: any = {
+		session: { messages },
+		buddyComponent: null,
+		widgetContainerBelow: { clear: vi.fn() },
+		ui: {
+			requestRender: vi.fn(),
+			terminal: { rows: 40 },
+			setFocus: vi.fn(),
+		},
+		editorContainer: {
+			clear: vi.fn(),
+			addChild: vi.fn(),
+		},
+		editor: {},
+		renderWidgets: vi.fn(),
+		showStatus: vi.fn((msg: string) => statusMessages.push(msg)),
+		showWarning: vi.fn((msg: string) => warningMessages.push(msg)),
+		showError: vi.fn(),
+		showSelector: vi.fn((create: (done: () => void) => any) => {
+			const done = vi.fn();
+			const result = create(done);
+			// Extract the onCopy and onCancel from the CopySelectorComponent
+			// The component is passed callbacks in its constructor
+			// We can get them via the messageList's handlers
+			const messageList = result.focus;
+			captured.onCopy = messageList.onCopy;
+			captured.onCancel = messageList.onCancel;
+		}),
+	};
+
+	return { fakeThis, captured, statusMessages, warningMessages };
+}
+
+describe("InteractiveMode.showCopySelector", () => {
+	test("empty session shows status and returns early", () => {
+		const { fakeThis, captured } = createFakeContext([]);
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("No messages to copy");
+		expect(fakeThis.showSelector).not.toHaveBeenCalled();
+		expect(captured.onCopy).toBeUndefined();
+	});
+
+	test("builds items from session messages and opens selector", () => {
+		const messages = [makeUserMessage("Hello"), makeAssistantMessage("World")];
+		const { fakeThis, captured } = createFakeContext(messages);
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		expect(fakeThis.showSelector).toHaveBeenCalledTimes(1);
+		expect(captured.onCopy).toBeDefined();
+		expect(captured.onCancel).toBeDefined();
+	});
+
+	test("empty selection on confirm shows warning", async () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, captured, warningMessages } = createFakeContext(messages);
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([]);
+
+		expect(warningMessages).toContain("No messages selected");
+		expect(mockCopyToClipboard).not.toHaveBeenCalled();
+	});
+
+	test("all-image selection shows no copyable text warning", async () => {
+		const messages = [makeImageOnlyMessage(), makeImageOnlyMessage()];
+		const { fakeThis, captured, warningMessages } = createFakeContext(messages);
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([0, 1]);
+
+		expect(warningMessages).toContain("Selected messages have no copyable text");
+		expect(mockCopyToClipboard).not.toHaveBeenCalled();
+	});
+
+	test("successful copy with native method shows 'Copied' status", async () => {
+		const messages = [makeUserMessage("Hello"), makeAssistantMessage("World")];
+		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([0, 1]);
+
+		expect(mockCopyToClipboard).toHaveBeenCalledWith("Hello\n\n---\n\nWorld");
+		expect(statusMessages).toContain("Copied 2 messages to clipboard");
+	});
+
+	test("successful copy with platform method shows 'Copied' status", async () => {
+		const messages = [makeUserMessage("Single message")];
+		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "platform" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([0]);
+
+		expect(statusMessages).toContain("Copied 1 message to clipboard");
+	});
+
+	test("osc52 fallback shows 'Sent to terminal clipboard' status", async () => {
+		const messages = [makeUserMessage("Hello"), makeAssistantMessage("World")];
+		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "osc52" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([0, 1]);
+
+		expect(statusMessages).toContain("Sent 2 messages to terminal clipboard (OSC 52)");
+	});
+
+	test("singular message count in status", async () => {
+		const messages = [makeUserMessage("One")];
+		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "osc52" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		await captured.onCopy!([0]);
+
+		expect(statusMessages).toContain("Sent 1 message to terminal clipboard (OSC 52)");
+	});
+
+	test("cancel callback restores UI without copying", async () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, captured } = createFakeContext(messages);
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		captured.onCancel!();
+
+		expect(mockCopyToClipboard).not.toHaveBeenCalled();
+		expect(fakeThis.ui.requestRender).toHaveBeenCalled();
+	});
+
+	test("buddy is hidden during selector and restored on confirm", async () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, captured } = createFakeContext(messages);
+		fakeThis.buddyComponent = {}; // non-null = buddy exists
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		expect(fakeThis.widgetContainerBelow.clear).toHaveBeenCalled();
+
+		await captured.onCopy!([0]);
+		expect(fakeThis.renderWidgets).toHaveBeenCalled();
+	});
+
+	test("buddy is hidden during selector and restored on cancel", () => {
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis, captured } = createFakeContext(messages);
+		fakeThis.buddyComponent = {}; // non-null = buddy exists
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		captured.onCancel!();
+
+		expect(fakeThis.widgetContainerBelow.clear).toHaveBeenCalled();
+		expect(fakeThis.renderWidgets).toHaveBeenCalled();
+	});
+
+	test("maxVisible is clamped between 3 and 15 based on terminal rows", () => {
+		// Small terminal: rows=15, overhead=12 → maxVisible=3 (floor)
+		const messages = [makeUserMessage("Hello")];
+		const { fakeThis } = createFakeContext(messages);
+		fakeThis.ui.terminal.rows = 15;
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+
+		// Verify selector was called (we can't directly read maxVisible, but
+		// we verify it doesn't crash with a small terminal)
+		expect(fakeThis.showSelector).toHaveBeenCalledTimes(1);
+	});
+
+	test("skips image-only messages but copies text messages", async () => {
+		const messages = [makeUserMessage("Text message"), makeImageOnlyMessage(), makeAssistantMessage("Reply")];
+		const { fakeThis, captured, statusMessages } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		// Select all three
+		await captured.onCopy!([0, 1, 2]);
+
+		// Only 2 texts should be joined (image-only filtered out)
+		expect(mockCopyToClipboard).toHaveBeenCalledWith("Text message\n\n---\n\nReply");
+		expect(statusMessages).toContain("Copied 2 messages to clipboard");
+	});
+});

--- a/packages/coding-agent/test/copy-selector.test.ts
+++ b/packages/coding-agent/test/copy-selector.test.ts
@@ -1,0 +1,260 @@
+import { setKeybindings } from "@dreb/tui";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { type CopyMessageItem, CopySelectorComponent } from "../src/modes/interactive/components/copy-selector.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+beforeEach(() => {
+	setKeybindings(new KeybindingsManager());
+});
+
+// Key escape sequences
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+const ESC = "\x1b";
+const SPACE = " ";
+const CTRL_A = "\x01";
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+
+function makeItems(count: number): CopyMessageItem[] {
+	const items: CopyMessageItem[] = [];
+	for (let i = 0; i < count; i++) {
+		items.push({
+			index: i,
+			roleLabel: i % 2 === 0 ? "You" : "Assistant",
+			preview: `Message ${i} content here`,
+		});
+	}
+	return items;
+}
+
+describe("CopyMessageList", () => {
+	test("renders items with checkboxes and role labels", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		const lines = list.render(80);
+
+		// Should have rendered lines for each item
+		expect(lines.length).toBeGreaterThanOrEqual(3);
+		// Check that role labels appear
+		expect(lines.some((l) => l.includes("You"))).toBe(true);
+		expect(lines.some((l) => l.includes("Assistant"))).toBe(true);
+		// Check that previews appear
+		expect(lines.some((l) => l.includes("Message 0"))).toBe(true);
+	});
+
+	test("bottom-anchor: selectedIndex starts at last item", () => {
+		const items = makeItems(5);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		const lines = list.render(80);
+
+		// The last item (index 4) should have the cursor indicator ›
+		// Find a line that has both › and "Message 4"
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 4"))).toBe(true);
+	});
+
+	test("navigation: up/down arrows move cursor with wrapping", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Starts at index 2 (last). Move down should wrap to 0.
+		list.handleInput(DOWN);
+		let lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 0"))).toBe(true);
+
+		// Move up should wrap back to 2
+		list.handleInput(UP);
+		lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 2"))).toBe(true);
+
+		// Move up should go to 1
+		list.handleInput(UP);
+		lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 1"))).toBe(true);
+	});
+
+	test("toggle selection: Space toggles current item", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Cursor at last item (2). Toggle it.
+		list.handleInput(SPACE);
+		let lines = list.render(80);
+		// Should show [×] for selected item
+		const selectedLine = lines.find((l) => l.includes("Message 2"));
+		expect(selectedLine).toBeDefined();
+		expect(selectedLine!.includes("×")).toBe(true);
+
+		// Toggle again to deselect
+		list.handleInput(SPACE);
+		lines = list.render(80);
+		const deselectedLine = lines.find((l) => l.includes("Message 2"));
+		expect(deselectedLine).toBeDefined();
+		expect(deselectedLine!.includes("×")).toBe(false);
+	});
+
+	test("select all: Ctrl+A selects all, then deselects all", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Ctrl+A selects all
+		list.handleInput(CTRL_A);
+		let lines = list.render(80);
+		const selectedCount = lines.filter((l) => l.includes("×")).length;
+		expect(selectedCount).toBe(3);
+
+		// Ctrl+A again deselects all
+		list.handleInput(CTRL_A);
+		lines = list.render(80);
+		const deselectedCount = lines.filter((l) => l.includes("×")).length;
+		expect(deselectedCount).toBe(0);
+	});
+
+	test("confirm: Enter calls onCopy with sorted selected indices", () => {
+		const items = makeItems(5);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Select items out of order: cursor at 4, select it
+		list.handleInput(SPACE); // select item 4
+		list.handleInput(UP); // move to 3
+		list.handleInput(UP); // move to 2
+		list.handleInput(SPACE); // select item 2
+		list.handleInput(UP); // move to 1
+		list.handleInput(UP); // move to 0
+		list.handleInput(SPACE); // select item 0
+
+		list.handleInput(ENTER);
+		expect(onCopy).toHaveBeenCalledWith([0, 2, 4]);
+	});
+
+	test("cancel: Escape calls onCancel", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		list.handleInput(ESC);
+		expect(onCancel).toHaveBeenCalled();
+	});
+
+	test("empty selection on confirm: Enter with nothing selected calls onCopy with empty array", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		list.handleInput(ENTER);
+		expect(onCopy).toHaveBeenCalledWith([]);
+	});
+
+	test("scrolling: viewport window adjusts as cursor moves", () => {
+		// Create more items than maxVisible (15)
+		const items = makeItems(20);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Starts at item 19 (last). Viewport should show items near the end.
+		let lines = list.render(80);
+		// Should have scroll indicator
+		expect(lines.some((l) => l.includes("20/20"))).toBe(true);
+		// Should show the last item
+		expect(lines.some((l) => l.includes("Message 19"))).toBe(true);
+
+		// Move cursor to start
+		for (let i = 0; i < 19; i++) {
+			list.handleInput(UP);
+		}
+		lines = list.render(80);
+		expect(lines.some((l) => l.includes("1/20"))).toBe(true);
+		expect(lines.some((l) => l.includes("Message 0"))).toBe(true);
+	});
+
+	test("page up/down: jumps by maxVisible", () => {
+		const items = makeItems(30);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+		const list = component.getMessageList();
+
+		// Starts at 29. Page up should jump to 14.
+		list.handleInput(PAGE_UP);
+		let lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 14"))).toBe(true);
+
+		// Page down should jump back to 29
+		list.handleInput(PAGE_DOWN);
+		lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 29"))).toBe(true);
+
+		// Page up twice from 29: 29 -> 14 -> 0 (clamped)
+		list.handleInput(PAGE_UP);
+		list.handleInput(PAGE_UP);
+		lines = list.render(80);
+		expect(lines.some((l) => l.includes("›") && l.includes("Message 0"))).toBe(true);
+	});
+});
+
+describe("CopySelectorComponent", () => {
+	test("container renders header, controls text, borders, and list", () => {
+		const items = makeItems(3);
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		const component = new CopySelectorComponent(items, onCopy, onCancel);
+
+		const lines = component.render(80);
+		const output = lines.join("\n");
+
+		// Header
+		expect(output).toContain("Copy Messages");
+		// Controls
+		expect(output).toContain("Navigate");
+		expect(output).toContain("Space Toggle");
+		expect(output).toContain("Enter Copy");
+		expect(output).toContain("Esc Cancel");
+		// Borders (─ chars)
+		expect(output).toContain("─");
+		// List items
+		expect(output).toContain("Message 0");
+	});
+
+	test("empty items: auto-cancels", async () => {
+		vi.useFakeTimers();
+		const onCopy = vi.fn();
+		const onCancel = vi.fn();
+		new CopySelectorComponent([], onCopy, onCancel);
+
+		vi.advanceTimersByTime(200);
+		expect(onCancel).toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+});

--- a/packages/coding-agent/test/copy-selector.test.ts
+++ b/packages/coding-agent/test/copy-selector.test.ts
@@ -249,12 +249,15 @@ describe("CopySelectorComponent", () => {
 
 	test("empty items: auto-cancels", async () => {
 		vi.useFakeTimers();
-		const onCopy = vi.fn();
-		const onCancel = vi.fn();
-		new CopySelectorComponent([], onCopy, onCancel);
+		try {
+			const onCopy = vi.fn();
+			const onCancel = vi.fn();
+			new CopySelectorComponent([], onCopy, onCancel);
 
-		vi.advanceTimersByTime(200);
-		expect(onCancel).toHaveBeenCalled();
-		vi.useRealTimers();
+			vi.advanceTimersByTime(200);
+			expect(onCancel).toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/coding-agent/test/message-text.test.ts
+++ b/packages/coding-agent/test/message-text.test.ts
@@ -1,0 +1,287 @@
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "@dreb/ai";
+import { describe, expect, test } from "vitest";
+import type {
+	BashExecutionMessage,
+	BranchSummaryMessage,
+	CompactionSummaryMessage,
+	CustomMessage,
+} from "../src/core/messages.js";
+import { extractCopyableText, getMessagePreview, getMessageRoleLabel } from "../src/utils/message-text.js";
+
+// --- Helpers for creating test messages ---
+
+function makeUserMessage(content: UserMessage["content"]): UserMessage {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+function makeAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function makeToolResult(toolName: string, content: ToolResultMessage["content"]): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call-1",
+		toolName,
+		content,
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+function makeBashExecution(command: string, output: string): BashExecutionMessage {
+	return {
+		role: "bashExecution",
+		command,
+		output,
+		exitCode: 0,
+		cancelled: false,
+		truncated: false,
+		timestamp: Date.now(),
+	};
+}
+
+function makeBranchSummary(summary: string): BranchSummaryMessage {
+	return { role: "branchSummary", summary, fromId: "branch-1", timestamp: Date.now() };
+}
+
+function makeCompactionSummary(summary: string): CompactionSummaryMessage {
+	return { role: "compactionSummary", summary, tokensBefore: 5000, timestamp: Date.now() };
+}
+
+function makeCustomMessage(customType: string, content: CustomMessage["content"]): CustomMessage {
+	return { role: "custom", customType, content, display: true, timestamp: Date.now() };
+}
+
+// --- extractCopyableText tests ---
+
+describe("extractCopyableText", () => {
+	describe("user messages", () => {
+		test("string content", () => {
+			const msg = makeUserMessage("Hello, world!");
+			expect(extractCopyableText(msg)).toBe("Hello, world!");
+		});
+
+		test("TextContent array", () => {
+			const msg = makeUserMessage([
+				{ type: "text", text: "First part" },
+				{ type: "text", text: "Second part" },
+			]);
+			expect(extractCopyableText(msg)).toBe("First part\nSecond part");
+		});
+
+		test("mixed text + image content (images skipped)", () => {
+			const msg = makeUserMessage([
+				{ type: "text", text: "Some text" },
+				{ type: "image", data: "base64data", mimeType: "image/png" },
+				{ type: "text", text: "More text" },
+			]);
+			expect(extractCopyableText(msg)).toBe("Some text\nMore text");
+		});
+
+		test("only image content returns empty string", () => {
+			const msg = makeUserMessage([{ type: "image", data: "base64data", mimeType: "image/png" }]);
+			expect(extractCopyableText(msg)).toBe("");
+		});
+	});
+
+	describe("assistant messages", () => {
+		test("single text block", () => {
+			const msg = makeAssistantMessage([{ type: "text", text: "Hello from assistant" }]);
+			expect(extractCopyableText(msg)).toBe("Hello from assistant");
+		});
+
+		test("multiple text blocks", () => {
+			const msg = makeAssistantMessage([
+				{ type: "text", text: "First response" },
+				{ type: "text", text: "Second response" },
+			]);
+			expect(extractCopyableText(msg)).toBe("First response\nSecond response");
+		});
+
+		test("thinking blocks included with header", () => {
+			const msg = makeAssistantMessage([
+				{ type: "text", text: "Visible reply" },
+				{ type: "thinking", thinking: "Internal reasoning here" },
+			]);
+			expect(extractCopyableText(msg)).toBe("Visible reply\n[thinking]\nInternal reasoning here");
+		});
+
+		test("multiple thinking blocks each get header", () => {
+			const msg = makeAssistantMessage([
+				{ type: "thinking", thinking: "Step 1" },
+				{ type: "text", text: "Answer" },
+				{ type: "thinking", thinking: "Step 2" },
+			]);
+			expect(extractCopyableText(msg)).toBe("Answer\n[thinking]\nStep 1\n[thinking]\nStep 2");
+		});
+
+		test("toolCall blocks are skipped", () => {
+			const msg = makeAssistantMessage([
+				{ type: "text", text: "I will use a tool" },
+				{ type: "toolCall", id: "tc-1", name: "read", arguments: { path: "foo.ts" } },
+			]);
+			expect(extractCopyableText(msg)).toBe("I will use a tool");
+		});
+
+		test("empty content returns empty string", () => {
+			const msg = makeAssistantMessage([]);
+			expect(extractCopyableText(msg)).toBe("");
+		});
+
+		test("only toolCall blocks returns empty string", () => {
+			const msg = makeAssistantMessage([
+				{ type: "toolCall", id: "tc-1", name: "bash", arguments: { command: "ls" } },
+			]);
+			expect(extractCopyableText(msg)).toBe("");
+		});
+	});
+
+	describe("tool result messages", () => {
+		test("text content with tool name header", () => {
+			const msg = makeToolResult("read", [{ type: "text", text: "file contents here" }]);
+			expect(extractCopyableText(msg)).toBe("[read]\nfile contents here");
+		});
+
+		test("image-only content returns empty string", () => {
+			const msg = makeToolResult("screenshot", [{ type: "image", data: "base64data", mimeType: "image/png" }]);
+			expect(extractCopyableText(msg)).toBe("");
+		});
+
+		test("mixed content (text extracted, images skipped)", () => {
+			const msg = makeToolResult("bash", [
+				{ type: "text", text: "output line 1" },
+				{ type: "image", data: "base64data", mimeType: "image/png" },
+				{ type: "text", text: "output line 2" },
+			]);
+			expect(extractCopyableText(msg)).toBe("[bash]\noutput line 1\noutput line 2");
+		});
+	});
+
+	describe("bash execution messages", () => {
+		test("command with output", () => {
+			const msg = makeBashExecution("ls -la", "total 42\ndrwxr-xr-x 5 user");
+			expect(extractCopyableText(msg)).toBe("$ ls -la\ntotal 42\ndrwxr-xr-x 5 user");
+		});
+
+		test("command with empty output", () => {
+			const msg = makeBashExecution("mkdir test", "");
+			expect(extractCopyableText(msg)).toBe("$ mkdir test\n");
+		});
+	});
+
+	describe("branch summary messages", () => {
+		test("returns summary text", () => {
+			const msg = makeBranchSummary("Explored authentication approach but reverted");
+			expect(extractCopyableText(msg)).toBe("Explored authentication approach but reverted");
+		});
+	});
+
+	describe("compaction summary messages", () => {
+		test("returns summary text", () => {
+			const msg = makeCompactionSummary("Discussed project setup and installed dependencies");
+			expect(extractCopyableText(msg)).toBe("Discussed project setup and installed dependencies");
+		});
+	});
+
+	describe("custom messages", () => {
+		test("string content", () => {
+			const msg = makeCustomMessage("notification", "Extension loaded successfully");
+			expect(extractCopyableText(msg)).toBe("Extension loaded successfully");
+		});
+
+		test("array content", () => {
+			const msg = makeCustomMessage("info", [
+				{ type: "text", text: "Status: ready" },
+				{ type: "text", text: "Version: 1.0" },
+			]);
+			expect(extractCopyableText(msg)).toBe("Status: ready\nVersion: 1.0");
+		});
+	});
+});
+
+// --- getMessageRoleLabel tests ---
+
+describe("getMessageRoleLabel", () => {
+	test("user → 'You'", () => {
+		expect(getMessageRoleLabel(makeUserMessage("hi"))).toBe("You");
+	});
+
+	test("assistant → 'Assistant'", () => {
+		expect(getMessageRoleLabel(makeAssistantMessage([]))).toBe("Assistant");
+	});
+
+	test("toolResult → 'Tool: <name>'", () => {
+		expect(getMessageRoleLabel(makeToolResult("read", []))).toBe("Tool: read");
+		expect(getMessageRoleLabel(makeToolResult("bash", []))).toBe("Tool: bash");
+	});
+
+	test("bashExecution → 'Bash'", () => {
+		expect(getMessageRoleLabel(makeBashExecution("ls", ""))).toBe("Bash");
+	});
+
+	test("branchSummary → 'Branch'", () => {
+		expect(getMessageRoleLabel(makeBranchSummary("summary"))).toBe("Branch");
+	});
+
+	test("compactionSummary → 'Summary'", () => {
+		expect(getMessageRoleLabel(makeCompactionSummary("summary"))).toBe("Summary");
+	});
+
+	test("custom → 'Custom: <type>'", () => {
+		expect(getMessageRoleLabel(makeCustomMessage("myext", "content"))).toBe("Custom: myext");
+	});
+});
+
+// --- getMessagePreview tests ---
+
+describe("getMessagePreview", () => {
+	test("returns first line content normalized", () => {
+		const msg = makeUserMessage("First line\nSecond line\nThird line");
+		expect(getMessagePreview(msg)).toBe("First line Second line Third line");
+	});
+
+	test("truncates to 200 chars", () => {
+		const longText = "x".repeat(300);
+		const msg = makeUserMessage(longText);
+		const preview = getMessagePreview(msg);
+		expect(preview.length).toBe(200);
+		expect(preview).toBe("x".repeat(200));
+	});
+
+	test("returns '[no text content]' for image-only messages", () => {
+		const msg = makeUserMessage([{ type: "image", data: "base64data", mimeType: "image/png" }]);
+		expect(getMessagePreview(msg)).toBe("[no text content]");
+	});
+
+	test("returns '[no text content]' for empty assistant", () => {
+		const msg = makeAssistantMessage([]);
+		expect(getMessagePreview(msg)).toBe("[no text content]");
+	});
+
+	test("collapses multiple whitespace", () => {
+		const msg = makeUserMessage("hello   world\n\n\ntest");
+		expect(getMessagePreview(msg)).toBe("hello world test");
+	});
+
+	test("trims leading/trailing whitespace", () => {
+		const msg = makeUserMessage("  padded content  ");
+		expect(getMessagePreview(msg)).toBe("padded content");
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.22.1",
+	"version": "2.23.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1150,22 +1150,15 @@ export class TUI extends Container {
 		}
 
 		// Track where cursor ended up after rendering
-		let finalCursorRow = renderEnd;
+		const finalCursorRow = renderEnd;
 
-		// If we had more lines before, clear them and move cursor back
+		// If we had more lines before, clear ghost lines below new content.
+		// Use a full redraw (clear screen) to avoid ghost whitespace from terminals
+		// that don't properly collapse cleared lines below the cursor.
 		if (this.previousLines.length > newLines.length) {
-			// Move to end of new content first if we stopped before it
-			if (renderEnd < newLines.length - 1) {
-				const moveDown = newLines.length - 1 - renderEnd;
-				buffer += `\x1b[${moveDown}B`;
-				finalCursorRow = newLines.length - 1;
-			}
-			const extraLines = this.previousLines.length - newLines.length;
-			for (let i = newLines.length; i < this.previousLines.length; i++) {
-				buffer += "\r\n\x1b[2K";
-			}
-			// Move cursor back to end of new content
-			buffer += `\x1b[${extraLines}A`;
+			logRedraw(`content shrank (${this.previousLines.length} -> ${newLines.length})`);
+			fullRender(true, false);
+			return;
 		}
 
 		buffer += "\x1b[?2026l"; // End synchronized output


### PR DESCRIPTION
Closes #217

Multi-select copy modal for the TUI — `/copy` opens a message picker that lets users select any combination of messages and copy their original source text (without wrap-induced line breaks).

Implementation plan posted as a comment below.
