### PR TITLE
Committed-scrollback + live-region TUI rendering model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8947,7 +8947,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8976,7 +8976,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -9032,7 +9032,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9161,7 +9161,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9210,7 +9210,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
 				"grammy": "^1.35.0"
@@ -9242,7 +9242,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.25.5",
+			"version": "2.26.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,7 +2457,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.1",
@@ -2471,7 +2472,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.1",
@@ -2485,7 +2487,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.1",
@@ -2499,7 +2502,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.1",
@@ -2513,7 +2517,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.1",
@@ -2527,7 +2532,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.1",
@@ -2541,7 +2547,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.1",
@@ -2555,7 +2562,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.1",
@@ -2569,7 +2577,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.1",
@@ -2583,7 +2592,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.1",
@@ -2597,7 +2607,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.1",
@@ -2611,7 +2622,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.1",
@@ -2625,7 +2637,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.1",
@@ -2639,7 +2652,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.1",
@@ -2653,7 +2667,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.1",
@@ -2667,7 +2682,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.1",
@@ -2681,7 +2697,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.1",
@@ -2695,7 +2712,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.1",
@@ -2709,7 +2727,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.1",
@@ -2723,7 +2742,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.1",
@@ -2737,7 +2757,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.1",
@@ -2751,7 +2772,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.1",
@@ -2765,7 +2787,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.1",
@@ -2779,7 +2802,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.1",
@@ -2793,7 +2817,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.5",
 		"@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -469,6 +469,15 @@ The TUI uses a two-zone rendering architecture:
 
 Because scrollback is append-only, components must commit in display order. If tool 3 finishes before tool 2, tool 3 cannot be committed until tool 2 finishes and commits first. Only the leading contiguous run of fully-finalized components may advance into scrollback.
 
+### Transient inline UI (autocomplete menu)
+
+Inline UI that expands and collapses inside the live region — such as the editor's autocomplete/slash-command menu — needs special handling, because terminals can only scroll content *up* into scrollback, never pull it back *down*. When such a menu opens it grows the live region and pushes committed content up into scrollback; a later shrink (filtering to fewer matches, or dismissing) cannot restore that committed content with a relative redraw, leaving ghost whitespace below the prompt.
+
+Two complementary measures prevent this:
+
+1. **Stable height while open** — the menu block is padded to a per-session high-water mark, so filtering to fewer matches never shrinks the live region. Filtering only repaints in place.
+2. **`recommitAll()` on close** — dismissing or accepting the menu repaints the whole transcript with position-independent sequences, restoring the committed content that scrolled off. This is safe because such menus only appear while the user is typing at the bottom with no agent streaming.
+
 ### Environment variables
 
 | Variable | Purpose |

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -443,6 +443,39 @@ interface MyTheme {
 }
 ```
 
+## Committed-scrollback + live-region model
+
+The TUI uses a two-zone rendering architecture:
+
+- **Committed region** — the first N children of the TUI root (set via `setCommittedChildCount()`). Their output is written to terminal scrollback once and **never re-rendered** by the differential renderer. This prevents the "transcript replay" problem where every turn-end would re-emit the entire session into scrollback.
+- **Live region** — all children after the committed boundary. This is the only content the differential renderer manages. Full redraws are cheap because they only clear and rewrite the small live region (streaming message + spinner + editor + footer).
+
+### Key methods
+
+| Method | Purpose |
+|--------|---------|
+| `setCommittedChildCount(n)` | Mark the first N children as committed |
+| `commit()` | Update line tracking after components move into committed containers |
+| `recommitAll()` | Clear screen + scrollback, re-render everything, re-establish boundary. Used for global actions (theme change, width resize, expand-all, show-images, hide-thinking, session switch) |
+
+### How it works
+
+1. `interactive-mode.ts` maintains a `committedChatContainer` (finalized messages/tools) and a live `chatContainer` (streaming + pending)
+2. When a message or tool finalizes, it moves from live → committed container, and `commit()` advances the boundary
+3. The differential renderer (`doRender`) only renders live children, so the "content shrank" full-redraw path (triggered by spinner removal) only replays the live region — not the whole transcript
+4. Terminal width changes and other global mutations call `recommitAll()` for one deliberate repaint
+
+### Prefix-commit ordering rule
+
+Because scrollback is append-only, components must commit in display order. If tool 3 finishes before tool 2, tool 3 cannot be committed until tool 2 finishes and commits first. Only the leading contiguous run of fully-finalized components may advance into scrollback.
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `DREB_DEBUG_REDRAW=1` | Log every full-redraw trigger to `~/.dreb/agent/dreb-debug.log` |
+| `DREB_TUI_DEBUG=1` | Write full render state to `/tmp/tui/` on each differential render |
+
 ## Debug logging
 
 Set `DREB_TUI_WRITE_LOG` to capture the raw ANSI stream written to stdout.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -35,7 +35,11 @@ export class ToolExecutionComponent extends Container {
 		details?: any;
 	};
 	private convertedImages: Map<number, { data: string; mimeType: string }> = new Map();
+	private pendingConversionCount = 0;
 	private hideComponent = false;
+
+	/** Callback fired when all pending Kitty image conversions settle. */
+	public onConversionComplete?: () => void;
 
 	constructor(
 		toolName: string,
@@ -180,14 +184,29 @@ export class ToolExecutionComponent extends Container {
 			if (this.convertedImages.has(i)) continue;
 
 			const index = i;
+			this.pendingConversionCount++;
 			convertToPng(img.data, img.mimeType).then((converted) => {
+				this.pendingConversionCount--;
 				if (converted) {
 					this.convertedImages.set(index, converted);
 					this.updateDisplay();
 					this.ui.requestRender();
 				}
+				if (this.pendingConversionCount === 0) {
+					this.onConversionComplete?.();
+				}
 			});
 		}
+	}
+
+	/** Whether this component has pending Kitty PNG conversions that haven't settled yet. */
+	hasPendingConversions(): boolean {
+		return this.pendingConversionCount > 0;
+	}
+
+	/** Get the tool call ID for this component. */
+	getToolCallId(): string {
+		return this.toolCallId;
 	}
 
 	setExpanded(expanded: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3120,7 +3120,9 @@ export class InteractiveMode {
 			process.removeListener("SIGINT", ignoreSigint);
 			this.ui.start();
 			this.activateStderrGuard();
-			this.ui.requestRender(true);
+			// stop() moved the cursor, so hardwareCursorRow is stale. recommitAll()
+			// uses position-independent sequences (2J/H/3J) — safe after terminal takeover.
+			this.ui.recommitAll();
 		});
 
 		try {
@@ -3360,8 +3362,9 @@ export class InteractiveMode {
 			// Restart TUI and re-intercept stderr
 			this.ui.start();
 			this.activateStderrGuard();
-			// Force full re-render since external editor uses alternate screen
-			this.ui.requestRender(true);
+			// stop() moved the cursor, so hardwareCursorRow is stale. recommitAll()
+			// uses position-independent sequences (2J/H/3J) — safe after terminal takeover.
+			this.ui.recommitAll();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3223,17 +3223,6 @@ export class InteractiveMode {
 	}
 
 	/**
-	 * Scan the live chatContainer for the longest contiguous prefix of fully-finalized
-	 * components, move them to committedChatContainer, and advance the TUI's committed
-	 * boundary. This prevents the differential renderer from replaying history.
-	 *
-	 * A component is "finalized" if:
-	 * - AssistantMessageComponent: not the active streamingComponent
-	 * - ToolExecutionComponent: not in pendingTools AND no pending Kitty conversions
-	 * - Any other component (Spacer, Text, etc.): always finalized
-	 */
-
-	/**
 	 * Clear committed and live chat, re-render from session state, commit the
 	 * finalized prefix, and repaint everything. Used after session switches,
 	 * imports, resumes, and navigation — any operation that replaces the
@@ -3247,6 +3236,16 @@ export class InteractiveMode {
 		this.ui.recommitAll();
 	}
 
+	/**
+	 * Scan the live chatContainer for the longest contiguous prefix of fully-finalized
+	 * components, move them to committedChatContainer, and advance the TUI's committed
+	 * boundary. This prevents the differential renderer from replaying history.
+	 *
+	 * A component is "finalized" if:
+	 * - AssistantMessageComponent: not the active streamingComponent
+	 * - ToolExecutionComponent: not in pendingTools AND no pending Kitty conversions
+	 * - Any other component (Spacer, Text, etc.): always finalized
+	 */
 	private tryCommitPrefix(): void {
 		let commitCount = 0;
 		for (const child of this.chatContainer.children) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -163,6 +163,7 @@ export interface InteractiveModeOptions {
 export class InteractiveMode {
 	private session: AgentSession;
 	private ui: TUI;
+	private committedChatContainer: Container;
 	private chatContainer: Container;
 	private pendingMessagesContainer: Container;
 	private statusContainer: Container;
@@ -305,6 +306,7 @@ export class InteractiveMode {
 		});
 		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
 		this.headerContainer = new Container();
+		this.committedChatContainer = new Container();
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
@@ -577,6 +579,7 @@ export class InteractiveMode {
 			}
 		}
 
+		this.ui.addChild(this.committedChatContainer);
 		this.ui.addChild(this.chatContainer);
 		this.ui.addChild(this.pendingMessagesContainer);
 		this.ui.addChild(this.statusContainer);
@@ -587,6 +590,10 @@ export class InteractiveMode {
 		this.ui.addChild(this.widgetContainerBelow);
 		this.ui.addChild(this.footer);
 		this.ui.setFocus(this.editor);
+
+		// Mark header + committedChatContainer as committed to scrollback.
+		// The differential renderer will only manage children after this boundary.
+		this.ui.setCommittedChildCount(2);
 
 		this.setupKeyHandlers();
 		this.setupEditorSubmitHandler();
@@ -604,6 +611,7 @@ export class InteractiveMode {
 
 		// Render initial messages AFTER showing loaded resources
 		this.renderInitialMessages();
+		this.tryCommitPrefix();
 
 		// Set terminal title
 		this.updateTerminalTitle();
@@ -621,7 +629,8 @@ export class InteractiveMode {
 		onThemeChange(() => {
 			this.ui.invalidate();
 			this.updateEditorBorderColor();
-			this.ui.requestRender();
+			// Theme affects committed content — full re-commit to repaint
+			this.ui.recommitAll();
 		});
 
 		// Set up git branch watcher (uses provider instead of footer)
@@ -1288,6 +1297,7 @@ export class InteractiveMode {
 
 					// Clear UI state
 					this.editor.setGhostText?.(null);
+					this.committedChatContainer.clear();
 					this.chatContainer.clear();
 					this.pendingMessagesContainer.clear();
 					this.compactionQueuedMessages = [];
@@ -1297,7 +1307,8 @@ export class InteractiveMode {
 
 					// Render any messages added via setup, or show empty session
 					this.renderInitialMessages();
-					this.ui.requestRender();
+					this.tryCommitPrefix();
+					this.ui.recommitAll();
 
 					return { cancelled: false };
 				},
@@ -1307,8 +1318,11 @@ export class InteractiveMode {
 						return { cancelled: true };
 					}
 
+					this.committedChatContainer.clear();
 					this.chatContainer.clear();
 					this.renderInitialMessages();
+					this.tryCommitPrefix();
+					this.ui.recommitAll();
 					this.editor.setText(result.selectedText);
 					this.showStatus("Forked to new session");
 
@@ -1325,8 +1339,11 @@ export class InteractiveMode {
 						return { cancelled: true };
 					}
 
+					this.committedChatContainer.clear();
 					this.chatContainer.clear();
 					this.renderInitialMessages();
+					this.tryCommitPrefix();
+					this.ui.recommitAll();
 					if (result.editorText && !this.editor.getText().trim()) {
 						this.editor.setText(result.editorText);
 					}
@@ -2492,6 +2509,8 @@ export class InteractiveMode {
 				}
 				// Capture assistant response for buddy context
 				this.buddyController.handleEvent(event);
+				// Try to commit finalized components to scrollback
+				this.tryCommitPrefix();
 				this.ui.requestRender();
 				break;
 
@@ -2531,6 +2550,13 @@ export class InteractiveMode {
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
 					this.pendingTools.delete(event.toolCallId);
+					// Wire up Kitty conversion callback for deferred commit
+					component.onConversionComplete = () => {
+						this.tryCommitPrefix();
+						this.ui.requestRender();
+					};
+					// Try to commit finalized components to scrollback
+					this.tryCommitPrefix();
 					this.ui.requestRender();
 				}
 				// Buddy context + reaction for tool execution
@@ -2556,6 +2582,8 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 				}
 				this.pendingTools.clear();
+				// Final commit sweep — all remaining finalized components move to scrollback
+				this.tryCommitPrefix();
 
 				await this.checkShutdownRequested();
 
@@ -2604,8 +2632,11 @@ export class InteractiveMode {
 					this.showStatus("Auto-compaction cancelled");
 				} else if (event.result) {
 					// Rebuild chat to show compacted state
+					this.committedChatContainer.clear();
 					this.chatContainer.clear();
 					this.rebuildChatFromMessages();
+					this.tryCommitPrefix();
+					this.ui.recommitAll();
 					// Add compaction component at bottom so user sees it without scrolling
 					this.addMessageToChat({
 						role: "compactionSummary",
@@ -3003,6 +3034,10 @@ export class InteractiveMode {
 	}
 
 	private rebuildChatFromMessages(): void {
+		// Clear both containers (committed content will be re-committed after rebuild).
+		// Callers that use this for global actions should also call
+		// tryCommitPrefix() + ui.recommitAll() after.
+		this.committedChatContainer.clear();
 		this.chatContainer.clear();
 		const context = this.sessionManager.buildSessionContext();
 		this.renderSessionContext(context);
@@ -3184,25 +3219,70 @@ export class InteractiveMode {
 		this.showStatus(`Tasks panel: ${this.tasksPanel.visible ? "visible" : "hidden"}`);
 	}
 
+	/**
+	 * Scan the live chatContainer for the longest contiguous prefix of fully-finalized
+	 * components, move them to committedChatContainer, and advance the TUI's committed
+	 * boundary. This prevents the differential renderer from replaying history.
+	 *
+	 * A component is "finalized" if:
+	 * - AssistantMessageComponent: not the active streamingComponent
+	 * - ToolExecutionComponent: not in pendingTools AND no pending Kitty conversions
+	 * - Any other component (Spacer, Text, etc.): always finalized
+	 */
+	private tryCommitPrefix(): void {
+		let commitCount = 0;
+		for (const child of this.chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === this.streamingComponent) break; // still streaming
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (this.pendingTools.has(child.getToolCallId())) break; // still executing
+				if (child.hasPendingConversions()) break; // Kitty conversion pending
+				commitCount++;
+			} else {
+				commitCount++; // Spacer, Text, etc. — always safe
+			}
+		}
+
+		if (commitCount === 0) return;
+
+		// Move the finalized prefix from chatContainer to committedChatContainer
+		const toCommit = this.chatContainer.children.splice(0, commitCount);
+		for (const c of toCommit) {
+			this.committedChatContainer.addChild(c);
+		}
+
+		// Update the TUI's committed line tracking
+		this.ui.commit();
+	}
+
 	private toggleToolOutputExpansion(): void {
 		this.setToolsExpanded(!this.toolOutputExpanded);
 	}
 
 	private setToolsExpanded(expanded: boolean): void {
 		this.toolOutputExpanded = expanded;
+		// Expand/collapse in both committed and live containers
+		for (const child of this.committedChatContainer.children) {
+			if (isExpandable(child)) {
+				child.setExpanded(expanded);
+			}
+		}
 		for (const child of this.chatContainer.children) {
 			if (isExpandable(child)) {
 				child.setExpanded(expanded);
 			}
 		}
-		this.ui.requestRender();
+		// Committed content changed — full re-commit to repaint
+		this.ui.recommitAll();
 	}
 
 	private toggleThinkingBlockVisibility(): void {
 		this.hideThinkingBlock = !this.hideThinkingBlock;
 		this.settingsManager.setHideThinkingBlock(this.hideThinkingBlock);
 
-		// Rebuild chat from session messages
+		// Full rebuild: clear both committed and live chat, rebuild, re-commit
+		this.committedChatContainer.clear();
 		this.chatContainer.clear();
 		this.rebuildChatFromMessages();
 
@@ -3212,6 +3292,10 @@ export class InteractiveMode {
 			this.streamingComponent.updateContent(this.streamingMessage);
 			this.chatContainer.addChild(this.streamingComponent);
 		}
+
+		// Committed content rebuilt — full re-commit to repaint
+		this.tryCommitPrefix();
+		this.ui.recommitAll();
 
 		this.showStatus(`Thinking blocks: ${this.hideThinkingBlock ? "hidden" : "visible"}`);
 	}
@@ -3600,11 +3684,18 @@ export class InteractiveMode {
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);
+						for (const child of this.committedChatContainer.children) {
+							if (child instanceof ToolExecutionComponent) {
+								child.setShowImages(enabled);
+							}
+						}
 						for (const child of this.chatContainer.children) {
 							if (child instanceof ToolExecutionComponent) {
 								child.setShowImages(enabled);
 							}
 						}
+						// Committed content changed — full re-commit to repaint
+						this.ui.recommitAll();
 					},
 					onAutoResizeImagesChange: (enabled) => {
 						this.settingsManager.setImageAutoResize(enabled);
@@ -3649,13 +3740,12 @@ export class InteractiveMode {
 					onHideThinkingBlockChange: (hidden) => {
 						this.hideThinkingBlock = hidden;
 						this.settingsManager.setHideThinkingBlock(hidden);
-						for (const child of this.chatContainer.children) {
-							if (child instanceof AssistantMessageComponent) {
-								child.setHideThinkingBlock(hidden);
-							}
-						}
+						// Full rebuild: clear both committed and live chat
+						this.committedChatContainer.clear();
 						this.chatContainer.clear();
 						this.rebuildChatFromMessages();
+						this.tryCommitPrefix();
+						this.ui.recommitAll();
 					},
 					onThinkingDisplayChange: (display) => {
 						const model = this.session.model;
@@ -3950,8 +4040,11 @@ export class InteractiveMode {
 						return;
 					}
 
+					this.committedChatContainer.clear();
 					this.chatContainer.clear();
 					this.renderInitialMessages();
+					this.tryCommitPrefix();
+					this.ui.recommitAll();
 					this.editor.setText(result.selectedText);
 					done();
 					this.showStatus("Branched to new session");
@@ -4062,8 +4155,11 @@ export class InteractiveMode {
 						}
 
 						// Update UI
+						this.committedChatContainer.clear();
 						this.chatContainer.clear();
 						this.renderInitialMessages();
+						this.tryCommitPrefix();
+						this.ui.recommitAll();
 						if (result.editorText && !this.editor.getText().trim()) {
 							this.editor.setText(result.editorText);
 						}
@@ -4149,8 +4245,11 @@ export class InteractiveMode {
 		await this.footerDataProvider.refreshDailyCost();
 
 		// Clear and re-render the chat
+		this.committedChatContainer.clear();
 		this.chatContainer.clear();
 		this.renderInitialMessages();
+		this.tryCommitPrefix();
+		this.ui.recommitAll();
 		this.showStatus("Resumed session");
 	}
 
@@ -4353,6 +4452,8 @@ export class InteractiveMode {
 				this.setupExtensionShortcuts(runner);
 			}
 			this.rebuildChatFromMessages();
+			this.tryCommitPrefix();
+			this.ui.recommitAll();
 			dismissLoader(this.editor as Component);
 			this.showLoadedResources({
 				force: false,
@@ -4422,8 +4523,11 @@ export class InteractiveMode {
 			}
 
 			// Clear and re-render the chat
+			this.committedChatContainer.clear();
 			this.chatContainer.clear();
 			this.renderInitialMessages();
+			this.tryCommitPrefix();
+			this.ui.recommitAll();
 			this.showStatus(`Session imported from: ${inputPath}`);
 		} catch (error: unknown) {
 			this.showError(`Failed to import session: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -4745,6 +4849,7 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 
 		// Clear UI state
 		this.headerContainer.clear();
+		this.committedChatContainer.clear();
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
@@ -4754,7 +4859,7 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(`${theme.fg("accent", "✓ New session started")}`, 1, 1));
-		this.ui.requestRender();
+		this.ui.recommitAll();
 	}
 
 	private handleDebugCommand(): void {
@@ -5090,6 +5195,7 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 
 			// Rebuild UI
 			this.rebuildChatFromMessages();
+			this.tryCommitPrefix();
 
 			// Add compaction component at bottom so user sees it without scrolling
 			const msg = createCompactionSummaryMessage(result.summary, result.tokensBefore, new Date().toISOString());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -199,6 +199,9 @@ export class InteractiveMode {
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 
+	// Deferred commit: set to true when components finalize, commit runs after next render
+	private commitNeeded = false;
+
 	// Tool output expansion state
 	private toolOutputExpanded = false;
 
@@ -595,6 +598,18 @@ export class InteractiveMode {
 		// The differential renderer will only manage children after this boundary.
 		this.ui.setCommittedChildCount(2);
 
+		// Wire up deferred commit: after each render cycle, commit any finalized
+		// components that were painted with their final state. This ensures
+		// components are committed to scrollback only AFTER their final content
+		// has been rendered to the terminal (not before, which would freeze
+		// stale/intermediate content in scrollback).
+		this.ui.onPostRender = () => {
+			if (this.commitNeeded) {
+				this.commitNeeded = false;
+				this.tryCommitPrefix();
+			}
+		};
+
 		this.setupKeyHandlers();
 		this.setupEditorSubmitHandler();
 
@@ -609,9 +624,10 @@ export class InteractiveMode {
 		// Initialize extensions first so resources are shown before messages
 		await this.initExtensions();
 
-		// Render initial messages AFTER showing loaded resources
-		this.renderInitialMessages();
-		this.tryCommitPrefix();
+		// Render initial messages AFTER showing loaded resources.
+		// resetChatDisplay clears containers, renders session messages,
+		// commits the finalized prefix, and paints everything via recommitAll.
+		this.resetChatDisplay();
 
 		// Set terminal title
 		this.updateTerminalTitle();
@@ -1297,18 +1313,14 @@ export class InteractiveMode {
 
 					// Clear UI state
 					this.editor.setGhostText?.(null);
-					this.committedChatContainer.clear();
-					this.chatContainer.clear();
 					this.pendingMessagesContainer.clear();
 					this.compactionQueuedMessages = [];
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
 					this.pendingTools.clear();
 
-					// Render any messages added via setup, or show empty session
-					this.renderInitialMessages();
-					this.tryCommitPrefix();
-					this.ui.recommitAll();
+					// Re-render from new session state
+					this.resetChatDisplay();
 
 					return { cancelled: false };
 				},
@@ -1318,11 +1330,7 @@ export class InteractiveMode {
 						return { cancelled: true };
 					}
 
-					this.committedChatContainer.clear();
-					this.chatContainer.clear();
-					this.renderInitialMessages();
-					this.tryCommitPrefix();
-					this.ui.recommitAll();
+					this.resetChatDisplay();
 					this.editor.setText(result.selectedText);
 					this.showStatus("Forked to new session");
 
@@ -1339,11 +1347,7 @@ export class InteractiveMode {
 						return { cancelled: true };
 					}
 
-					this.committedChatContainer.clear();
-					this.chatContainer.clear();
-					this.renderInitialMessages();
-					this.tryCommitPrefix();
-					this.ui.recommitAll();
+					this.resetChatDisplay();
 					if (result.editorText && !this.editor.getText().trim()) {
 						this.editor.setText(result.editorText);
 					}
@@ -2509,8 +2513,8 @@ export class InteractiveMode {
 				}
 				// Capture assistant response for buddy context
 				this.buddyController.handleEvent(event);
-				// Try to commit finalized components to scrollback
-				this.tryCommitPrefix();
+				// Defer commit until after the next render paints the final state
+				this.commitNeeded = true;
 				this.ui.requestRender();
 				break;
 
@@ -2552,11 +2556,11 @@ export class InteractiveMode {
 					this.pendingTools.delete(event.toolCallId);
 					// Wire up Kitty conversion callback for deferred commit
 					component.onConversionComplete = () => {
-						this.tryCommitPrefix();
+						this.commitNeeded = true;
 						this.ui.requestRender();
 					};
-					// Try to commit finalized components to scrollback
-					this.tryCommitPrefix();
+					// Defer commit until after the next render paints the final state
+					this.commitNeeded = true;
 					this.ui.requestRender();
 				}
 				// Buddy context + reaction for tool execution
@@ -2582,8 +2586,9 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 				}
 				this.pendingTools.clear();
-				// Final commit sweep — all remaining finalized components move to scrollback
-				this.tryCommitPrefix();
+				// Defer final commit sweep — all remaining finalized components will
+				// move to scrollback after the next render paints their final state
+				this.commitNeeded = true;
 
 				await this.checkShutdownRequested();
 
@@ -2632,8 +2637,6 @@ export class InteractiveMode {
 					this.showStatus("Auto-compaction cancelled");
 				} else if (event.result) {
 					// Rebuild chat to show compacted state
-					this.committedChatContainer.clear();
-					this.chatContainer.clear();
 					this.rebuildChatFromMessages();
 					this.tryCommitPrefix();
 					this.ui.recommitAll();
@@ -3229,6 +3232,21 @@ export class InteractiveMode {
 	 * - ToolExecutionComponent: not in pendingTools AND no pending Kitty conversions
 	 * - Any other component (Spacer, Text, etc.): always finalized
 	 */
+
+	/**
+	 * Clear committed and live chat, re-render from session state, commit the
+	 * finalized prefix, and repaint everything. Used after session switches,
+	 * imports, resumes, and navigation — any operation that replaces the
+	 * displayed transcript with a different session's content.
+	 */
+	private resetChatDisplay(): void {
+		this.committedChatContainer.clear();
+		this.chatContainer.clear();
+		this.renderInitialMessages();
+		this.tryCommitPrefix();
+		this.ui.recommitAll();
+	}
+
 	private tryCommitPrefix(): void {
 		let commitCount = 0;
 		for (const child of this.chatContainer.children) {
@@ -3281,9 +3299,7 @@ export class InteractiveMode {
 		this.hideThinkingBlock = !this.hideThinkingBlock;
 		this.settingsManager.setHideThinkingBlock(this.hideThinkingBlock);
 
-		// Full rebuild: clear both committed and live chat, rebuild, re-commit
-		this.committedChatContainer.clear();
-		this.chatContainer.clear();
+		// Full rebuild: rebuildChatFromMessages() clears both containers internally
 		this.rebuildChatFromMessages();
 
 		// If streaming, re-add the streaming component with updated visibility and re-render
@@ -3740,9 +3756,7 @@ export class InteractiveMode {
 					onHideThinkingBlockChange: (hidden) => {
 						this.hideThinkingBlock = hidden;
 						this.settingsManager.setHideThinkingBlock(hidden);
-						// Full rebuild: clear both committed and live chat
-						this.committedChatContainer.clear();
-						this.chatContainer.clear();
+						// Full rebuild: rebuildChatFromMessages() clears both containers
 						this.rebuildChatFromMessages();
 						this.tryCommitPrefix();
 						this.ui.recommitAll();
@@ -4040,11 +4054,7 @@ export class InteractiveMode {
 						return;
 					}
 
-					this.committedChatContainer.clear();
-					this.chatContainer.clear();
-					this.renderInitialMessages();
-					this.tryCommitPrefix();
-					this.ui.recommitAll();
+					this.resetChatDisplay();
 					this.editor.setText(result.selectedText);
 					done();
 					this.showStatus("Branched to new session");
@@ -4155,11 +4165,7 @@ export class InteractiveMode {
 						}
 
 						// Update UI
-						this.committedChatContainer.clear();
-						this.chatContainer.clear();
-						this.renderInitialMessages();
-						this.tryCommitPrefix();
-						this.ui.recommitAll();
+						this.resetChatDisplay();
 						if (result.editorText && !this.editor.getText().trim()) {
 							this.editor.setText(result.editorText);
 						}
@@ -4245,11 +4251,7 @@ export class InteractiveMode {
 		await this.footerDataProvider.refreshDailyCost();
 
 		// Clear and re-render the chat
-		this.committedChatContainer.clear();
-		this.chatContainer.clear();
-		this.renderInitialMessages();
-		this.tryCommitPrefix();
-		this.ui.recommitAll();
+		this.resetChatDisplay();
 		this.showStatus("Resumed session");
 	}
 
@@ -4523,11 +4525,7 @@ export class InteractiveMode {
 			}
 
 			// Clear and re-render the chat
-			this.committedChatContainer.clear();
-			this.chatContainer.clear();
-			this.renderInitialMessages();
-			this.tryCommitPrefix();
-			this.ui.recommitAll();
+			this.resetChatDisplay();
 			this.showStatus(`Session imported from: ${inputPath}`);
 		} catch (error: unknown) {
 			this.showError(`Failed to import session: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -5196,6 +5194,7 @@ ${cycleModelForward || cycleModelBackward ? `| \`${cycleModelForward}\` / \`${cy
 			// Rebuild UI
 			this.rebuildChatFromMessages();
 			this.tryCommitPrefix();
+			this.ui.recommitAll();
 
 			// Add compaction component at bottom so user sees it without scrolling
 			const msg = createCompactionSummaryMessage(result.summary, result.tokensBefore, new Date().toISOString());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -625,9 +625,13 @@ export class InteractiveMode {
 		await this.initExtensions();
 
 		// Render initial messages AFTER showing loaded resources.
-		// resetChatDisplay clears containers, renders session messages,
-		// commits the finalized prefix, and paints everything via recommitAll.
-		this.resetChatDisplay();
+		// Do NOT call resetChatDisplay() here — initExtensions() already populated
+		// chatContainer with Context/Memory/Skills via showLoadedResources().
+		// Clearing would erase that content. Just append session messages, commit,
+		// and repaint.
+		this.renderInitialMessages();
+		this.tryCommitPrefix();
+		this.ui.recommitAll();
 
 		// Set terminal title
 		this.updateTerminalTitle();
@@ -1652,7 +1656,9 @@ export class InteractiveMode {
 			}
 		}
 
-		this.ui.requestRender();
+		// Header is committed content (child 0 of the TUI, before committedChildCount);
+		// requestRender() only re-renders the live region and would silently drop this change.
+		this.ui.recommitAll();
 	}
 
 	private addExtensionTerminalInputListener(

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1781,11 +1781,8 @@ export class InteractiveMode {
 	 */
 	private hideExtensionSelector(): void {
 		this.extensionSelector?.dispose();
-		this.editorContainer.clear();
-		this.editorContainer.addChild(this.editor);
 		this.extensionSelector = undefined;
-		this.ui.setFocus(this.editor);
-		this.ui.requestRender();
+		this.restoreEditorComponent();
 	}
 
 	/**
@@ -1848,11 +1845,8 @@ export class InteractiveMode {
 	 */
 	private hideExtensionInput(): void {
 		this.extensionInput?.dispose();
-		this.editorContainer.clear();
-		this.editorContainer.addChild(this.editor);
 		this.extensionInput = undefined;
-		this.ui.setFocus(this.editor);
-		this.ui.requestRender();
+		this.restoreEditorComponent();
 	}
 
 	/**
@@ -1886,11 +1880,8 @@ export class InteractiveMode {
 	 * Hide the extension editor.
 	 */
 	private hideExtensionEditor(): void {
-		this.editorContainer.clear();
-		this.editorContainer.addChild(this.editor);
 		this.extensionEditor = undefined;
-		this.ui.setFocus(this.editor);
-		this.ui.requestRender();
+		this.restoreEditorComponent();
 	}
 
 	/**
@@ -1994,11 +1985,8 @@ export class InteractiveMode {
 		const isOverlay = options?.overlay ?? false;
 
 		const restoreEditor = () => {
-			this.editorContainer.clear();
-			this.editorContainer.addChild(this.editor);
 			this.editor.setText(savedText);
-			this.ui.setFocus(this.editor);
-			this.ui.requestRender();
+			this.restoreEditorComponent();
 		};
 
 		return new Promise((resolve, reject) => {
@@ -3636,14 +3624,31 @@ export class InteractiveMode {
 	// =========================================================================
 
 	/**
+	 * Restore an editor component into the editor container after an inline modal
+	 * (selector, dialog, input, loader) was shown in its place, and repaint.
+	 *
+	 * Uses recommitAll() rather than requestRender(): an inline modal can grow the
+	 * live region tall enough to push committed content up into terminal scrollback.
+	 * Closing it shrinks the live region, and a differential redraw can't pull that
+	 * committed content back down — leaving ghost whitespace below the prompt.
+	 * recommitAll() repaints the whole transcript with position-independent sequences.
+	 * Safe here: these modals are interactive and the user is at the bottom with no
+	 * agent streaming.
+	 */
+	private restoreEditorComponent(editor: Component = this.editor): void {
+		this.editorContainer.clear();
+		this.editorContainer.addChild(editor);
+		this.ui.setFocus(editor);
+		this.ui.recommitAll();
+	}
+
+	/**
 	 * Shows a selector component in place of the editor.
 	 * @param create Factory that receives a `done` callback and returns the component and focus target
 	 */
 	private showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {
 		const done = () => {
-			this.editorContainer.clear();
-			this.editorContainer.addChild(this.editor);
-			this.ui.setFocus(this.editor);
+			this.restoreEditorComponent();
 		};
 		const { component, focus } = create(done);
 		this.editorContainer.clear();
@@ -4332,10 +4337,7 @@ export class InteractiveMode {
 
 		// Restore editor helper
 		const restoreEditor = () => {
-			this.editorContainer.clear();
-			this.editorContainer.addChild(this.editor);
-			this.ui.setFocus(this.editor);
-			this.ui.requestRender();
+			this.restoreEditorComponent();
 		};
 
 		try {
@@ -4425,10 +4427,7 @@ export class InteractiveMode {
 
 		const dismissLoader = (editor: Component) => {
 			loader.dispose();
-			this.editorContainer.clear();
-			this.editorContainer.addChild(editor);
-			this.ui.setFocus(editor);
-			this.ui.requestRender();
+			this.restoreEditorComponent(editor);
 		};
 
 		try {
@@ -4457,7 +4456,8 @@ export class InteractiveMode {
 			}
 			this.rebuildChatFromMessages();
 			this.tryCommitPrefix();
-			this.ui.recommitAll();
+			// dismissLoader() restores the editor and calls recommitAll(), which
+			// repaints the rebuilt committed content — no separate recommit needed.
 			dismissLoader(this.editor as Component);
 			this.showLoadedResources({
 				force: false,

--- a/packages/coding-agent/test/commit-prefix.test.ts
+++ b/packages/coding-agent/test/commit-prefix.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for the committed-scrollback rendering model's commit logic.
+ * Tests tryCommitPrefix(), onPostRender deferred commit, and Kitty hold-back.
+ */
+import type { AssistantMessage } from "@dreb/ai";
+import { Container, type TUI } from "@dreb/tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function createAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "Hello" }],
+		api: "messages",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+function createFakeTui(): TUI {
+	return {
+		requestRender: vi.fn(),
+		recommitAll: vi.fn(),
+		commit: vi.fn(),
+		setCommittedChildCount: vi.fn(),
+		onPostRender: undefined,
+	} as unknown as TUI;
+}
+
+describe("tryCommitPrefix logic", () => {
+	test("finalized AssistantMessageComponent is committable when not streaming", () => {
+		const chatContainer = new Container();
+		const committedChatContainer = new Container();
+
+		// Create a finalized assistant message (not the active streaming component)
+		const msg = new AssistantMessageComponent(createAssistantMessage());
+		chatContainer.addChild(msg);
+
+		// Simulate tryCommitPrefix logic
+		const streamingComponent: AssistantMessageComponent | undefined = undefined;
+		const pendingTools = new Map<string, ToolExecutionComponent>();
+		let commitCount = 0;
+
+		for (const child of chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === streamingComponent) break;
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (pendingTools.has(child.getToolCallId())) break;
+				if (child.hasPendingConversions()) break;
+				commitCount++;
+			} else {
+				commitCount++;
+			}
+		}
+
+		expect(commitCount).toBe(1);
+
+		// Move to committed
+		const toCommit = chatContainer.children.splice(0, commitCount);
+		for (const c of toCommit) committedChatContainer.addChild(c);
+
+		expect(chatContainer.children.length).toBe(0);
+		expect(committedChatContainer.children.length).toBe(1);
+	});
+
+	test("streaming AssistantMessageComponent blocks commit", () => {
+		const chatContainer = new Container();
+
+		const msg = new AssistantMessageComponent(
+			createAssistantMessage({
+				content: [{ type: "text", text: "Still typing..." }],
+			}),
+		);
+		chatContainer.addChild(msg);
+
+		// This IS the active streaming component
+		const streamingComponent = msg;
+		const pendingTools = new Map<string, ToolExecutionComponent>();
+		let commitCount = 0;
+
+		for (const child of chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === streamingComponent) break; // blocks here
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (pendingTools.has(child.getToolCallId())) break;
+				if (child.hasPendingConversions()) break;
+				commitCount++;
+			} else {
+				commitCount++;
+			}
+		}
+
+		expect(commitCount).toBe(0);
+	});
+
+	test("pending tool blocks commit of itself and everything after", () => {
+		const ui = createFakeTui();
+		const chatContainer = new Container();
+		const committedChatContainer = new Container();
+
+		// Finalized message
+		const msg = new AssistantMessageComponent(
+			createAssistantMessage({
+				content: [{ type: "text", text: "Done" }],
+			}),
+		);
+		chatContainer.addChild(msg);
+
+		// Pending tool (still executing)
+		const tool = new ToolExecutionComponent("bash", "tool-1", { command: "ls" }, {}, undefined as any, ui);
+		chatContainer.addChild(tool);
+
+		const streamingComponent: AssistantMessageComponent | undefined = undefined;
+		const pendingTools = new Map<string, ToolExecutionComponent>();
+		pendingTools.set("tool-1", tool);
+		let commitCount = 0;
+
+		for (const child of chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === streamingComponent) break;
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (pendingTools.has(child.getToolCallId())) break; // blocks here
+				if (child.hasPendingConversions()) break;
+				commitCount++;
+			} else {
+				commitCount++;
+			}
+		}
+
+		// Only the message before the pending tool can be committed
+		expect(commitCount).toBe(1);
+
+		const toCommit = chatContainer.children.splice(0, commitCount);
+		for (const c of toCommit) committedChatContainer.addChild(c);
+
+		expect(committedChatContainer.children.length).toBe(1);
+		expect(chatContainer.children.length).toBe(1); // tool remains
+	});
+
+	test("finalized tool without pending conversions is committable", () => {
+		const ui = createFakeTui();
+		const chatContainer = new Container();
+
+		const tool = new ToolExecutionComponent("bash", "tool-1", { command: "ls" }, {}, undefined as any, ui);
+		tool.updateResult({ content: [{ type: "text", text: "file.txt" }], isError: false });
+		chatContainer.addChild(tool);
+
+		const streamingComponent: AssistantMessageComponent | undefined = undefined;
+		const pendingTools = new Map<string, ToolExecutionComponent>();
+		// tool-1 is NOT in pendingTools (already finished)
+		let commitCount = 0;
+
+		for (const child of chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === streamingComponent) break;
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (pendingTools.has(child.getToolCallId())) break;
+				if (child.hasPendingConversions()) break;
+				commitCount++;
+			} else {
+				commitCount++;
+			}
+		}
+
+		expect(commitCount).toBe(1);
+	});
+});
+
+describe("Kitty hold-back", () => {
+	test("hasPendingConversions blocks commit", () => {
+		const ui = createFakeTui();
+		const chatContainer = new Container();
+
+		const tool = new ToolExecutionComponent("bash", "tool-1", { command: "ls" }, {}, undefined as any, ui);
+		tool.updateResult({
+			content: [
+				{ type: "text", text: "result" },
+				{ type: "image", data: "base64data", mimeType: "image/jpeg" },
+			],
+			isError: false,
+		});
+		chatContainer.addChild(tool);
+
+		// hasPendingConversions is false by default (no kitty support active)
+		expect(tool.hasPendingConversions()).toBe(false);
+	});
+
+	test("getToolCallId returns the correct ID", () => {
+		const ui = createFakeTui();
+		const tool = new ToolExecutionComponent("bash", "my-tool-id-123", {}, {}, undefined as any, ui);
+		expect(tool.getToolCallId()).toBe("my-tool-id-123");
+	});
+
+	test("onConversionComplete callback fires when set", () => {
+		const ui = createFakeTui();
+		const tool = new ToolExecutionComponent("bash", "tool-1", {}, {}, undefined as any, ui);
+		tool.updateResult({ content: [{ type: "text", text: "ok" }], isError: false });
+
+		let callbackFired = false;
+		tool.onConversionComplete = () => {
+			callbackFired = true;
+		};
+
+		// Callback is available to be called
+		expect(tool.onConversionComplete).toBeDefined();
+		tool.onConversionComplete!();
+		expect(callbackFired).toBe(true);
+	});
+});
+
+describe("deferred commit via onPostRender", () => {
+	test("commitNeeded flag pattern ensures render-before-commit ordering", () => {
+		// This tests the pattern used by interactive-mode:
+		// 1. Set commitNeeded = true
+		// 2. requestRender() schedules next render
+		// 3. After render, onPostRender fires and does the commit
+		const ui = createFakeTui();
+		const events: string[] = [];
+
+		let commitNeeded = false;
+		ui.onPostRender = () => {
+			if (commitNeeded) {
+				events.push("commit");
+				commitNeeded = false;
+			}
+		};
+
+		// Simulate tool_execution_end
+		events.push("updateResult");
+		commitNeeded = true;
+		events.push("requestRender");
+
+		// Simulate render cycle completing
+		events.push("render");
+		ui.onPostRender!();
+
+		expect(events).toEqual(["updateResult", "requestRender", "render", "commit"]);
+		expect(commitNeeded).toBe(false);
+	});
+
+	test("commitNeeded is false by default — no spurious commits", () => {
+		const ui = createFakeTui();
+		let commitCalled = false;
+
+		let commitNeeded = false;
+		ui.onPostRender = () => {
+			if (commitNeeded) {
+				commitCalled = true;
+				commitNeeded = false;
+			}
+		};
+
+		// Simulate a normal render (no pending commit)
+		ui.onPostRender!();
+		expect(commitCalled).toBe(false);
+	});
+
+	test("multiple events before render only commit once", () => {
+		const ui = createFakeTui();
+		let commitCount = 0;
+
+		let commitNeeded = false;
+		ui.onPostRender = () => {
+			if (commitNeeded) {
+				commitCount++;
+				commitNeeded = false;
+			}
+		};
+
+		// Multiple events set commitNeeded
+		commitNeeded = true; // message_end
+		commitNeeded = true; // tool_execution_end
+		commitNeeded = true; // agent_end
+
+		// Only one commit on render
+		ui.onPostRender!();
+		expect(commitCount).toBe(1);
+
+		// Second render: nothing to commit
+		ui.onPostRender!();
+		expect(commitCount).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/commit-prefix.test.ts
+++ b/packages/coding-agent/test/commit-prefix.test.ts
@@ -188,7 +188,7 @@ describe("tryCommitPrefix logic", () => {
 });
 
 describe("Kitty hold-back", () => {
-	test("hasPendingConversions blocks commit", () => {
+	test("hasPendingConversions() returns false when no Kitty support is active", () => {
 		const ui = createFakeTui();
 		const chatContainer = new Container();
 
@@ -204,6 +204,58 @@ describe("Kitty hold-back", () => {
 
 		// hasPendingConversions is false by default (no kitty support active)
 		expect(tool.hasPendingConversions()).toBe(false);
+	});
+
+	test("hasPendingConversions() blocks commit when Kitty conversions are pending", () => {
+		const ui = createFakeTui();
+		const chatContainer = new Container();
+		const committedChatContainer = new Container();
+
+		// Finalized message before the tool
+		const msg = new AssistantMessageComponent(createAssistantMessage());
+		chatContainer.addChild(msg);
+
+		// Tool with a result — mock hasPendingConversions to simulate active Kitty conversion
+		const tool = new ToolExecutionComponent("bash", "tool-1", { command: "ls" }, {}, undefined as any, ui);
+		tool.updateResult({
+			content: [
+				{ type: "text", text: "result" },
+				{ type: "image", data: "base64data", mimeType: "image/jpeg" },
+			],
+			isError: false,
+		});
+		vi.spyOn(tool, "hasPendingConversions").mockReturnValue(true);
+		chatContainer.addChild(tool);
+
+		// Another finalized message after the tool
+		const msg2 = new AssistantMessageComponent(createAssistantMessage());
+		chatContainer.addChild(msg2);
+
+		const streamingComponent: AssistantMessageComponent | undefined = undefined;
+		const pendingTools = new Map<string, ToolExecutionComponent>();
+		let commitCount = 0;
+
+		for (const child of chatContainer.children) {
+			if (child instanceof AssistantMessageComponent) {
+				if (child === streamingComponent) break;
+				commitCount++;
+			} else if (child instanceof ToolExecutionComponent) {
+				if (pendingTools.has(child.getToolCallId())) break;
+				if (child.hasPendingConversions()) break; // blocks here
+				commitCount++;
+			} else {
+				commitCount++;
+			}
+		}
+
+		// Only the message before the pending-conversion tool is committed
+		expect(commitCount).toBe(1);
+
+		const toCommit = chatContainer.children.splice(0, commitCount);
+		for (const c of toCommit) committedChatContainer.addChild(c);
+
+		expect(committedChatContainer.children.length).toBe(1);
+		expect(chatContainer.children.length).toBe(2); // tool + msg2 remain
 	});
 
 	test("getToolCallId returns the correct ID", () => {

--- a/packages/coding-agent/test/interactive-mode-suspend.test.ts
+++ b/packages/coding-agent/test/interactive-mode-suspend.test.ts
@@ -5,6 +5,7 @@ type FakeUi = {
 	start: () => void;
 	stop: () => void;
 	requestRender: (force?: boolean) => void;
+	recommitAll: () => void;
 };
 
 type HandleCtrlZThis = {
@@ -34,6 +35,7 @@ describe("InteractiveMode.handleCtrlZ", () => {
 			start: vi.fn(),
 			stop: vi.fn(),
 			requestRender: vi.fn(),
+			recommitAll: vi.fn(),
 		};
 		const context: HandleCtrlZThis = { ui, activateStderrGuard: vi.fn() };
 		const keepAliveHandle = setTimeout(() => undefined, 0);
@@ -76,7 +78,7 @@ describe("InteractiveMode.handleCtrlZ", () => {
 		expect(clearIntervalSpy).toHaveBeenCalledWith(keepAliveHandle);
 		expect(removeListenerSpy).toHaveBeenCalledWith("SIGINT", sigintHandler);
 		expect(ui.start).toHaveBeenCalledTimes(1);
-		expect(ui.requestRender).toHaveBeenCalledWith(true);
+		expect(ui.recommitAll).toHaveBeenCalledTimes(1);
 	});
 
 	test("cleans up the temporary handlers if suspension fails", () => {
@@ -84,6 +86,7 @@ describe("InteractiveMode.handleCtrlZ", () => {
 			start: vi.fn(),
 			stop: vi.fn(),
 			requestRender: vi.fn(),
+			recommitAll: vi.fn(),
 		};
 		const context: HandleCtrlZThis = { ui, activateStderrGuard: vi.fn() };
 		const keepAliveHandle = setTimeout(() => undefined, 0);
@@ -111,6 +114,6 @@ describe("InteractiveMode.handleCtrlZ", () => {
 		expect(clearIntervalSpy).toHaveBeenCalledWith(keepAliveHandle);
 		expect(removeListenerSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
 		expect(ui.start).not.toHaveBeenCalled();
-		expect(ui.requestRender).not.toHaveBeenCalled();
+		expect(ui.recommitAll).not.toHaveBeenCalled();
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.25.5",
+  "version": "2.26.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.25.5",
+	"version": "2.26.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -244,6 +244,12 @@ export class Editor implements Component, Focusable {
 	private autocompleteState: "regular" | "force" | null = null;
 	private autocompletePrefix: string = "";
 	private autocompleteMaxVisible: number = 5;
+	// High-water mark of autocomplete-list rows rendered during the current open
+	// session. The block is padded to this height so filtering to fewer matches
+	// never shrinks the live region — a shrink would strand committed content in
+	// scrollback (ghost whitespace), since terminals can't scroll scrollback down.
+	// Reset to 0 when the menu closes (clearAutocompleteUi).
+	private autocompleteRenderHighWater: number = 0;
 	private autocompleteAbort?: AbortController;
 	private autocompleteDebounceTimer?: ReturnType<typeof setTimeout>;
 	private autocompleteRequestTask: Promise<void> = Promise.resolve();
@@ -539,10 +545,18 @@ export class Editor implements Component, Focusable {
 			result.push(horizontal.repeat(width));
 		}
 
-		// Add autocomplete list if active
+		// Add autocomplete list if active.
+		// The block is padded to a per-session high-water mark so that filtering the
+		// list to fewer matches never shrinks the live region. A shrink would force
+		// committed content (already in terminal scrollback) to scroll back down to
+		// fill the freed rows — which terminals cannot do — leaving ghost whitespace.
+		// Keeping the height stable means filtering only repaints in place; the menu
+		// is fully cleared on close via recommitAll() (see cancelAutocomplete).
 		if (this.autocompleteState && this.autocompleteList) {
 			const autocompleteResult = this.autocompleteList.render(contentWidth);
-			for (const line of autocompleteResult) {
+			this.autocompleteRenderHighWater = Math.max(this.autocompleteRenderHighWater, autocompleteResult.length);
+			for (let i = 0; i < this.autocompleteRenderHighWater; i++) {
+				const line = autocompleteResult[i] ?? "";
 				const lineWidth = visibleWidth(line);
 				const linePadding = " ".repeat(Math.max(0, contentWidth - lineWidth));
 				result.push(`${leftPadding}${line}${linePadding}${rightPadding}`);
@@ -2256,11 +2270,20 @@ export class Editor implements Component, Focusable {
 		this.autocompleteState = null;
 		this.autocompleteList = undefined;
 		this.autocompletePrefix = "";
+		this.autocompleteRenderHighWater = 0;
 	}
 
 	private cancelAutocomplete(): void {
+		const wasActive = this.autocompleteState !== null;
 		this.cancelAutocompleteRequest();
 		this.clearAutocompleteUi();
+		// Closing the menu shrinks the live region. While the menu was open it pushed
+		// committed content up into terminal scrollback; a live-region-only redraw
+		// can't pull that content back, so a relative clear would leave ghost
+		// whitespace below the prompt. recommitAll() repaints the whole transcript
+		// with position-independent sequences. Safe here: autocomplete only happens
+		// while the user is typing at the bottom with no agent streaming.
+		if (wasActive) this.tui.recommitAll();
 	}
 
 	public isShowingAutocomplete(): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -333,7 +333,10 @@ export class TUI extends Container {
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}
 					if (this.overlayStack.length === 0) this.terminal.hideCursor();
-					this.requestRender();
+					// Overlay dismissed — user was at the bottom of the TUI by definition,
+					// so a full recommit is safe and ensures no ghost whitespace from
+					// overlay padding lines.
+					this.recommitAll();
 				}
 			},
 			setHidden: (hidden: boolean) => {
@@ -384,7 +387,8 @@ export class TUI extends Container {
 			this.setFocus(topVisible?.component ?? overlay.preFocus);
 		}
 		if (this.overlayStack.length === 0) this.terminal.hideCursor();
-		this.requestRender();
+		// Overlay dismissed — full recommit clears any ghost padding lines.
+		this.recommitAll();
 	}
 
 	/** Check if there are any visible overlays */

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -552,6 +552,7 @@ export class TUI extends Container {
 	 * repaint finalized content (theme change, width resize, expand-all, etc.).
 	 */
 	recommitAll(): void {
+		if (this.stopped) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1308,6 +1308,17 @@ export class TUI extends Container {
 		// Use a full redraw (clear screen) to avoid ghost whitespace from terminals
 		// that don't properly collapse cleared lines below the cursor.
 		if (this.previousLines.length > newLines.length) {
+			if (this.previousLines.length > height) {
+				// Previous live content exceeded the terminal viewport — overlay padding
+				// or long streaming content caused scrolling. A live-region-only clear
+				// can't restore the viewport (CUU can't reach past viewport top into
+				// scrollback), so do a full recommit to repaint everything cleanly.
+				logRedraw(
+					`content shrank past viewport (${this.previousLines.length} -> ${newLines.length}, height=${height})`,
+				);
+				this.recommitAll();
+				return;
+			}
 			logRedraw(`content shrank (${this.previousLines.length} -> ${newLines.length})`);
 			fullRender(true);
 			return;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -234,6 +234,8 @@ export class TUI extends Container {
 
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
 	public onDebug?: () => void;
+	/** Callback fired after every render completes (doRender differential path, fullRender, or recommitAll). */
+	public onPostRender?: () => void;
 	private renderTimer: ReturnType<typeof setTimeout> | null = null;
 	private lastRenderAt = 0;
 	private cursorRow = 0; // Logical cursor row within live region (end of live content)
@@ -593,6 +595,8 @@ export class TUI extends Container {
 		} else {
 			this.positionHardwareCursor(null, liveLines.length);
 		}
+
+		this.onPostRender?.();
 	}
 
 	/**
@@ -1078,6 +1082,7 @@ export class TUI extends Container {
 			this.previousLines = newLines;
 			this.previousWidth = width;
 			this.previousHeight = height;
+			this.onPostRender?.();
 		};
 
 		const debugRedraw = process.env.DREB_DEBUG_REDRAW === "1";
@@ -1142,6 +1147,7 @@ export class TUI extends Container {
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousViewportTop = prevViewportTop;
 			this.previousHeight = height;
+			this.onPostRender?.();
 			return;
 		}
 
@@ -1197,6 +1203,7 @@ export class TUI extends Container {
 			this.previousWidth = width;
 			this.previousHeight = height;
 			this.previousViewportTop = prevViewportTop;
+			this.onPostRender?.();
 			return;
 		}
 
@@ -1359,6 +1366,8 @@ export class TUI extends Container {
 		this.previousLines = newLines;
 		this.previousWidth = width;
 		this.previousHeight = height;
+
+		this.onPostRender?.();
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -107,9 +107,9 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 	return undefined;
 }
 
-function isTermuxSession(): boolean {
-	return Boolean(process.env.TERMUX_VERSION);
-}
+// isTermuxSession guard removed: with the committed-scrollback model, height
+// changes only re-render the small live region (no transcript replay), so the
+// Termux special-case is no longer needed.
 
 /**
  * Options for overlay positioning and sizing.
@@ -210,11 +210,23 @@ export class Container implements Component {
 const RENDER_THROTTLE_MS = 16; // ~60fps
 
 /**
- * TUI - Main class for managing terminal UI with differential rendering
+ * TUI - Main class for managing terminal UI with differential rendering.
+ *
+ * Supports a committed-scrollback + live-region rendering model:
+ * - **Committed region**: the first `committedChildCount` children. Their output
+ *   is written to terminal scrollback once and never re-rendered by the
+ *   differential renderer.
+ * - **Live region**: children after the committed boundary. This is the only
+ *   content the differential renderer manages — keeps full redraws cheap and
+ *   prevents transcript replay into scrollback.
+ *
+ * Use `setCommittedChildCount()` + `commit()` to advance the boundary.
+ * Use `recommitAll()` for global actions that need to repaint everything
+ * (theme change, width resize, expand-all, etc.).
  */
 export class TUI extends Container {
 	public terminal: Terminal;
-	private previousLines: string[] = [];
+	private previousLines: string[] = []; // Live-region lines only (after committed boundary)
 	private previousWidth = 0;
 	private previousHeight = 0;
 	private focusedComponent: Component | null = null;
@@ -224,15 +236,19 @@ export class TUI extends Container {
 	public onDebug?: () => void;
 	private renderTimer: ReturnType<typeof setTimeout> | null = null;
 	private lastRenderAt = 0;
-	private cursorRow = 0; // Logical cursor row (end of rendered content)
-	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
+	private cursorRow = 0; // Logical cursor row within live region (end of live content)
+	private hardwareCursorRow = 0; // Actual cursor row within live region (may differ due to IME)
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
 	private showHardwareCursor = process.env.DREB_HARDWARE_CURSOR === "1";
-	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
-	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
+	private maxLinesRendered = 0; // High-water mark of live-region lines rendered
+	private previousViewportTop = 0; // Previous viewport top within live region
 	private fullRedrawCount = 0;
 	private stopped = false;
+
+	// Committed-scrollback state
+	private committedChildCount = 0; // children[0..n) are committed to scrollback
+	private committedLineCount = 0; // total lines written to scrollback from committed children
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -457,14 +473,137 @@ export class TUI extends Container {
 	requestRender(force = false): void {
 		if (force) {
 			this.previousLines = [];
-			this.previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
-			this.previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
+			// Don't set previousWidth/Height to -1 — that would trigger recommitAll
+			// (scrollback clear) on the next doRender. Force should only re-render
+			// the live region cleanly, not wipe committed scrollback.
+			this.previousWidth = 0;
+			this.previousHeight = 0;
+			// Keep hardwareCursorRow intact — it tracks the physical cursor position,
+			// which hasn't moved. fullRender needs it to calculate movement to
+			// live-region start. cursorRow can be reset since it's the logical end.
 			this.cursorRow = 0;
-			this.hardwareCursorRow = 0;
 			this.maxLinesRendered = 0;
 			this.previousViewportTop = 0;
 		}
 		this.scheduleRender();
+	}
+
+	/**
+	 * Get the number of committed children.
+	 */
+	getCommittedChildCount(): number {
+		return this.committedChildCount;
+	}
+
+	/**
+	 * Set how many leading children are committed (their output is in scrollback).
+	 * Must be followed by `commit()` to update line tracking.
+	 */
+	setCommittedChildCount(count: number): void {
+		this.committedChildCount = count;
+	}
+
+	/**
+	 * Update committed line tracking after components were added to committed containers.
+	 * Re-renders committed children to count their current lines, then trims
+	 * `previousLines` and adjusts cursor state so the differential renderer
+	 * only operates on the live region.
+	 */
+	commit(): void {
+		const width = this.terminal.columns;
+
+		// Count lines from committed children
+		let newCommittedLineCount = 0;
+		for (let i = 0; i < this.committedChildCount && i < this.children.length; i++) {
+			const childLines = this.children[i].render(width);
+			newCommittedLineCount += childLines.length;
+		}
+
+		const delta = newCommittedLineCount - this.committedLineCount;
+		if (delta <= 0) return; // nothing new to commit
+
+		// Trim previousLines: remove the leading committed lines
+		if (this.previousLines.length >= delta) {
+			this.previousLines = this.previousLines.slice(delta);
+		} else {
+			this.previousLines = [];
+		}
+
+		// Adjust cursor positions (now relative to smaller live region)
+		this.hardwareCursorRow = Math.max(0, this.hardwareCursorRow - delta);
+		this.cursorRow = Math.max(0, this.cursorRow - delta);
+
+		this.committedLineCount = newCommittedLineCount;
+
+		// Reset live-region tracking
+		this.maxLinesRendered = this.previousLines.length;
+		this.previousViewportTop = Math.max(0, this.previousLines.length - this.terminal.rows);
+	}
+
+	/**
+	 * Clear screen + scrollback, re-render the entire transcript (committed + live),
+	 * and re-establish the committed boundary. Used for global actions that need to
+	 * repaint finalized content (theme change, width resize, expand-all, etc.).
+	 */
+	recommitAll(): void {
+		const width = this.terminal.columns;
+		const height = this.terminal.rows;
+
+		// Render ALL children (committed + live)
+		const allLines: string[] = [];
+		let newCommittedLineCount = 0;
+		for (let i = 0; i < this.children.length; i++) {
+			const childLines = this.children[i].render(width);
+			for (const line of childLines) allLines.push(line);
+			if (i < this.committedChildCount) {
+				newCommittedLineCount += childLines.length;
+			}
+		}
+
+		// Extract cursor position before applying resets
+		const cursorPos = this.extractCursorPosition(allLines, height);
+
+		this.applyLineResets(allLines);
+
+		// Clear screen + scrollback, write everything
+		this.fullRedrawCount += 1;
+		let buffer = "\x1b[?2026h\x1b[2J\x1b[H\x1b[3J";
+		for (let i = 0; i < allLines.length; i++) {
+			if (i > 0) buffer += "\r\n";
+			buffer += allLines[i];
+		}
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+
+		// Update state: previousLines holds only live portion
+		const liveLines = allLines.slice(newCommittedLineCount);
+		this.committedLineCount = newCommittedLineCount;
+		this.previousLines = liveLines;
+		this.cursorRow = Math.max(0, liveLines.length - 1);
+		this.hardwareCursorRow = this.cursorRow;
+		this.maxLinesRendered = liveLines.length;
+		this.previousViewportTop = Math.max(0, liveLines.length - height);
+		this.previousWidth = width;
+		this.previousHeight = height;
+
+		// Position hardware cursor (cursorPos is absolute, adjust to live-relative)
+		if (cursorPos && cursorPos.row >= newCommittedLineCount) {
+			const liveCursorPos = { row: cursorPos.row - newCommittedLineCount, col: cursorPos.col };
+			this.positionHardwareCursor(liveCursorPos, liveLines.length);
+		} else {
+			this.positionHardwareCursor(null, liveLines.length);
+		}
+	}
+
+	/**
+	 * Render only the live-region children (after the committed boundary).
+	 */
+	private renderLive(width: number): string[] {
+		const lines: string[] = [];
+		for (let i = this.committedChildCount; i < this.children.length; i++) {
+			for (const line of this.children[i].render(width)) lines.push(line);
+		}
+		return lines;
 	}
 
 	private scheduleRender(): void {
@@ -894,8 +1033,8 @@ export class TUI extends Container {
 			return targetScreenRow - currentScreenRow;
 		};
 
-		// Render all components to get new lines
-		let newLines = this.render(width);
+		// Render only live-region children (after committed boundary)
+		let newLines = this.renderLive(width);
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
@@ -907,13 +1046,17 @@ export class TUI extends Container {
 
 		newLines = this.applyLineResets(newLines);
 
-		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean, clearScrollback = false): void => {
+		// Helper to clear the live region and re-render live-region lines.
+		// Only clears from the live-region start to the end of the screen —
+		// committed scrollback above is never touched.
+		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
-				buffer += "\x1b[2J\x1b[H"; // Clear screen, home
-				if (clearScrollback) buffer += "\x1b[3J"; // Clear scrollback (only for width changes)
+				// Move cursor to start of live region (row 0 in live-relative coords)
+				const moveUp = hardwareCursorRow; // Use local (captured from this.hardwareCursorRow)
+				if (moveUp > 0) buffer += `\x1b[${moveUp}A`;
+				buffer += "\r\x1b[J"; // Carriage return + clear from cursor to end of screen
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
@@ -945,26 +1088,28 @@ export class TUI extends Container {
 			fs.appendFileSync(logPath, msg);
 		};
 
-		// First render - just output everything without clearing (assumes clean screen)
+		// First render or force re-render — clear live region and write
 		if (this.previousLines.length === 0 && !widthChanged && !heightChanged) {
 			logRedraw("first render");
-			fullRender(false);
+			fullRender(true);
 			return;
 		}
 
-		// Width changes always need a full re-render because wrapping changes.
+		// Width changes need a full re-render of everything (including committed
+		// content, since wrapping changes). Use recommitAll to clear screen +
+		// scrollback and re-render the entire transcript at the new width.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
-			fullRender(true, true);
+			this.recommitAll();
 			return;
 		}
 
-		// Height changes normally need a full re-render to keep the visible viewport aligned,
-		// but Termux changes height when the software keyboard shows or hides.
-		// In that environment, a full redraw causes the entire history to replay on every toggle.
-		if (heightChanged && !isTermuxSession()) {
+		// Height changes need a full re-render to keep the visible viewport aligned.
+		// With the committed-scrollback model, only the live region is re-rendered,
+		// so this is cheap and safe even on Termux (no transcript replay).
+		if (heightChanged) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
-			fullRender(true, false);
+			fullRender(true);
 			return;
 		}
 
@@ -1008,7 +1153,7 @@ export class TUI extends Container {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true, false);
+					fullRender(true);
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
@@ -1023,7 +1168,7 @@ export class TUI extends Container {
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true, false);
+					fullRender(true);
 					return;
 				}
 				if (extraLines > 0) {
@@ -1077,7 +1222,7 @@ export class TUI extends Container {
 			} else {
 				// Viewport needs to shift — full redraw without scrollback clear
 				logRedraw(`firstChanged < viewportTop with viewport shift (${firstChanged} < ${prevViewportTop})`);
-				fullRender(true, false);
+				fullRender(true);
 				return;
 			}
 		}
@@ -1157,7 +1302,7 @@ export class TUI extends Container {
 		// that don't properly collapse cleared lines below the cursor.
 		if (this.previousLines.length > newLines.length) {
 			logRedraw(`content shrank (${this.previousLines.length} -> ${newLines.length})`);
-			fullRender(true, false);
+			fullRender(true);
 			return;
 		}
 

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, Container, TUI } from "../src/tui.js";
+import { VirtualTerminal } from "./virtual-terminal.js";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+	render(_width: number): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	getWriteCount(): number {
+		return this.writes.length;
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+describe("TUI committed-scrollback region", () => {
+	it("commit() prevents transcript replay on content shrink", async () => {
+		// This is the core fix: after committing finalized content, a 1-line
+		// shrink (like spinner removal at agent_end) should NOT trigger a full
+		// transcript replay into scrollback.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		// Simulate layout: [committed container] [live container]
+		const committedContainer = new Container();
+		const liveContainer = new Container();
+		tui.addChild(committedContainer);
+		tui.addChild(liveContainer);
+
+		// Add "finalized messages" to committed container (taller than terminal)
+		const messageLines = Array.from({ length: 15 }, (_, i) => `Message ${i}`);
+		const messageComponent = new TestComponent();
+		messageComponent.lines = messageLines;
+		committedContainer.addChild(messageComponent);
+
+		// Add "spinner" to live container
+		const spinnerComponent = new TestComponent();
+		spinnerComponent.lines = ["Working..."];
+		liveContainer.addChild(spinnerComponent);
+
+		tui.start();
+		await terminal.flush();
+
+		// Mark committedContainer as committed (child 0)
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		const _redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// Simulate spinner removal (the trigger for the bug)
+		spinnerComponent.lines = [];
+		tui.requestRender();
+		await terminal.flush();
+
+		// The key assertions:
+		// 1. No full-screen clear (\x1b[2J) — committed content untouched
+		assert.ok(
+			!terminal.getWrites().includes("\x1b[2J"),
+			"Content shrink after commit should not clear entire screen",
+		);
+		// 2. No scrollback clear (\x1b[3J)
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Content shrink after commit should not clear scrollback");
+		// 3. The committed lines ("Message 0" through "Message 14") should NOT
+		//    appear in the write stream — they were already in scrollback.
+		assert.ok(
+			!terminal.getWrites().includes("Message 0"),
+			"Committed message content should not be re-emitted on shrink",
+		);
+
+		tui.stop();
+	});
+
+	it("commit writes to scrollback once — subsequent shrink doesn't grow it", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committedContainer = new Container();
+		const liveContainer = new Container();
+		tui.addChild(committedContainer);
+		tui.addChild(liveContainer);
+
+		// 5 message lines + 2 live lines
+		const messages = new TestComponent();
+		messages.lines = ["Msg 0", "Msg 1", "Msg 2", "Msg 3", "Msg 4"];
+		committedContainer.addChild(messages);
+
+		const spinner = new TestComponent();
+		spinner.lines = ["Working...", "Status"];
+		liveContainer.addChild(spinner);
+
+		tui.start();
+		await terminal.flush();
+
+		// Commit the message container
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		// Get scroll buffer size after commit
+		const bufferAfterCommit = terminal.getScrollBuffer().filter((l) => l.trim()).length;
+
+		// Shrink live content (remove one line)
+		spinner.lines = ["Working..."];
+		tui.requestRender();
+		await terminal.flush();
+
+		const bufferAfterShrink = terminal.getScrollBuffer().filter((l) => l.trim()).length;
+
+		// Scroll buffer should NOT grow by a transcript-sized copy
+		// (at most it might change by 1 line, but should not double)
+		assert.ok(
+			bufferAfterShrink <= bufferAfterCommit + 1,
+			`Scroll buffer grew unexpectedly: before=${bufferAfterCommit}, after=${bufferAfterShrink}`,
+		);
+
+		tui.stop();
+	});
+
+	it("live-region differential path leaves committed lines untouched", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const msg = new TestComponent();
+		msg.lines = ["Header", "Committed content"];
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Editor line 1", "Editor line 2"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		terminal.clearWrites();
+
+		// Update only live content
+		editor.lines = ["Editor line 1", "Editor UPDATED"];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Committed content should not be in the write stream
+		assert.ok(!terminal.getWrites().includes("Header"), "Committed 'Header' should not be re-emitted");
+		assert.ok(!terminal.getWrites().includes("Committed content"), "Committed content should not be re-emitted");
+		// Live content should be updated
+		assert.ok(terminal.getWrites().includes("Editor UPDATED"), "Live content should be updated");
+
+		tui.stop();
+	});
+
+	it("recommitAll() clears scrollback and re-renders everything", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const msg = new TestComponent();
+		msg.lines = ["Old theme message"];
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Editor"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		const redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// Simulate theme change: modify content and recommit
+		msg.lines = ["New theme message"];
+		tui.recommitAll();
+
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "recommitAll should clear scrollback");
+		assert.ok(terminal.getWrites().includes("New theme message"), "recommitAll should re-render committed content");
+		assert.ok(terminal.getWrites().includes("Editor"), "recommitAll should re-render live content");
+		assert.ok(tui.fullRedraws > redrawsBefore, "recommitAll should increment fullRedraws");
+
+		tui.stop();
+	});
+
+	it("width change triggers recommitAll (re-renders everything at new width)", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const msg = new TestComponent();
+		msg.lines = ["Committed at width 40"];
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Live"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		terminal.clearWrites();
+
+		// Width change should trigger recommitAll (re-render at new width)
+		terminal.resize(60, 10);
+		await terminal.flush();
+
+		assert.ok(terminal.getWrites().includes("\x1b[3J"), "Width change should clear scrollback via recommitAll");
+		assert.ok(
+			terminal.getWrites().includes("Committed at width 40"),
+			"Width change should re-render committed content",
+		);
+
+		tui.stop();
+	});
+
+	it("height change only re-renders live region (no scrollback clear)", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const msg = new TestComponent();
+		msg.lines = Array.from({ length: 8 }, (_, i) => `Msg ${i}`);
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Editor"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		tui.setCommittedChildCount(1);
+		tui.commit();
+
+		terminal.clearWrites();
+
+		// Height change should NOT clear scrollback
+		terminal.resize(40, 15);
+		await terminal.flush();
+
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
+		// Committed content should NOT be re-emitted
+		assert.ok(!terminal.getWrites().includes("Msg 0"), "Height change should not re-emit committed content");
+
+		tui.stop();
+	});
+
+	it("multiple commits accumulate correctly", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		tui.setCommittedChildCount(1);
+
+		// Start with live content only
+		const comp1 = new TestComponent();
+		comp1.lines = ["Turn 1 msg", "Turn 1 tool"];
+		live.addChild(comp1);
+
+		const comp2 = new TestComponent();
+		comp2.lines = ["Turn 2 msg"];
+		live.addChild(comp2);
+
+		const spinner = new TestComponent();
+		spinner.lines = ["Working..."];
+		live.addChild(spinner);
+
+		tui.start();
+		await terminal.flush();
+
+		// Commit turn 1 (move comp1 from live to committed)
+		live.removeChild(comp1);
+		committed.addChild(comp1);
+		tui.commit();
+
+		terminal.clearWrites();
+
+		// Commit turn 2
+		live.removeChild(comp2);
+		committed.addChild(comp2);
+		tui.commit();
+
+		terminal.clearWrites();
+
+		// Remove spinner (content shrink)
+		spinner.lines = [];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Neither turn's content should be re-emitted
+		assert.ok(!terminal.getWrites().includes("Turn 1"), "Turn 1 not re-emitted after shrink");
+		assert.ok(!terminal.getWrites().includes("Turn 2"), "Turn 2 not re-emitted after shrink");
+
+		tui.stop();
+	});
+
+	it("getCommittedChildCount returns current value", () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		assert.strictEqual(tui.getCommittedChildCount(), 0);
+
+		tui.addChild(new TestComponent());
+		tui.setCommittedChildCount(1);
+		assert.strictEqual(tui.getCommittedChildCount(), 1);
+	});
+});

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -349,4 +349,213 @@ describe("TUI committed-scrollback region", () => {
 		tui.setCommittedChildCount(1);
 		assert.strictEqual(tui.getCommittedChildCount(), 1);
 	});
+
+	it("onPostRender fires after fullRender path", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+		tui.setCommittedChildCount(1);
+
+		const msg = new TestComponent();
+		msg.lines = ["Committed"];
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Editor"];
+		live.addChild(editor);
+
+		let postRenderCount = 0;
+		tui.onPostRender = () => {
+			postRenderCount++;
+		};
+
+		tui.start();
+		await terminal.flush();
+
+		assert.ok(postRenderCount > 0, "onPostRender should fire after first render");
+
+		const before = postRenderCount;
+
+		// Trigger content shrink → fullRender path
+		editor.lines = [];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.ok(postRenderCount > before, "onPostRender should fire after fullRender (content shrink)");
+
+		tui.stop();
+	});
+
+	it("onPostRender fires after recommitAll", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+		tui.setCommittedChildCount(1);
+
+		const msg = new TestComponent();
+		msg.lines = ["Msg"];
+		committed.addChild(msg);
+
+		tui.start();
+		await terminal.flush();
+
+		let postRenderCount = 0;
+		tui.onPostRender = () => {
+			postRenderCount++;
+		};
+
+		tui.recommitAll();
+		assert.strictEqual(postRenderCount, 1, "onPostRender should fire after recommitAll");
+
+		tui.stop();
+	});
+
+	it("onPostRender fires after differential render path", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const live = new Container();
+		tui.addChild(live);
+
+		const editor = new TestComponent();
+		editor.lines = ["Line 1", "Line 2"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		let postRenderCount = 0;
+		tui.onPostRender = () => {
+			postRenderCount++;
+		};
+
+		// Change only one line → differential path (no fullRender)
+		editor.lines = ["Line 1", "Line UPDATED"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.strictEqual(postRenderCount, 1, "onPostRender should fire after differential render");
+
+		tui.stop();
+	});
+
+	it("deferred commit via onPostRender paints final state before committing", async () => {
+		// This is the key regression test for Finding 2: components must be
+		// rendered with their final state BEFORE being committed to scrollback.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+		tui.setCommittedChildCount(1);
+
+		// Simulate a tool in "streaming" state
+		const tool = new TestComponent();
+		tool.lines = ["Working..."];
+		live.addChild(tool);
+
+		const spinner = new TestComponent();
+		spinner.lines = ["Spinner"];
+		live.addChild(spinner);
+
+		tui.start();
+		await terminal.flush();
+
+		// Simulate tool_execution_end: update to final state, then defer commit
+		tool.lines = ["Tool result: success", "Output line 2", "Output line 3"];
+
+		// Wire up deferred commit (like interactive-mode does)
+		let commitNeeded = false;
+		tui.onPostRender = () => {
+			if (commitNeeded) {
+				commitNeeded = false;
+				// Move tool from live to committed (like tryCommitPrefix)
+				live.removeChild(tool);
+				committed.addChild(tool);
+				tui.commit();
+			}
+		};
+
+		// Mark for deferred commit and trigger render
+		commitNeeded = true;
+		terminal.clearWrites();
+		tui.requestRender();
+		await terminal.flush();
+
+		// The render should have painted the FINAL tool state before committing
+		const writes = terminal.getWrites();
+		assert.ok(
+			writes.includes("Tool result: success"),
+			"Final tool state should be painted to terminal before commit",
+		);
+		assert.ok(writes.includes("Output line 3"), "All lines of final tool state should be visible");
+
+		// After the post-render callback, tool is in committed container
+		assert.strictEqual(committed.children.length, 1, "Tool should be in committed container");
+		assert.strictEqual(live.children.length, 1, "Only spinner should remain in live");
+
+		// A subsequent render should NOT re-emit the committed tool content
+		terminal.clearWrites();
+		spinner.lines = ["Done"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.ok(
+			!terminal.getWrites().includes("Tool result"),
+			"Committed tool content should not be re-emitted on subsequent render",
+		);
+
+		tui.stop();
+	});
+
+	it("commit() is idempotent when called twice without new content", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+		tui.setCommittedChildCount(1);
+
+		const msg = new TestComponent();
+		msg.lines = ["Msg 1", "Msg 2"];
+		committed.addChild(msg);
+
+		const editor = new TestComponent();
+		editor.lines = ["Editor"];
+		live.addChild(editor);
+
+		tui.start();
+		await terminal.flush();
+
+		tui.commit();
+		const afterFirst = tui.getCommittedChildCount();
+
+		// Second commit with no new content
+		tui.commit();
+		const afterSecond = tui.getCommittedChildCount();
+
+		assert.strictEqual(afterFirst, afterSecond, "Idempotent commit should not change state");
+
+		// Rendering should still work
+		terminal.clearWrites();
+		editor.lines = ["Updated"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.ok(terminal.getWrites().includes("Updated"), "Rendering should work after idempotent commit");
+
+		tui.stop();
+	});
 });

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
+import type { AutocompleteProvider } from "../src/autocomplete.js";
+import { Editor } from "../src/components/editor.js";
 import { type Component, Container, TUI } from "../src/tui.js";
+import { defaultEditorTheme } from "./test-themes.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
 class TestComponent implements Component {
@@ -555,6 +558,188 @@ describe("TUI committed-scrollback region", () => {
 		await terminal.flush();
 
 		assert.ok(terminal.getWrites().includes("Updated"), "Rendering should work after idempotent commit");
+
+		tui.stop();
+	});
+});
+
+describe("autocomplete + committed scrollback (ghost whitespace)", () => {
+	function applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: { value: string },
+		prefix: string,
+	) {
+		const line = lines[cursorLine] || "";
+		const before = line.slice(0, cursorCol - prefix.length);
+		const after = line.slice(cursorCol);
+		const newLines = [...lines];
+		newLines[cursorLine] = before + item.value + after;
+		return { lines: newLines, cursorLine, cursorCol: cursorCol - prefix.length + item.value.length };
+	}
+
+	async function flushAutocomplete(): Promise<void> {
+		await Promise.resolve();
+		await new Promise((resolve) => setImmediate(resolve));
+	}
+
+	function slashProvider(): AutocompleteProvider {
+		const all = [
+			{ value: "/help", label: "/help" },
+			{ value: "/model", label: "/model" },
+			{ value: "/settings", label: "/settings" },
+			{ value: "/compact", label: "/compact" },
+			{ value: "/clear", label: "/clear" },
+		];
+		return {
+			getSuggestions: async (lines, _cl, cursorCol) => {
+				const text = lines[0] || "";
+				const prefix = text.slice(0, cursorCol);
+				if (!prefix.startsWith("/")) return null;
+				const items = all.filter((i) => i.value.startsWith(prefix));
+				return items.length ? { items, prefix } : null;
+			},
+			applyCompletion,
+		};
+	}
+
+	function setup(height: number) {
+		const terminal = new VirtualTerminal(40, height);
+		const tui = new TUI(terminal);
+		const committed = new Container();
+		const transcript = new TestComponent();
+		transcript.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		committed.addChild(transcript);
+		const editor = new Editor(tui, defaultEditorTheme);
+		const footer = new TestComponent();
+		footer.lines = ["[footer]"];
+		tui.addChild(committed);
+		tui.addChild(editor);
+		tui.addChild(footer);
+		editor.setAutocompleteProvider(slashProvider());
+		return { terminal, tui, editor };
+	}
+
+	it("dismissing the menu restores committed content (no ghost whitespace)", async () => {
+		const { terminal, tui, editor } = setup(10);
+		tui.start();
+		tui.setFocus(editor);
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		editor.handleInput("/");
+		tui.requestRender();
+		await flushAutocomplete();
+		await terminal.flush();
+		assert.strictEqual(editor.isShowingAutocomplete(), true, "menu open after /");
+
+		// Dismiss with Escape
+		editor.handleInput("\x1b");
+		tui.requestRender();
+		await terminal.flush();
+
+		const viewport = terminal.getViewport();
+		const lastNonBlank = viewport.map((l) => l.trim()).reduce((acc, l, i) => (l !== "" ? i : acc), -1);
+		const blankBelow = viewport.length - 1 - lastNonBlank;
+		assert.ok(blankBelow <= 1, `Expected no ghost whitespace below prompt, got ${blankBelow} blank rows`);
+		// Committed content scrolled off by the menu should be back in view.
+		assert.ok(
+			viewport.some((l) => l.includes("[footer]")),
+			"footer should be visible at the bottom after dismiss",
+		);
+
+		tui.stop();
+	});
+
+	it("filtering the menu shorter keeps the live region height stable", async () => {
+		const { terminal, tui, editor } = setup(12);
+		tui.start();
+		tui.setFocus(editor);
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		editor.handleInput("/");
+		tui.requestRender();
+		await flushAutocomplete();
+		await terminal.flush();
+		const footerRowOpen = terminal.getViewport().findIndex((l) => l.includes("[footer]"));
+
+		// Filter from 5 matches down to 1 ("/s" -> /settings)
+		editor.handleInput("s");
+		tui.requestRender();
+		await flushAutocomplete();
+		await terminal.flush();
+		const footerRowFiltered = terminal.getViewport().findIndex((l) => l.includes("[footer]"));
+
+		assert.strictEqual(
+			footerRowFiltered,
+			footerRowOpen,
+			"footer row must not move up when the list narrows (no live-region shrink)",
+		);
+
+		tui.stop();
+	});
+
+	it("closing a tall inline modal via recommitAll leaves no ghost whitespace", async () => {
+		// Mirrors the interactive-mode pattern: an inline modal (settings/extension
+		// selector) is swapped into the editor slot, growing the live region and
+		// scrolling committed content off; closing it must recommitAll() to restore
+		// the committed content rather than leaving blank rows below the prompt.
+		const height = 10;
+		const terminal = new VirtualTerminal(40, height);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const transcript = new TestComponent();
+		transcript.lines = Array.from({ length: 30 }, (_, i) => `Line ${i}`);
+		committed.addChild(transcript);
+
+		// editorSlot holds either the small editor or a tall modal
+		const editorSlot = new Container();
+		const editor = new TestComponent();
+		editor.lines = ["> "];
+		editorSlot.addChild(editor);
+		const footer = new TestComponent();
+		footer.lines = ["[footer]"];
+
+		tui.addChild(committed);
+		tui.addChild(editorSlot);
+		tui.addChild(footer);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		// Open a tall modal in the editor slot (taller than what fits below committed)
+		const modal = new TestComponent();
+		modal.lines = Array.from({ length: 6 }, (_, i) => `Setting ${i}`);
+		editorSlot.clear();
+		editorSlot.addChild(modal);
+		tui.requestRender();
+		await terminal.flush();
+
+		// Close: swap the editor back and recommitAll (what restoreEditorComponent does)
+		editorSlot.clear();
+		editorSlot.addChild(editor);
+		tui.recommitAll();
+		await terminal.flush();
+
+		const viewport = terminal.getViewport();
+		const lastNonBlank = viewport.map((l) => l.trim()).reduce((acc, l, i) => (l !== "" ? i : acc), -1);
+		const blankBelow = viewport.length - 1 - lastNonBlank;
+		assert.ok(blankBelow <= 1, `Expected no ghost whitespace after modal close, got ${blankBelow} blank rows`);
+		assert.ok(
+			viewport.some((l) => l.includes("[footer]")),
+			"footer should be visible at the bottom after modal close",
+		);
+		assert.ok(!viewport.some((l) => l.includes("Setting ")), "modal content should be gone after close");
 
 		tui.stop();
 	});

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -95,7 +95,10 @@ describe("TUI resize handling", () => {
 		});
 	});
 
-	it("skips full re-render on height changes in Termux", async () => {
+	it("height changes in Termux only re-render live region (no transcript replay)", async () => {
+		// With committed-scrollback model, height changes only re-render the
+		// live region. This is cheap and safe even on Termux — no Termux
+		// special-case is needed since the live region is small.
 		await withEnv({ TERMUX_VERSION: "1" }, async () => {
 			const terminal = new LoggingVirtualTerminal(40, 10);
 			const tui = new TUI(terminal);
@@ -113,8 +116,8 @@ describe("TUI resize handling", () => {
 				await terminal.flush();
 			}
 
-			assert.strictEqual(tui.fullRedraws, initialRedraws, "Height change should not trigger full redraw");
-			assert.ok(!terminal.getWrites().includes("\x1b[2J"), "Height change should not clear the screen");
+			// Height changes trigger live-region redraws (cheap, no scrollback clear)
+			assert.ok(tui.fullRedraws > initialRedraws, "Height change should trigger live-region redraw");
 			assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
 
 			const viewport = terminal.getViewport();
@@ -564,11 +567,12 @@ describe("TUI scrollback preservation", () => {
 			await terminal.flush();
 			terminal.clearWrites();
 
-			// Height change should clear screen but NOT scrollback
+			// Height change clears only the live region (not scrollback).
+			// Uses \x1b[J (clear from cursor to end) instead of \x1b[2J (clear entire screen).
 			terminal.resize(40, 15);
 			await terminal.flush();
 
-			assert.ok(terminal.getWrites().includes("\x1b[2J"), "Height change should clear screen");
+			assert.ok(terminal.getWrites().includes("\x1b[J"), "Height change should clear live region");
 			assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
 			tui.stop();
 		});


### PR DESCRIPTION
Closes #257

Architectural fix for the TUI replaying the entire transcript into scrollback on routine refreshes (the root cause behind the #239 symptom). Introduces a committed-scrollback + live-region rendering model: finalized messages/tools are committed to scrollback once and never re-rendered; only the small bottom live region is differentially rendered. The seven global mutation actions do one deliberate full re-commit.

Implementation plan posted as a comment below.
