### PR TITLE
Redirect web_fetch on GitHub URLs to gh / clone-to-tmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8436,7 +8436,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8725,7 +8725,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9041,7 +9041,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9418,7 +9418,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9727,7 +9727,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -10019,7 +10019,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.25.0",
+			"version": "2.25.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/web.ts
+++ b/packages/coding-agent/src/core/tools/web.ts
@@ -534,13 +534,57 @@ function formatFetchResult(
 	return text;
 }
 
+/**
+ * Detect GitHub URLs and return guidance to use the `gh` CLI or a local clone
+ * instead of fetching. Fetching GitHub web pages is unreliable: `/blob/` URLs
+ * return rendered HTML chrome instead of file content, private repos 404 (no
+ * auth), and `api.github.com` needs a specific Accept header. The `gh` CLI is
+ * authenticated and purpose-built; cloning to /tmp gives direct file access.
+ *
+ * Returns guidance text for GitHub hosts, or `null` for any other host.
+ */
+export function getGitHubFetchGuidance(parsed: URL): string | null {
+	const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+	const isGitHubHost =
+		host === "github.com" ||
+		host === "gist.github.com" ||
+		host === "api.github.com" ||
+		host === "raw.githubusercontent.com" ||
+		host.endsWith(".githubusercontent.com");
+	if (!isGitHubHost) {
+		return null;
+	}
+
+	const path = parsed.pathname;
+	let hint: string;
+	if (host === "api.github.com") {
+		hint = `Use the \`gh api\` command instead, e.g. \`gh api ${path.replace(/^\//, "")}\`.`;
+	} else if (
+		host === "raw.githubusercontent.com" ||
+		host.endsWith(".githubusercontent.com") ||
+		/\/(blob|raw)\//.test(path)
+	) {
+		hint =
+			"To read file contents, clone the repo to /tmp (`git clone <repo> /tmp/<name>`) and read the file locally, or use `gh api` to fetch the raw content.";
+	} else if (/\/pull\//.test(path)) {
+		hint = "Use `gh pr view <number>` (add `--comments`) or `gh pr diff <number>` instead.";
+	} else if (/\/issues\//.test(path)) {
+		hint = "Use `gh issue view <number>` (add `--comments`) instead.";
+	} else {
+		hint =
+			"Use the `gh` CLI (e.g. `gh repo view`, `gh api`, `gh pr view`, `gh issue view`) or clone the repo to /tmp and read files locally.";
+	}
+
+	return `web_fetch does not work reliably on GitHub URLs (private repos 404, /blob/ pages return HTML chrome, not file content). ${hint}`;
+}
+
 export function createWebFetchToolDefinition(
 	_cwd: string,
 ): ToolDefinition<typeof webFetchSchema, WebFetchToolDetails | undefined> {
 	return {
 		name: "web_fetch",
 		label: "web_fetch",
-		description: `Fetch a URL and return its text content. Extracts readable text from HTML pages. Supports PDF text extraction. Content truncated to ~${Math.round(MAX_CONTENT_LENGTH / 1024)}KB. Results cached for 15 minutes.`,
+		description: `Fetch a URL and return its text content. Extracts readable text from HTML pages. Supports PDF text extraction. Content truncated to ~${Math.round(MAX_CONTENT_LENGTH / 1024)}KB. Results cached for 15 minutes. GitHub URLs are redirected to guidance for the \`gh\` CLI or a local clone instead of being fetched.`,
 		promptSnippet: "Fetch a URL and extract its text content",
 		parameters: webFetchSchema,
 		async execute(_toolCallId, { url }: { url: string }) {
@@ -559,6 +603,15 @@ export function createWebFetchToolDefinition(
 			if (!parsed.protocol.startsWith("http")) {
 				return {
 					content: [{ type: "text", text: `Unsupported protocol: ${parsed.protocol}` }],
+					details: undefined,
+				};
+			}
+
+			// Redirect GitHub URLs to gh/clone guidance — fetching them is unreliable
+			const githubGuidance = getGitHubFetchGuidance(parsed);
+			if (githubGuidance) {
+				return {
+					content: [{ type: "text", text: githubGuidance }],
 					details: undefined,
 				};
 			}

--- a/packages/coding-agent/test/tools/web-fetch.test.ts
+++ b/packages/coding-agent/test/tools/web-fetch.test.ts
@@ -13,6 +13,13 @@ describe("getGitHubFetchGuidance", () => {
 		expect(g).toContain("gh api");
 	});
 
+	it("returns guidance for github.com /raw/ URLs (clone/api hint)", () => {
+		const g = getGitHubFetchGuidance(new URL("https://github.com/owner/repo/raw/main/src/file.ts"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("clone");
+		expect(g).toContain("gh api");
+	});
+
 	it("returns guidance for raw.githubusercontent.com (clone/api hint)", () => {
 		const g = getGitHubFetchGuidance(new URL("https://raw.githubusercontent.com/owner/repo/main/file.ts"));
 		expect(g).toBeTruthy();

--- a/packages/coding-agent/test/tools/web-fetch.test.ts
+++ b/packages/coding-agent/test/tools/web-fetch.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWebFetchToolDefinition, getGitHubFetchGuidance } from "../../src/core/tools/web.js";
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.map((c) => c.text ?? "").join("\n");
+}
+
+describe("getGitHubFetchGuidance", () => {
+	it("returns guidance for github.com blob URLs (clone/api hint)", () => {
+		const g = getGitHubFetchGuidance(new URL("https://github.com/owner/repo/blob/main/src/file.ts"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("clone");
+		expect(g).toContain("gh api");
+	});
+
+	it("returns guidance for raw.githubusercontent.com (clone/api hint)", () => {
+		const g = getGitHubFetchGuidance(new URL("https://raw.githubusercontent.com/owner/repo/main/file.ts"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("clone");
+	});
+
+	it("returns guidance for *.githubusercontent.com subdomains", () => {
+		const g = getGitHubFetchGuidance(new URL("https://objects.githubusercontent.com/some/asset"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("clone");
+	});
+
+	it("returns guidance for gist.github.com", () => {
+		const g = getGitHubFetchGuidance(new URL("https://gist.github.com/owner/abc123"));
+		expect(g).toBeTruthy();
+	});
+
+	it("returns gh api guidance for api.github.com", () => {
+		const g = getGitHubFetchGuidance(new URL("https://api.github.com/repos/owner/repo/contents/src"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("gh api");
+		expect(g).toContain("repos/owner/repo/contents/src");
+	});
+
+	it("returns PR guidance for pull request URLs", () => {
+		const g = getGitHubFetchGuidance(new URL("https://github.com/owner/repo/pull/42"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("gh pr view");
+	});
+
+	it("returns issue guidance for issue URLs", () => {
+		const g = getGitHubFetchGuidance(new URL("https://github.com/owner/repo/issues/42"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("gh issue view");
+	});
+
+	it("returns generic guidance for a repo root URL", () => {
+		const g = getGitHubFetchGuidance(new URL("https://github.com/owner/repo"));
+		expect(g).toBeTruthy();
+		expect(g).toContain("gh");
+		expect(g).toContain("/tmp");
+	});
+
+	it("handles www. and uppercase hosts", () => {
+		expect(getGitHubFetchGuidance(new URL("https://WWW.GitHub.com/owner/repo"))).toBeTruthy();
+	});
+
+	it("returns null for non-GitHub hosts", () => {
+		expect(getGitHubFetchGuidance(new URL("https://example.com/page"))).toBeNull();
+		expect(getGitHubFetchGuidance(new URL("https://www.npmjs.com/package/foo"))).toBeNull();
+		// not GitHub — a lookalike host must not match
+		expect(getGitHubFetchGuidance(new URL("https://github.com.evil.example/owner/repo"))).toBeNull();
+	});
+});
+
+describe("web_fetch execute — GitHub redirect", () => {
+	const originalFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("short-circuits GitHub URLs without performing a network fetch", async () => {
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const def = createWebFetchToolDefinition(process.cwd());
+		const result = await def.execute(
+			"call-1",
+			{ url: "https://github.com/owner/repo/blob/main/file.ts" },
+			undefined,
+			undefined,
+			undefined as never,
+		);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(getText(result)).toContain("gh");
+	});
+
+	it("attempts a network fetch for non-GitHub URLs", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			headers: new Headers({ "content-type": "text/html" }),
+			text: async () => "<html><head><title>Example</title></head><body>Hello world</body></html>",
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const def = createWebFetchToolDefinition(process.cwd());
+		// unique URL to avoid the module-level fetch cache
+		const result = await def.execute(
+			"call-2",
+			{ url: `https://example.com/page-${Date.now()}` },
+			undefined,
+			undefined,
+			undefined as never,
+		);
+
+		expect(fetchMock).toHaveBeenCalled();
+		expect(getText(result)).toContain("Hello world");
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.25.0",
+	"version": "2.25.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #244

Intercept `web_fetch` calls on GitHub hosts and return guidance to use the `gh` CLI or clone to `/tmp` instead of attempting an unreliable raw fetch. GitHub URLs are the single largest source of real `web_fetch` failures in session history (404s on `/blob/` pages and private repos, 415 on `api.github.com`), and dreb already has better-supported paths.

Implementation plan posted as a comment below.
