### PR TITLE
Fix: /buddy off now persists across sessions (don't mount hidden buddy at startup)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8436,7 +8436,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8725,7 +8725,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9041,7 +9041,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9418,7 +9418,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9727,7 +9727,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -10019,7 +10019,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.25.1",
+			"version": "2.25.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 ### Fixed
 
+- Fixed `/buddy off` not persisting across sessions — the buddy reappeared in the TUI on restart. The `hidden` flag was persisted correctly, but the startup auto-mount ignored it. The startup mount is now gated on the persisted `hidden` flag (extracted into `mountExistingBuddyIfVisible()`); a hidden buddy stays loaded but unmounted until you run `/buddy` to bring it back. ([#243](https://github.com/aebrer/dreb/issues/243))
+
 - Fixed subagents silently returning empty results when a child's final response was truncated at the model's token limit. The subagent spawn handler now inspects the last assistant message's `stopReason`: a clean exit with no output now surfaces a descriptive error (truncation, loud truncation failure, or "completed with no output") instead of a silent empty string, and a clean exit with partial output now flags the truncation via `errorMessage` while preserving the partial text — covering both raw `length` truncation and the loud `error` stopReason produced when the core agent loop exhausts its length retries. The parent renders these errors even on a clean (exit code 0) exit. ([#240](https://github.com/aebrer/dreb/issues/240))
 
 - Fixed ghost whitespace appearing after the TUI content shrinks (e.g., closing the copy selector, filtering slash-command autocomplete, editor line deletion). The differential renderer now triggers a full screen redraw when content shrinks instead of clearing extra lines individually, which some terminals would not collapse. ([#217](https://github.com/aebrer/dreb/issues/217))

--- a/packages/coding-agent/docs/buddy.md
+++ b/packages/coding-agent/docs/buddy.md
@@ -27,13 +27,13 @@ The buddy won't react until a model is configured. The choice is persisted acros
 
 | Command | Description |
 |---|---|
-| `/buddy` | Hatch a new buddy (or show existing one) |
+| `/buddy` | Hatch a new buddy (or show an existing one — also brings back a buddy hidden via `/buddy off`) |
 | `/buddy model` | Show current Ollama model and available models |
 | `/buddy model <name>` | Set the Ollama model for buddy reactions |
 | `/buddy pet` | Pet your buddy |
 | `/buddy reroll` | Reroll for a new buddy (new species, name, personality) |
 | `/buddy stats` | Show buddy stats panel |
-| `/buddy off` | Hide the buddy |
+| `/buddy off` | Hide the buddy (persists across sessions — it stays hidden on restart until you run `/buddy`) |
 
 ## How It Works
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -612,9 +612,11 @@ export class InteractiveMode {
 		// Subscribe to agent events
 		this.subscribeToAgent();
 
-		// Auto-load buddy if one exists
+		// Auto-load buddy if one exists. Skip visual mount when the buddy was
+		// hidden via /buddy off — start() still loads it (disabled) so context
+		// wiring works, but we must not re-mount it on screen.
 		const existingBuddy = this.buddyController.start();
-		if (existingBuddy) {
+		if (existingBuddy && !existingBuddy.hidden) {
 			this.mountBuddy(existingBuddy);
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -612,13 +612,8 @@ export class InteractiveMode {
 		// Subscribe to agent events
 		this.subscribeToAgent();
 
-		// Auto-load buddy if one exists. Skip visual mount when the buddy was
-		// hidden via /buddy off — start() still loads it (disabled) so context
-		// wiring works, but we must not re-mount it on screen.
-		const existingBuddy = this.buddyController.start();
-		if (existingBuddy && !existingBuddy.hidden) {
-			this.mountBuddy(existingBuddy);
-		}
+		// Auto-load buddy if one exists (skips visual mount when hidden via /buddy off).
+		this.mountExistingBuddyIfVisible();
 
 		// Set up theme file watcher
 		onThemeChange(() => {
@@ -5164,6 +5159,20 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 		this.mountBuddy(state);
 		this.showBuddyStatsPanel(state);
 		await this.checkAndWarnOllama();
+	}
+
+	/**
+	 * Load the persisted buddy at startup and mount it only if it is visible.
+	 * A buddy hidden via `/buddy off` is still loaded by start() (disabled) so
+	 * context/idle wiring stays intact, but it must not be re-mounted on screen
+	 * in a new session — that is the regression fixed for #243. Extracted into a
+	 * standalone method so the mount-gate decision is directly unit-testable.
+	 */
+	private mountExistingBuddyIfVisible(): void {
+		const existingBuddy = this.buddyController.start();
+		if (existingBuddy && !existingBuddy.hidden) {
+			this.mountBuddy(existingBuddy);
+		}
 	}
 
 	private mountBuddy(state: import("../../core/buddy/buddy-types.js").BuddyState): void {

--- a/packages/coding-agent/test/buddy-controller.test.ts
+++ b/packages/coding-agent/test/buddy-controller.test.ts
@@ -76,6 +76,7 @@ function writeStoredBuddy(
 		backstory: string;
 		rerollCount: number;
 		ollamaModel: string;
+		hidden: boolean;
 	}>,
 ) {
 	const stored = {
@@ -277,13 +278,8 @@ describe("enabled flag", () => {
 	});
 
 	it("should start with enabled=false when stored buddy has hidden=true", () => {
-		writeStoredBuddy();
+		writeStoredBuddy({ hidden: true });
 		const { controller } = createTestController();
-
-		// Manually set hidden
-		const stored = JSON.parse(readFileSync(join(TEST_DIR, "buddy.json"), "utf-8"));
-		stored.hidden = true;
-		writeFileSync(join(TEST_DIR, "buddy.json"), JSON.stringify(stored));
 
 		const state = controller.start();
 		expect(state).not.toBeNull(); // buddy loaded from disk
@@ -294,12 +290,8 @@ describe("enabled flag", () => {
 	// startup site gates the visual mount on the `hidden` flag returned by
 	// start(), so start() must faithfully surface `hidden` on the loaded state.
 	it("should return hidden=true from start() so the frontend skips mounting", () => {
-		writeStoredBuddy();
+		writeStoredBuddy({ hidden: true });
 		const { controller } = createTestController();
-
-		const stored = JSON.parse(readFileSync(join(TEST_DIR, "buddy.json"), "utf-8"));
-		stored.hidden = true;
-		writeFileSync(join(TEST_DIR, "buddy.json"), JSON.stringify(stored));
 
 		const state = controller.start();
 		expect(state).not.toBeNull();

--- a/packages/coding-agent/test/buddy-controller.test.ts
+++ b/packages/coding-agent/test/buddy-controller.test.ts
@@ -290,6 +290,35 @@ describe("enabled flag", () => {
 		expect(controller.enabled).toBe(false); // but disabled
 	});
 
+	// Regression for #243: /buddy off must persist across sessions. The TUI
+	// startup site gates the visual mount on the `hidden` flag returned by
+	// start(), so start() must faithfully surface `hidden` on the loaded state.
+	it("should return hidden=true from start() so the frontend skips mounting", () => {
+		writeStoredBuddy();
+		const { controller } = createTestController();
+
+		const stored = JSON.parse(readFileSync(join(TEST_DIR, "buddy.json"), "utf-8"));
+		stored.hidden = true;
+		writeFileSync(join(TEST_DIR, "buddy.json"), JSON.stringify(stored));
+
+		const state = controller.start();
+		expect(state).not.toBeNull();
+		// The startup gate mounts only when `!state.hidden`; a hidden buddy
+		// must report hidden so it is not re-shown on a new session.
+		expect(state!.hidden).toBe(true);
+		expect(controller.enabled).toBe(false);
+	});
+
+	it("should return hidden falsy from start() for a visible buddy so it mounts", () => {
+		writeStoredBuddy(); // no hidden flag set
+		const { controller } = createTestController();
+
+		const state = controller.start();
+		expect(state).not.toBeNull();
+		expect(state!.hidden).toBeFalsy(); // startup gate will mount it
+		expect(controller.enabled).toBe(true);
+	});
+
 	it("should keep buddy disabled after reset() when /buddy off was called", async () => {
 		writeStoredBuddy();
 		const { controller, manager } = createTestController();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -191,3 +191,45 @@ describe("InteractiveMode.showLoadedResources", () => {
 		expect(output).not.toContain("[Skills]");
 	});
 });
+
+// Regression for #243: /buddy off must persist across sessions. The startup
+// site loads the buddy via start() but must NOT visually mount it when hidden.
+// These tests exercise the actual mount-gate (mountExistingBuddyIfVisible) — if
+// the `!hidden` guard regresses, they fail (the controller-contract tests in
+// buddy-controller.test.ts would not catch a revert of the gate itself).
+describe("InteractiveMode.mountExistingBuddyIfVisible", () => {
+	function createFakeThis(startReturn: { hidden?: boolean } | null) {
+		const mountBuddy = vi.fn();
+		const fakeThis: any = {
+			buddyController: { start: vi.fn(() => startReturn) },
+			mountBuddy,
+		};
+		return { fakeThis, mountBuddy };
+	}
+
+	test("does not mount a hidden buddy at startup", () => {
+		const { fakeThis, mountBuddy } = createFakeThis({ hidden: true });
+		(InteractiveMode as any).prototype.mountExistingBuddyIfVisible.call(fakeThis);
+		expect(mountBuddy).not.toHaveBeenCalled();
+	});
+
+	test("mounts a visible buddy at startup", () => {
+		const visibleBuddy = { hidden: false };
+		const { fakeThis, mountBuddy } = createFakeThis(visibleBuddy);
+		(InteractiveMode as any).prototype.mountExistingBuddyIfVisible.call(fakeThis);
+		expect(mountBuddy).toHaveBeenCalledWith(visibleBuddy);
+	});
+
+	test("mounts a buddy with no hidden flag (undefined) at startup", () => {
+		const buddy = {}; // hidden never persisted
+		const { fakeThis, mountBuddy } = createFakeThis(buddy);
+		(InteractiveMode as any).prototype.mountExistingBuddyIfVisible.call(fakeThis);
+		expect(mountBuddy).toHaveBeenCalledWith(buddy);
+	});
+
+	test("does nothing when no buddy is stored", () => {
+		const { fakeThis, mountBuddy } = createFakeThis(null);
+		(InteractiveMode as any).prototype.mountExistingBuddyIfVisible.call(fakeThis);
+		expect(mountBuddy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.25.1",
+	"version": "2.25.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #243

`/buddy off` persists `hidden: true` but the TUI mounts the buddy on startup regardless, so it reappears. Gate the startup mount on the hidden flag.

Implementation plan posted as a comment below.
