### PR TITLE
fix: add telegram package license metadata

### DIFF
--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -2,6 +2,7 @@
 	"name": "@dreb/telegram",
 	"version": "2.25.5",
 	"description": "Telegram bot frontend for dreb coding agent",
+	"license": "MIT",
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Add missing `license` metadata to the `@dreb/telegram` package manifest.
- Use `MIT`, matching the repository root `LICENSE` file.
- Keep the change package-metadata-only: no runtime code, dependency, version, or build output changes.

## Validation
- `node` metadata assertion verifying `@dreb/telegram` now declares `license: "MIT"` and the root license is MIT
- `cd packages/telegram && npm pack --dry-run --json`
- `git diff --check`
