### PR TITLE
Use git worktrees for new PRs instead of switching branches

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -633,6 +633,12 @@ async function executeToolCallsSequential(
 				),
 			);
 		}
+
+		// Refresh tools from live state after each call — allows tools like chdir
+		// to rebuild tool bindings mid-turn so subsequent calls use the updated cwd.
+		if (config.getLatestTools) {
+			currentContext.tools = config.getLatestTools();
+		}
 	}
 
 	return { results, endTurn };

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -629,6 +629,7 @@ export class Agent {
 				return this.dequeueSteeringMessages();
 			},
 			getFollowUpMessages: async () => this.dequeueFollowUpMessages(),
+			getLatestTools: () => this._state.tools,
 		};
 
 		try {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -257,6 +257,13 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * The hook receives the agent abort signal and is responsible for honoring it.
 	 */
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+
+	/**
+	 * Called after each tool execution in sequential mode to get the current live tool list.
+	 * Allows tools like `chdir` to rebuild the tool set mid-turn so that subsequent tool
+	 * calls in the same model response use updated bindings (e.g. new bash cwd).
+	 */
+	getLatestTools?: () => AgentTool<any>[];
 }
 
 /**

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -348,8 +348,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras", () => {
-		it("llama3.1-8b - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("cerebras", "llama3.1-8b");
+		it("gpt-oss-120b - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("cerebras", "gpt-oss-120b");
 			const result = await testContextOverflow(model, process.env.CEREBRAS_API_KEY!);
 			logResult(result);
 
@@ -624,7 +624,7 @@ describe("Context overflow error handling", () => {
 
 	let llamaCppRunning = false;
 	try {
-		execSync("curl -s --max-time 1 http://localhost:8081/health > /dev/null", { stdio: "ignore" });
+		execSync("curl -s --max-time 2 http://localhost:8081/v1/models | grep -q '\"id\"'", { stdio: "ignore" });
 		llamaCppRunning = true;
 	} catch {
 		llamaCppRunning = false;

--- a/packages/ai/test/lazy-module-load.test.ts
+++ b/packages/ai/test/lazy-module-load.test.ts
@@ -63,7 +63,10 @@ function runProbe(action: string): ProbeResult {
 	return JSON.parse(lastLine) as ProbeResult;
 }
 
-describe("lazy provider module loading", () => {
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+const skip = nodeVersion < 22;
+
+describe.skipIf(skip)("lazy provider module loading", () => {
 	it("does not load provider SDKs when importing the root barrel", () => {
 		const result = runProbe("");
 		expect(result.loadedSpecifiers).toEqual([]);

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -152,7 +152,7 @@ describe("Token Statistics on Abort", () => {
 	});
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras Provider", () => {
-		const llm = getModel("cerebras", "llama3.1-8b");
+		const llm = getModel("cerebras", "gpt-oss-120b");
 
 		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
 			await testTokensOnAbort(llm);

--- a/packages/coding-agent/skills/mach6-implement/SKILL.md
+++ b/packages/coding-agent/skills/mach6-implement/SKILL.md
@@ -30,10 +30,30 @@ Extract:
 If only a PR number is given → **implement mode**.
 If finding numbers or `ci` → **fix mode**.
 
-## Step 2: Checkout
+## Step 2: Checkout via worktree
+
+Instead of switching branches in the current directory, use a git worktree. This keeps the user's working tree untouched.
 
 ```bash
-gh pr checkout <pr-number>
+# Get the PR's branch name and linked issue number
+PR_BRANCH=$(gh pr view <pr-number> --json headRefName --jq '.headRefName')
+# Extract issue number from PR body (look for "Closes #N" or similar)
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the PR branch, reuse it.
+# If not, create one:
+git worktree add "../${REPO_NAME}-worktrees/issue-<N>" "$PR_BRANCH"
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "<worktree-path>" }
+```
+
+Then pull latest changes:
+```bash
 git pull
 ```
 

--- a/packages/coding-agent/skills/mach6-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6-plan/SKILL.md
@@ -93,6 +93,11 @@ Use a git worktree to isolate the PR's work from the current directory. This kee
 # Derive branch name from issue
 # Format: feature/issue-<N>-<slug> (slug = 3-5 words from title, lowercase, hyphens)
 
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the branch, reuse it (skip branch + worktree creation).
+# If not, create the branch and worktree:
+
 # Create the branch (without switching to it)
 git branch feature/issue-<N>-<slug>
 

--- a/packages/coding-agent/skills/mach6-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6-plan/SKILL.md
@@ -87,12 +87,29 @@ Update task: plan → completed, branch → in_progress.
 
 ## Step 6: Create branch and draft PR
 
+Use a git worktree to isolate the PR's work from the current directory. This keeps the user's working tree untouched.
+
 ```bash
 # Derive branch name from issue
 # Format: feature/issue-<N>-<slug> (slug = 3-5 words from title, lowercase, hyphens)
-git checkout -b feature/issue-<N>-<slug>
 
-# Create an empty commit so the PR can be opened
+# Create the branch (without switching to it)
+git branch feature/issue-<N>-<slug>
+
+# Determine repo name for worktree path convention
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Create a worktree for the new branch
+git worktree add "../${REPO_NAME}-worktrees/issue-<N>" feature/issue-<N>-<slug>
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "../<repo-name>-worktrees/issue-<N>" }
+```
+
+Now operating in the worktree — create the empty commit and push:
+```bash
 git commit --allow-empty -m "chore: open PR for issue <N>"
 
 git push -u origin feature/issue-<N>-<slug>

--- a/packages/coding-agent/skills/mach6-publish/SKILL.md
+++ b/packages/coding-agent/skills/mach6-publish/SKILL.md
@@ -30,8 +30,27 @@ tasks_update([
 
 ## Step 2: Pre-merge checks
 
+Instead of switching branches in the current directory, use a git worktree:
+
 ```bash
-gh pr checkout <pr-number>
+# Get the PR's branch name
+PR_BRANCH=$(gh pr view <pr-number> --json headRefName --jq '.headRefName')
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the PR branch, reuse it.
+# If not, create one:
+git worktree add "../${REPO_NAME}-worktrees/issue-<N>" "$PR_BRANCH"
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "<worktree-path>" }
+```
+
+Then pull and check status:
+```bash
 git pull
 gh pr view <pr-number> --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,comments,body
 gh pr checks <pr-number>
@@ -141,14 +160,19 @@ gh pr merge <pr-number> --squash --delete-branch
 
 Use `--squash` by default. If the user prefers a different merge strategy, they can specify.
 
-Then update local:
+Then switch back to the main checkout and clean up the worktree:
 ```bash
+# Switch back to the original (main) checkout
+chdir { path: "<original-repo-path>" }
+
+# Pull latest on default branch
 git checkout $(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 git pull
-```
 
-Clean up local feature branch if it still exists:
-```bash
+# Remove the worktree (the branch was already deleted by --delete-branch)
+git worktree remove "../<repo-name>-worktrees/issue-<N>" --force 2>/dev/null
+
+# Clean up local feature branch if it still exists
 git branch -d <branch-name> 2>/dev/null
 ```
 

--- a/packages/coding-agent/skills/mach6-review/SKILL.md
+++ b/packages/coding-agent/skills/mach6-review/SKILL.md
@@ -39,8 +39,27 @@ Extract:
 
 ## Step 3: Prepare
 
+Instead of switching branches in the current directory, use a git worktree:
+
 ```bash
-gh pr checkout <pr-number>
+# Get the PR's branch name
+PR_BRANCH=$(gh pr view <pr-number> --json headRefName --jq '.headRefName')
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the PR branch, reuse it.
+# If not, create one:
+git worktree add "../${REPO_NAME}-worktrees/issue-<N>" "$PR_BRANCH"
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "<worktree-path>" }
+```
+
+Then pull latest and mark ready:
+```bash
 git pull
 ```
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -91,7 +91,7 @@ import {
 } from "./tools/index.js";
 import { expandSkillContent } from "./tools/skill.js";
 import { createToolDefinitionFromAgentTool, wrapToolDefinition } from "./tools/tool-definition-wrapper.js";
-import { isWorktreeConflictCommand } from "./worktree-guard.js";
+import { clearWorktreeCache, isWorktreeConflictCommand } from "./worktree-guard.js";
 
 // ============================================================================
 // Constants
@@ -2924,12 +2924,26 @@ export class AgentSession {
 	 * to use the new cwd. Called by the `chdir` tool via the `onChdir` callback.
 	 */
 	private _changeCwd(newCwd: string): void {
+		const oldCwd = this._cwd;
+		const oldGitRepoState = this._gitRepoState;
+
 		this._cwd = newCwd;
 		this._gitRepoState = getGitRepoState(this._cwd) ?? undefined;
-		this._buildRuntime({
-			activeToolNames: this.getActiveToolNames(),
-			includeAllExtensionTools: true,
-		});
+
+		// Invalidate worktree cache — the new cwd may have different worktrees
+		clearWorktreeCache();
+
+		try {
+			this._buildRuntime({
+				activeToolNames: this.getActiveToolNames(),
+				includeAllExtensionTools: true,
+			});
+		} catch (err) {
+			// Rollback state on failure to prevent split state
+			this._cwd = oldCwd;
+			this._gitRepoState = oldGitRepoState;
+			throw err;
+		}
 		// The system prompt and footer will reflect the new cwd after _buildRuntime completes.
 		// No explicit event needed — the rebuilt system prompt is set on the agent immediately.
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -91,6 +91,7 @@ import {
 } from "./tools/index.js";
 import { expandSkillContent } from "./tools/skill.js";
 import { createToolDefinitionFromAgentTool, wrapToolDefinition } from "./tools/tool-definition-wrapper.js";
+import { isWorktreeConflictCommand } from "./worktree-guard.js";
 
 // ============================================================================
 // Constants
@@ -409,6 +410,15 @@ export class AgentSession {
 						return {
 							block: true as const,
 							reason: `Command blocked by forbidden-commands guard: "${pattern}" matched "${command}".\n\n${FORBIDDEN_COMMAND_GUIDANCE}`,
+						};
+					}
+
+					// Check worktree conflicts — prevents checking out a branch that has an active worktree
+					const worktreeConflict = isWorktreeConflictCommand(command, this._cwd);
+					if (worktreeConflict.blocked) {
+						return {
+							block: true as const,
+							reason: worktreeConflict.reason ?? "Command blocked by worktree guard.",
 						};
 					}
 
@@ -2803,6 +2813,7 @@ export class AgentSession {
 			: createAllToolDefinitions(this._cwd, {
 					read: { autoResizeImages },
 					bash: { commandPrefix: shellCommandPrefix },
+					chdir: { onChdir: (newCwd: string) => this._changeCwd(newCwd) },
 					skill: {
 						getSkills: () => this._getFilteredSkills(),
 						getSessionId: () => this.sessionId,
@@ -2886,6 +2897,7 @@ export class AgentSession {
 			: [
 					"read",
 					"bash",
+					"chdir",
 					"edit",
 					"write",
 					"grep",
@@ -2905,6 +2917,21 @@ export class AgentSession {
 			activeToolNames: baseActiveToolNames,
 			includeAllExtensionTools: options.includeAllExtensionTools,
 		});
+	}
+
+	/**
+	 * Change the session's working directory. Rebuilds all tool bindings and system prompt
+	 * to use the new cwd. Called by the `chdir` tool via the `onChdir` callback.
+	 */
+	private _changeCwd(newCwd: string): void {
+		this._cwd = newCwd;
+		this._gitRepoState = getGitRepoState(this._cwd) ?? undefined;
+		this._buildRuntime({
+			activeToolNames: this.getActiveToolNames(),
+			includeAllExtensionTools: true,
+		});
+		// The system prompt and footer will reflect the new cwd after _buildRuntime completes.
+		// No explicit event needed — the rebuilt system prompt is set on the agent immediately.
 	}
 
 	async reload(): Promise<void> {

--- a/packages/coding-agent/src/core/git-env.ts
+++ b/packages/coding-agent/src/core/git-env.ts
@@ -1,0 +1,9 @@
+/**
+ * Create a clean environment for git commands.
+ * Removes GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE to prevent inherited
+ * env vars (e.g. from git hooks) from causing git to use the wrong repo.
+ */
+export function gitEnv(): NodeJS.ProcessEnv {
+	const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...env } = process.env;
+	return env;
+}

--- a/packages/coding-agent/src/core/git-repo-state.ts
+++ b/packages/coding-agent/src/core/git-repo-state.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { gitEnv } from "./git-env.js";
 import { findGitRoot } from "./git-root.js";
 
 export interface GitRepoState {
@@ -7,6 +8,7 @@ export interface GitRepoState {
 	recentCommits: Array<{ hash: string; subject: string }>;
 	recentTags: Array<{ name: string; date: string }>;
 	openPRs: Array<{ number: number; title: string; url: string }>;
+	worktrees: Array<{ path: string; branch: string }>;
 }
 
 const SPAWN_OPTS: { encoding: "utf8"; timeout: number; stdio: ["ignore", "pipe", "ignore"] } = {
@@ -96,5 +98,32 @@ export function getGitRepoState(cwd: string): GitRepoState | null {
 		}
 	}
 
-	return { branch, dirtyCount, recentCommits, recentTags, openPRs };
+	// Worktrees (only non-main worktrees — skip the primary working copy)
+	const worktrees: Array<{ path: string; branch: string }> = [];
+	const wtResult = spawnSync("git", ["worktree", "list", "--porcelain"], { ...SPAWN_OPTS, cwd, env: gitEnv() });
+	if (wtResult.status === 0 && wtResult.stdout) {
+		let currentPath = "";
+		let isFirst = true;
+		for (const line of wtResult.stdout.split("\n")) {
+			if (line.startsWith("worktree ")) {
+				if (!isFirst && currentPath) {
+					// Flush previous entry (it had no branch — skip detached)
+				}
+				currentPath = line.slice("worktree ".length);
+				isFirst = false;
+			} else if (line.startsWith("branch refs/heads/") && currentPath) {
+				const wtBranch = line.slice("branch refs/heads/".length);
+				worktrees.push({ path: currentPath, branch: wtBranch });
+				currentPath = "";
+			} else if (line === "") {
+				currentPath = "";
+			}
+		}
+	}
+	// Remove the first entry (main worktree = the repo itself)
+	if (worktrees.length > 0) {
+		worktrees.shift();
+	}
+
+	return { branch, dirtyCount, recentCommits, recentTags, openPRs, worktrees };
 }

--- a/packages/coding-agent/src/core/git-repo-state.ts
+++ b/packages/coding-agent/src/core/git-repo-state.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { gitEnv } from "./git-env.js";
 import { findGitRoot } from "./git-root.js";
+import { listWorktrees } from "./worktree.js";
 
 export interface GitRepoState {
 	branch: string;
@@ -11,10 +12,11 @@ export interface GitRepoState {
 	worktrees: Array<{ path: string; branch: string }>;
 }
 
-const SPAWN_OPTS: { encoding: "utf8"; timeout: number; stdio: ["ignore", "pipe", "ignore"] } = {
+const SPAWN_OPTS: { encoding: "utf8"; timeout: number; stdio: ["ignore", "pipe", "ignore"]; env: NodeJS.ProcessEnv } = {
 	encoding: "utf8",
 	timeout: 5000,
 	stdio: ["ignore", "pipe", "ignore"],
+	env: gitEnv(),
 };
 
 export function getGitRepoState(cwd: string): GitRepoState | null {
@@ -98,32 +100,11 @@ export function getGitRepoState(cwd: string): GitRepoState | null {
 		}
 	}
 
-	// Worktrees (only non-main worktrees — skip the primary working copy)
-	const worktrees: Array<{ path: string; branch: string }> = [];
-	const wtResult = spawnSync("git", ["worktree", "list", "--porcelain"], { ...SPAWN_OPTS, cwd, env: gitEnv() });
-	if (wtResult.status === 0 && wtResult.stdout) {
-		let currentPath = "";
-		let isFirst = true;
-		for (const line of wtResult.stdout.split("\n")) {
-			if (line.startsWith("worktree ")) {
-				if (!isFirst && currentPath) {
-					// Flush previous entry (it had no branch — skip detached)
-				}
-				currentPath = line.slice("worktree ".length);
-				isFirst = false;
-			} else if (line.startsWith("branch refs/heads/") && currentPath) {
-				const wtBranch = line.slice("branch refs/heads/".length);
-				worktrees.push({ path: currentPath, branch: wtBranch });
-				currentPath = "";
-			} else if (line === "") {
-				currentPath = "";
-			}
-		}
-	}
-	// Remove the first entry (main worktree = the repo itself)
-	if (worktrees.length > 0) {
-		worktrees.shift();
-	}
+	// Worktrees — skip the primary working copy (first entry) and detached/bare entries
+	const worktrees = listWorktrees(cwd)
+		.slice(1) // skip primary working copy
+		.filter((wt): wt is typeof wt & { branch: string } => !!wt.branch && !wt.bare)
+		.map((wt) => ({ path: wt.path, branch: wt.branch }));
 
 	return { branch, dirtyCount, recentCommits, recentTags, openPRs, worktrees };
 }

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -268,6 +268,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const defaultActiveToolNames: ToolName[] = [
 		"read",
 		"bash",
+		"chdir",
 		"edit",
 		"write",
 		"grep",

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -170,6 +170,13 @@ function formatGitStateSection(state: GitRepoState): string {
 		}
 	}
 
+	if (state.worktrees && state.worktrees.length > 0) {
+		section += "- Active worktrees:\n";
+		for (const wt of state.worktrees) {
+			section += `  - \`${wt.branch}\` → ${wt.path}\n`;
+		}
+	}
+
 	return section;
 }
 

--- a/packages/coding-agent/src/core/tools/chdir.ts
+++ b/packages/coding-agent/src/core/tools/chdir.ts
@@ -61,9 +61,7 @@ export function createChdirToolDefinition(
 
 			// Invoke callback to trigger session cwd change
 			const oldCwd = cwd;
-			if (options?.onChdir) {
-				options.onChdir(resolvedPath);
-			}
+			options?.onChdir?.(resolvedPath);
 
 			return {
 				content: [

--- a/packages/coding-agent/src/core/tools/chdir.ts
+++ b/packages/coding-agent/src/core/tools/chdir.ts
@@ -1,0 +1,104 @@
+import { existsSync, statSync } from "node:fs";
+import type { AgentTool } from "@dreb/agent-core";
+import { Text } from "@dreb/tui";
+import { type Static, Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "../extensions/types.js";
+import { findGitRoot } from "../git-root.js";
+import { resolveToCwd } from "./path-utils.js";
+import { wrapToolDefinition } from "./tool-definition-wrapper.js";
+
+const chdirSchema = Type.Object({
+	path: Type.String({ description: "Directory path to change to (absolute or relative to current cwd)" }),
+});
+
+export type ChdirToolInput = Static<typeof chdirSchema>;
+
+export interface ChdirToolOptions {
+	/** Callback invoked when cwd changes. The session uses this to rebuild tools. */
+	onChdir?: (newCwd: string) => void;
+}
+
+export function createChdirToolDefinition(
+	cwd: string,
+	options?: ChdirToolOptions,
+): ToolDefinition<typeof chdirSchema, undefined> {
+	return {
+		name: "chdir",
+		label: "chdir",
+		description:
+			"Change the working directory. Validates that the target exists and is inside a git repository. All subsequent tool operations will use the new directory.",
+		parameters: chdirSchema,
+		async execute(_toolCallId, { path }: { path: string }, _signal?, _onUpdate?, _ctx?) {
+			const resolvedPath = resolveToCwd(path, cwd);
+
+			// Validate: directory exists
+			if (!existsSync(resolvedPath)) {
+				return {
+					content: [{ type: "text" as const, text: `Error: Directory does not exist: ${resolvedPath}` }],
+					details: undefined,
+				};
+			}
+
+			// Validate: is a directory
+			const stat = statSync(resolvedPath);
+			if (!stat.isDirectory()) {
+				return {
+					content: [{ type: "text" as const, text: `Error: Path is not a directory: ${resolvedPath}` }],
+					details: undefined,
+				};
+			}
+
+			// Validate: is inside a git repository
+			const gitRoot = findGitRoot(resolvedPath);
+			if (!gitRoot) {
+				return {
+					content: [
+						{ type: "text" as const, text: `Error: Target is not inside a git repository: ${resolvedPath}` },
+					],
+					details: undefined,
+				};
+			}
+
+			// Invoke callback to trigger session cwd change
+			const oldCwd = cwd;
+			if (options?.onChdir) {
+				options.onChdir(resolvedPath);
+			}
+
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `Changed working directory:\n  from: ${oldCwd}\n  to:   ${resolvedPath}`,
+					},
+				],
+				details: undefined,
+			};
+		},
+		renderCall(args, theme, context) {
+			const targetPath = (args as { path?: string })?.path || "";
+			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+			text.setText(`${theme.fg("toolTitle", theme.bold("chdir"))} ${theme.fg("accent", targetPath)}`);
+			return text;
+		},
+		renderResult(result, _options, theme, context) {
+			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
+			const first = result.content?.[0];
+			if (first?.type === "text" && first.text.startsWith("Error:")) {
+				text.setText(theme.fg("error", first.text));
+				return text;
+			}
+			const output = first?.type === "text" ? first.text : "";
+			text.setText(theme.fg("muted", output));
+			return text;
+		},
+	};
+}
+
+export function createChdirTool(cwd: string, options?: ChdirToolOptions): AgentTool<typeof chdirSchema> {
+	return wrapToolDefinition(createChdirToolDefinition(cwd, options));
+}
+
+/** Default chdir tool using process.cwd() for backwards compatibility. */
+export const chdirToolDefinition = createChdirToolDefinition(process.cwd());
+export const chdirTool = createChdirTool(process.cwd());

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -12,6 +12,14 @@ export {
 	createLocalBashOperations,
 } from "./bash.js";
 export {
+	type ChdirToolInput,
+	type ChdirToolOptions,
+	chdirTool,
+	chdirToolDefinition,
+	createChdirTool,
+	createChdirToolDefinition,
+} from "./chdir.js";
+export {
 	createEditTool,
 	createEditToolDefinition,
 	type EditOperations,
@@ -164,6 +172,13 @@ import {
 	createBashTool,
 	createBashToolDefinition,
 } from "./bash.js";
+import {
+	type ChdirToolOptions,
+	chdirTool,
+	chdirToolDefinition,
+	createChdirTool,
+	createChdirToolDefinition,
+} from "./chdir.js";
 import { createEditTool, createEditToolDefinition, editTool, editToolDefinition } from "./edit.js";
 import { createFindTool, createFindToolDefinition, findTool, findToolDefinition } from "./find.js";
 import { createGrepTool, createGrepToolDefinition, grepTool, grepToolDefinition } from "./grep.js";
@@ -215,6 +230,7 @@ const waitTool = wrapToolDefinition(waitToolDefinition);
 export const allTools = {
 	read: readTool,
 	bash: bashTool,
+	chdir: chdirTool,
 	edit: editTool,
 	write: writeTool,
 	grep: grepTool,
@@ -231,6 +247,7 @@ export const allTools = {
 export const allToolDefinitions = {
 	read: readToolDefinition,
 	bash: bashToolDefinition,
+	chdir: chdirToolDefinition,
 	edit: editToolDefinition,
 	write: writeToolDefinition,
 	grep: grepToolDefinition,
@@ -249,6 +266,7 @@ export type ToolName = keyof typeof allTools;
 export interface ToolsOptions {
 	read?: ReadToolOptions;
 	bash?: BashToolOptions;
+	chdir?: ChdirToolOptions;
 	subagent?: SubagentToolOptions;
 	skill?: SkillToolOptions;
 	tasks?: { onUpdate: TasksUpdateCallback };
@@ -277,6 +295,7 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 	const tools: Record<string, ToolDef> = {
 		read: createReadToolDefinition(cwd, options?.read),
 		bash: createBashToolDefinition(cwd, options?.bash),
+		chdir: createChdirToolDefinition(cwd, options?.chdir),
 		edit: createEditToolDefinition(cwd),
 		write: createWriteToolDefinition(cwd),
 		grep: createGrepToolDefinition(cwd),
@@ -318,6 +337,7 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 	const tools: Record<string, Tool> = {
 		read: createReadTool(cwd, options?.read),
 		bash: createBashTool(cwd, options?.bash),
+		chdir: createChdirTool(cwd, options?.chdir),
 		edit: createEditTool(cwd),
 		write: createWriteTool(cwd),
 		grep: createGrepTool(cwd),

--- a/packages/coding-agent/src/core/worktree-guard.ts
+++ b/packages/coding-agent/src/core/worktree-guard.ts
@@ -1,15 +1,6 @@
 import { execSync } from "node:child_process";
+import { gitEnv } from "./git-env.js";
 import { findGitRoot } from "./git-root.js";
-
-/**
- * Create a clean environment for git commands.
- * Removes GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE to prevent inherited
- * env vars (e.g. from git hooks) from causing git to use the wrong repo.
- */
-function gitEnv(): NodeJS.ProcessEnv {
-	const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...env } = process.env;
-	return env;
-}
 
 export interface WorktreeConflictResult {
 	blocked: boolean;
@@ -35,15 +26,28 @@ function getWorktreeBranches(cwd: string): Map<string, string> | undefined {
 	}
 
 	try {
-		const output = execSync("git worktree list --porcelain", { cwd: gitRoot, encoding: "utf-8", env: gitEnv() });
+		const output = execSync("git worktree list --porcelain", {
+			cwd: gitRoot,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			env: gitEnv(),
+		});
 		const worktrees = new Map<string, string>(); // branch -> path
 		let currentPath = "";
+		let isFirst = true; // Skip the first entry (primary working copy)
 		for (const line of output.split("\n")) {
 			if (line.startsWith("worktree ")) {
 				currentPath = line.slice(9);
 			} else if (line.startsWith("branch refs/heads/")) {
-				const branch = line.slice(18);
-				worktrees.set(branch, currentPath);
+				if (isFirst) {
+					isFirst = false;
+				} else {
+					const branch = line.slice(18);
+					worktrees.set(branch, currentPath);
+				}
+			} else if (line === "" && currentPath) {
+				// End of block — mark first entry as consumed
+				if (isFirst) isFirst = false;
 			}
 		}
 		worktreeCache.set(gitRoot, { worktrees, timestamp: now });
@@ -51,6 +55,18 @@ function getWorktreeBranches(cwd: string): Map<string, string> | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * Strip heredoc content from a bash command so that text inside heredoc bodies
+ * doesn't trigger false-positive pattern matches.
+ *
+ * Handles both quoted delimiters (<<'EOF', <<"EOF") and unquoted (<<EOF).
+ */
+function stripHeredocs(command: string): string {
+	// Match heredoc start: << [-]? ['"]?DELIMITER['"]?
+	// Then remove everything up to and including the delimiter line
+	return command.replace(/<<-?\s*['"]?(\w+)['"]?[^\n]*\n[\s\S]*?\n\1\b[^\n]*/g, "");
 }
 
 /**
@@ -63,20 +79,21 @@ function extractBranchTarget(command: string): string | undefined {
 	// Match: gh pr checkout <number> — we can't easily resolve PR number to branch,
 	//   so we return a special marker
 
-	const trimmed = command.trim();
+	// Strip heredoc bodies to avoid false positives from PR comment content
+	const trimmed = stripHeredocs(command).trim();
 
 	// git checkout -- <file> → not a branch checkout
 	if (/\bgit\s+checkout\s+--\s/.test(trimmed)) return undefined;
 	// git checkout -b → creating new branch (allowed)
 	if (/\bgit\s+checkout\s+-[bB]\s/.test(trimmed)) return undefined;
 	// git checkout <branch>
-	const checkoutMatch = trimmed.match(/\bgit\s+checkout\s+([\w\-./]+)\s*$/);
+	const checkoutMatch = trimmed.match(/\bgit\s+checkout\s+([\w\-./]+)/);
 	if (checkoutMatch) return checkoutMatch[1];
 
 	// git switch -c → creating new branch (allowed)
 	if (/\bgit\s+switch\s+-[cC]\s/.test(trimmed)) return undefined;
 	// git switch <branch>
-	const switchMatch = trimmed.match(/\bgit\s+switch\s+([\w\-./]+)\s*$/);
+	const switchMatch = trimmed.match(/\bgit\s+switch\s+([\w\-./]+)/);
 	if (switchMatch) return switchMatch[1];
 
 	// gh pr checkout <N> — can't resolve to branch name without API call
@@ -126,4 +143,4 @@ export function clearWorktreeCache(): void {
 }
 
 // Export for testing
-export { extractBranchTarget as _extractBranchTarget };
+export { extractBranchTarget as _extractBranchTarget, stripHeredocs as _stripHeredocs };

--- a/packages/coding-agent/src/core/worktree-guard.ts
+++ b/packages/coding-agent/src/core/worktree-guard.ts
@@ -1,0 +1,129 @@
+import { execSync } from "node:child_process";
+import { findGitRoot } from "./git-root.js";
+
+/**
+ * Create a clean environment for git commands.
+ * Removes GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE to prevent inherited
+ * env vars (e.g. from git hooks) from causing git to use the wrong repo.
+ */
+function gitEnv(): NodeJS.ProcessEnv {
+	const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...env } = process.env;
+	return env;
+}
+
+export interface WorktreeConflictResult {
+	blocked: boolean;
+	reason?: string;
+	worktreePath?: string;
+}
+
+/**
+ * Cache for worktree list to avoid running git commands on every bash call.
+ * Keyed by git root. Invalidated after 30 seconds.
+ */
+const worktreeCache = new Map<string, { worktrees: Map<string, string>; timestamp: number }>();
+const CACHE_TTL_MS = 30_000;
+
+function getWorktreeBranches(cwd: string): Map<string, string> | undefined {
+	const gitRoot = findGitRoot(cwd);
+	if (!gitRoot) return undefined;
+
+	const now = Date.now();
+	const cached = worktreeCache.get(gitRoot);
+	if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+		return cached.worktrees;
+	}
+
+	try {
+		const output = execSync("git worktree list --porcelain", { cwd: gitRoot, encoding: "utf-8", env: gitEnv() });
+		const worktrees = new Map<string, string>(); // branch -> path
+		let currentPath = "";
+		for (const line of output.split("\n")) {
+			if (line.startsWith("worktree ")) {
+				currentPath = line.slice(9);
+			} else if (line.startsWith("branch refs/heads/")) {
+				const branch = line.slice(18);
+				worktrees.set(branch, currentPath);
+			}
+		}
+		worktreeCache.set(gitRoot, { worktrees, timestamp: now });
+		return worktrees;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Extract the target branch from a git checkout/switch command.
+ * Returns undefined if the command is not a branch checkout (e.g., file checkout).
+ */
+function extractBranchTarget(command: string): string | undefined {
+	// Match: git checkout <branch> (but NOT git checkout -- <file> or git checkout -b)
+	// Match: git switch <branch> (but NOT git switch -c)
+	// Match: gh pr checkout <number> — we can't easily resolve PR number to branch,
+	//   so we return a special marker
+
+	const trimmed = command.trim();
+
+	// git checkout -- <file> → not a branch checkout
+	if (/\bgit\s+checkout\s+--\s/.test(trimmed)) return undefined;
+	// git checkout -b → creating new branch (allowed)
+	if (/\bgit\s+checkout\s+-[bB]\s/.test(trimmed)) return undefined;
+	// git checkout <branch>
+	const checkoutMatch = trimmed.match(/\bgit\s+checkout\s+([\w\-./]+)\s*$/);
+	if (checkoutMatch) return checkoutMatch[1];
+
+	// git switch -c → creating new branch (allowed)
+	if (/\bgit\s+switch\s+-[cC]\s/.test(trimmed)) return undefined;
+	// git switch <branch>
+	const switchMatch = trimmed.match(/\bgit\s+switch\s+([\w\-./]+)\s*$/);
+	if (switchMatch) return switchMatch[1];
+
+	// gh pr checkout <N> — can't resolve to branch name without API call
+	// Block any gh pr checkout when worktrees exist
+	if (/\bgh\s+pr\s+checkout\b/.test(trimmed)) return "__gh_pr_checkout__";
+
+	return undefined;
+}
+
+/**
+ * Check if a bash command would conflict with an existing worktree.
+ * Called from the agent-session bash guard.
+ */
+export function isWorktreeConflictCommand(command: string, cwd: string): WorktreeConflictResult {
+	const branch = extractBranchTarget(command);
+	if (!branch) return { blocked: false };
+
+	const worktrees = getWorktreeBranches(cwd);
+	if (!worktrees || worktrees.size === 0) return { blocked: false };
+
+	// Special case: gh pr checkout — block if any worktrees exist
+	if (branch === "__gh_pr_checkout__") {
+		return {
+			blocked: true,
+			reason: `Command blocked: \`gh pr checkout\` is not allowed when worktrees exist. Use the \`chdir\` tool to switch to the appropriate worktree instead.\n\nExisting worktrees:\n${Array.from(
+				worktrees.entries(),
+			)
+				.map(([b, p]) => `  ${b} → ${p}`)
+				.join("\n")}`,
+		};
+	}
+
+	// Check if the target branch has a worktree
+	const worktreePath = worktrees.get(branch);
+	if (!worktreePath) return { blocked: false };
+
+	return {
+		blocked: true,
+		reason: `Command blocked: Branch "${branch}" already has an active worktree at:\n  ${worktreePath}\n\nUse the \`chdir\` tool to switch to it instead of checking out the branch.`,
+		worktreePath,
+	};
+}
+
+/** Clear the worktree cache. Useful after creating/removing worktrees. */
+export function clearWorktreeCache(): void {
+	worktreeCache.clear();
+}
+
+// Export for testing
+export { extractBranchTarget as _extractBranchTarget };

--- a/packages/coding-agent/src/core/worktree-guard.ts
+++ b/packages/coding-agent/src/core/worktree-guard.ts
@@ -1,6 +1,5 @@
-import { execSync } from "node:child_process";
-import { gitEnv } from "./git-env.js";
 import { findGitRoot } from "./git-root.js";
+import { listWorktrees } from "./worktree.js";
 
 export interface WorktreeConflictResult {
 	blocked: boolean;
@@ -25,36 +24,18 @@ function getWorktreeBranches(cwd: string): Map<string, string> | undefined {
 		return cached.worktrees;
 	}
 
-	try {
-		const output = execSync("git worktree list --porcelain", {
-			cwd: gitRoot,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-			env: gitEnv(),
-		});
-		const worktrees = new Map<string, string>(); // branch -> path
-		let currentPath = "";
-		let isFirst = true; // Skip the first entry (primary working copy)
-		for (const line of output.split("\n")) {
-			if (line.startsWith("worktree ")) {
-				currentPath = line.slice(9);
-			} else if (line.startsWith("branch refs/heads/")) {
-				if (isFirst) {
-					isFirst = false;
-				} else {
-					const branch = line.slice(18);
-					worktrees.set(branch, currentPath);
-				}
-			} else if (line === "" && currentPath) {
-				// End of block — mark first entry as consumed
-				if (isFirst) isFirst = false;
-			}
+	const allWorktrees = listWorktrees(gitRoot);
+	if (allWorktrees.length === 0) return undefined;
+
+	// Skip the first entry (primary working copy) and build branch→path map
+	const worktrees = new Map<string, string>();
+	for (const wt of allWorktrees.slice(1)) {
+		if (wt.branch) {
+			worktrees.set(wt.branch, wt.path);
 		}
-		worktreeCache.set(gitRoot, { worktrees, timestamp: now });
-		return worktrees;
-	} catch {
-		return undefined;
 	}
+	worktreeCache.set(gitRoot, { worktrees, timestamp: now });
+	return worktrees;
 }
 
 /**
@@ -66,7 +47,7 @@ function getWorktreeBranches(cwd: string): Map<string, string> | undefined {
 function stripHeredocs(command: string): string {
 	// Match heredoc start: << [-]? ['"]?DELIMITER['"]?
 	// Then remove everything up to and including the delimiter line
-	return command.replace(/<<-?\s*['"]?(\w+)['"]?[^\n]*\n[\s\S]*?\n\1\b[^\n]*/g, "");
+	return command.replace(/<<-?\s*['"]?(\w+)['"]?[^\n]*\n[\s\S]*?\n\t*\1\b[^\n]*/g, "");
 }
 
 /**

--- a/packages/coding-agent/src/core/worktree.ts
+++ b/packages/coding-agent/src/core/worktree.ts
@@ -1,0 +1,137 @@
+import { execSync } from "node:child_process";
+import { basename, dirname, join } from "node:path";
+
+/**
+ * Create a clean environment for git commands.
+ * Removes GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE to prevent inherited
+ * env vars (e.g. from git hooks) from causing git to use the wrong repo.
+ */
+function gitEnv(): NodeJS.ProcessEnv {
+	const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...env } = process.env;
+	return env;
+}
+
+export interface WorktreeInfo {
+	path: string;
+	head: string; // commit SHA
+	branch?: string; // branch name without refs/heads/ prefix
+	bare?: boolean;
+}
+
+/**
+ * Parse `git worktree list --porcelain` output into structured data.
+ * Runs the command in the given directory.
+ *
+ * Returns an empty array if the command fails (e.g. not in a git repo).
+ */
+export function listWorktrees(cwd: string): WorktreeInfo[] {
+	let output: string;
+	try {
+		output = execSync("git worktree list --porcelain", {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			env: gitEnv(),
+		});
+	} catch {
+		return [];
+	}
+
+	const worktrees: WorktreeInfo[] = [];
+	let current: Partial<WorktreeInfo> | null = null;
+
+	const flush = () => {
+		if (current?.path) {
+			worktrees.push({
+				path: current.path,
+				head: current.head ?? "",
+				branch: current.branch,
+				bare: current.bare,
+			});
+		}
+		current = null;
+	};
+
+	for (const rawLine of output.split("\n")) {
+		const line = rawLine.trimEnd();
+		if (line === "") {
+			// Blank line separates worktree blocks
+			flush();
+			continue;
+		}
+
+		if (line.startsWith("worktree ")) {
+			// Start of a new block
+			flush();
+			current = { path: line.slice("worktree ".length) };
+		} else if (!current) {
+		} else if (line.startsWith("HEAD ")) {
+			current.head = line.slice("HEAD ".length);
+		} else if (line.startsWith("branch ")) {
+			const ref = line.slice("branch ".length);
+			current.branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+		} else if (line === "bare") {
+			current.bare = true;
+		} else if (line === "detached") {
+			current.branch = undefined;
+		}
+	}
+	// Flush any trailing block (output may not end with a blank line)
+	flush();
+
+	return worktrees;
+}
+
+/**
+ * Find an existing worktree for a given branch name.
+ * Returns the worktree path or undefined if no worktree exists for that branch.
+ *
+ * Accepts either a bare branch name or a full `refs/heads/` prefixed name.
+ */
+export function findWorktreeForBranch(cwd: string, branch: string): string | undefined {
+	const normalized = branch.startsWith("refs/heads/") ? branch.slice("refs/heads/".length) : branch;
+
+	const match = listWorktrees(cwd).find((wt) => wt.branch === normalized);
+	return match?.path;
+}
+
+/**
+ * Compute the conventional worktree path for an issue number.
+ * Convention: <repo-parent>/<repo-name>-worktrees/issue-<N>/
+ */
+export function getWorktreePath(repoRoot: string, issueNumber: number): string {
+	const repoName = basename(repoRoot);
+	const parentDir = dirname(repoRoot);
+	return join(parentDir, `${repoName}-worktrees`, `issue-${issueNumber}`);
+}
+
+/**
+ * Create a worktree for a branch at the conventional path.
+ * If a worktree already exists for the branch, returns its path without
+ * creating a new one.
+ *
+ * Returns the absolute path to the worktree.
+ */
+export function createWorktree(cwd: string, branch: string, issueNumber: number): string {
+	// Reuse an existing worktree for this branch if present.
+	const existing = findWorktreeForBranch(cwd, branch);
+	if (existing) return existing;
+
+	const repoRoot = execSync("git rev-parse --show-toplevel", {
+		cwd,
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "ignore"],
+		env: gitEnv(),
+	}).trim();
+
+	const target = getWorktreePath(repoRoot, issueNumber);
+
+	execSync(`git worktree add ${JSON.stringify(target)} ${JSON.stringify(branch)}`, {
+		cwd,
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "ignore"],
+		env: gitEnv(),
+	});
+
+	return target;
+}

--- a/packages/coding-agent/src/core/worktree.ts
+++ b/packages/coding-agent/src/core/worktree.ts
@@ -1,15 +1,6 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
-
-/**
- * Create a clean environment for git commands.
- * Removes GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE to prevent inherited
- * env vars (e.g. from git hooks) from causing git to use the wrong repo.
- */
-function gitEnv(): NodeJS.ProcessEnv {
-	const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...env } = process.env;
-	return env;
-}
+import { gitEnv } from "./git-env.js";
 
 export interface WorktreeInfo {
 	path: string;
@@ -117,21 +108,28 @@ export function createWorktree(cwd: string, branch: string, issueNumber: number)
 	const existing = findWorktreeForBranch(cwd, branch);
 	if (existing) return existing;
 
-	const repoRoot = execSync("git rev-parse --show-toplevel", {
+	const repoRootResult = spawnSync("git", ["rev-parse", "--show-toplevel"], {
 		cwd,
 		encoding: "utf-8",
-		stdio: ["ignore", "pipe", "ignore"],
+		stdio: ["ignore", "pipe", "pipe"],
 		env: gitEnv(),
-	}).trim();
+	});
+	if (repoRootResult.status !== 0) {
+		throw new Error(`Failed to find git root: ${repoRootResult.stderr?.trim() || "unknown error"}`);
+	}
+	const repoRoot = repoRootResult.stdout.trim();
 
 	const target = getWorktreePath(repoRoot, issueNumber);
 
-	execSync(`git worktree add ${JSON.stringify(target)} ${JSON.stringify(branch)}`, {
+	const addResult = spawnSync("git", ["worktree", "add", target, branch], {
 		cwd,
 		encoding: "utf-8",
-		stdio: ["ignore", "pipe", "ignore"],
+		stdio: ["ignore", "pipe", "pipe"],
 		env: gitEnv(),
 	});
+	if (addResult.status !== 0) {
+		throw new Error(`Failed to create worktree: ${addResult.stderr?.trim() || "unknown error"}`);
+	}
 
 	return target;
 }

--- a/packages/coding-agent/test/agent-session-chdir.test.ts
+++ b/packages/coding-agent/test/agent-session-chdir.test.ts
@@ -1,0 +1,147 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findModel } from "@dreb/ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultResourceLoader } from "../src/core/resource-loader.js";
+import { createAgentSession } from "../src/core/sdk.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+
+// Remove GIT_* env vars that leak from git hooks
+const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;
+
+function git(cwd: string, args: string): void {
+	execSync(`git ${args}`, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], env: cleanEnv });
+}
+
+describe("AgentSession chdir integration", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let repoDir: string;
+	let subDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `dreb-chdir-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		repoDir = join(tempDir, "repo");
+		subDir = join(repoDir, "subdir");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(subDir, { recursive: true });
+
+		// Initialize a git repo
+		git(repoDir, "init -q");
+		git(repoDir, "config user.email test@test.com");
+		git(repoDir, "config user.name Test");
+		git(repoDir, "config commit.gpgsign false");
+		writeFileSync(join(repoDir, "README.md"), "hello\n");
+		git(repoDir, "add README.md");
+		git(repoDir, "commit -q -m init");
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("chdir tool is active in default session", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: repoDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: repoDir,
+			agentDir,
+			model: findModel("anthropic", "sonnet")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		expect(session.getActiveToolNames()).toContain("chdir");
+	});
+
+	it("_changeCwd updates session cwd and rebuilds tools", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: repoDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: repoDir,
+			agentDir,
+			model: findModel("anthropic", "sonnet")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		// Verify initial cwd
+		expect((session as any)._cwd).toBe(repoDir);
+
+		// Invoke the chdir tool directly via its definition
+		const chdirDef = session.getToolDefinition("chdir");
+		expect(chdirDef).toBeDefined();
+
+		const result = await chdirDef!.execute("test-call-id", { path: subDir }, undefined, undefined, undefined as any);
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("Changed working directory"),
+		});
+
+		// Verify cwd was updated
+		expect((session as any)._cwd).toBe(subDir);
+
+		// Verify system prompt reflects new cwd
+		expect(session.systemPrompt).toContain(subDir);
+	});
+
+	it("_changeCwd rolls back on _buildRuntime failure", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: repoDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: repoDir,
+			agentDir,
+			model: findModel("anthropic", "sonnet")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		// Sabotage _buildRuntime to throw
+		const _originalBuildRuntime = (session as any)._buildRuntime.bind(session);
+		let buildCalled = false;
+		(session as any)._buildRuntime = () => {
+			buildCalled = true;
+			throw new Error("simulated _buildRuntime failure");
+		};
+
+		// Attempt to change cwd — should throw and rollback
+		expect(() => (session as any)._changeCwd(subDir)).toThrow("simulated _buildRuntime failure");
+		expect(buildCalled).toBe(true);
+
+		// Verify cwd was rolled back
+		expect((session as any)._cwd).toBe(repoDir);
+	});
+});

--- a/packages/coding-agent/test/chdir.test.ts
+++ b/packages/coding-agent/test/chdir.test.ts
@@ -1,0 +1,92 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createChdirToolDefinition } from "../src/core/tools/chdir.js";
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	const first = result.content?.[0];
+	return first?.type === "text" ? (first.text ?? "") : "";
+}
+
+describe("chdir tool", () => {
+	let gitRepo: string;
+	let nonGitDir: string;
+
+	beforeEach(() => {
+		// Create a temp dir that is a git repo (realpath to resolve macOS /var -> /private/var symlinks)
+		gitRepo = realpathSync(mkdtempSync(path.join(tmpdir(), "chdir-git-")));
+		execSync("git init", { cwd: gitRepo, stdio: "ignore" });
+
+		// Create a temp dir that is NOT a git repo
+		nonGitDir = realpathSync(mkdtempSync(path.join(tmpdir(), "chdir-nogit-")));
+	});
+
+	afterEach(() => {
+		rmSync(gitRepo, { recursive: true, force: true });
+		rmSync(nonGitDir, { recursive: true, force: true });
+	});
+
+	it("changes to a valid git directory (happy path)", async () => {
+		const def = createChdirToolDefinition(gitRepo);
+		const result = await def.execute("id", { path: gitRepo }, undefined, undefined, undefined as any);
+		const text = getText(result as any);
+		expect(text).toContain("Changed working directory:");
+		expect(text).toContain(gitRepo);
+	});
+
+	it("returns error for a non-existent directory", async () => {
+		const def = createChdirToolDefinition(gitRepo);
+		const missing = path.join(gitRepo, "does-not-exist");
+		const result = await def.execute("id", { path: missing }, undefined, undefined, undefined as any);
+		const text = getText(result as any);
+		expect(text).toContain("Error: Directory does not exist:");
+		expect(text).toContain(missing);
+	});
+
+	it("returns error when path is a file, not a directory", async () => {
+		const filePath = path.join(gitRepo, "file.txt");
+		writeFileSync(filePath, "hello");
+		const def = createChdirToolDefinition(gitRepo);
+		const result = await def.execute("id", { path: filePath }, undefined, undefined, undefined as any);
+		const text = getText(result as any);
+		expect(text).toContain("Error: Path is not a directory:");
+		expect(text).toContain(filePath);
+	});
+
+	it("returns error when directory is not inside a git repo", async () => {
+		const def = createChdirToolDefinition(nonGitDir);
+		const result = await def.execute("id", { path: nonGitDir }, undefined, undefined, undefined as any);
+		const text = getText(result as any);
+		expect(text).toContain("Error: Target is not inside a git repository:");
+		expect(text).toContain(nonGitDir);
+	});
+
+	it("invokes onChdir callback with the resolved absolute path", async () => {
+		const onChdir = vi.fn();
+		const def = createChdirToolDefinition(gitRepo, { onChdir });
+		await def.execute("id", { path: gitRepo }, undefined, undefined, undefined as any);
+		expect(onChdir).toHaveBeenCalledTimes(1);
+		expect(onChdir).toHaveBeenCalledWith(gitRepo);
+	});
+
+	it("does not invoke onChdir when validation fails", async () => {
+		const onChdir = vi.fn();
+		const def = createChdirToolDefinition(gitRepo, { onChdir });
+		await def.execute("id", { path: path.join(gitRepo, "does-not-exist") }, undefined, undefined, undefined as any);
+		expect(onChdir).not.toHaveBeenCalled();
+	});
+
+	it("resolves a relative path against the cwd", async () => {
+		const subdir = path.join(gitRepo, "sub");
+		mkdirSync(subdir);
+		const onChdir = vi.fn();
+		const def = createChdirToolDefinition(gitRepo, { onChdir });
+		const result = await def.execute("id", { path: "sub" }, undefined, undefined, undefined as any);
+		const text = getText(result as any);
+		expect(text).toContain("Changed working directory:");
+		expect(text).toContain(subdir);
+		expect(onChdir).toHaveBeenCalledWith(subdir);
+	});
+});

--- a/packages/coding-agent/test/search/search-tool.test.ts
+++ b/packages/coding-agent/test/search/search-tool.test.ts
@@ -74,9 +74,11 @@ function createFixtureProject(dir: string): void {
 // Availability
 // ============================================================================
 
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+
 describe("isSearchAvailable", () => {
-	it("returns true on Node 22+", () => {
-		// We're running on Node 22, so node:sqlite should be available
+	it.skipIf(nodeVersion < 22)("returns true on Node 22+", () => {
+		// We're running on Node 22+, so node:sqlite should be available
 		expect(isSearchAvailable()).toBe(true);
 	});
 });
@@ -305,7 +307,7 @@ describe("createSearchToolDefinition", () => {
 	// Execute — empty query
 	// ============================================================================
 
-	describe("execute", () => {
+	describe.skipIf(nodeVersion < 22)("execute", () => {
 		it('returns "cannot be empty" message for empty query', async () => {
 			const result = await tool.execute("test-1", { query: "" }, undefined, undefined, undefined as any);
 			const text = result.content[0];

--- a/packages/coding-agent/test/session-dir-precedence.test.ts
+++ b/packages/coding-agent/test/session-dir-precedence.test.ts
@@ -73,7 +73,7 @@ vi.mock("../src/core/resource-loader.js", async (importOriginal) => {
 	};
 });
 
-describe("sessionDir precedence", () => {
+describe("sessionDir precedence", { timeout: 60_000 }, () => {
 	let tempDir: string;
 	let agentDir: string;
 	let projectDir: string;

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -131,6 +131,7 @@ describe("buildSystemPrompt", () => {
 				{ name: "v1.2.2", date: "3 weeks ago" },
 			],
 			openPRs: [{ number: 42, title: "Add feature X", url: "https://github.com/org/repo/pull/42" }],
+			worktrees: [{ path: "/home/user/repo-worktrees/issue-42", branch: "feature/issue-42-add-feature-x" }],
 		};
 
 		test("full state renders correctly", () => {
@@ -197,6 +198,7 @@ describe("buildSystemPrompt", () => {
 					recentCommits: [{ hash: "aaa1111", subject: "fix bug" }],
 					recentTags: [],
 					openPRs: [],
+					worktrees: [],
 				},
 			});
 

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -153,6 +153,19 @@ describe("buildSystemPrompt", () => {
 			expect(prompt).toContain("  - `v1.2.2` (3 weeks ago)");
 			expect(prompt).toContain("- Open PRs on this branch:");
 			expect(prompt).toContain("  - PR 42 — Add feature X (https://github.com/org/repo/pull/42)");
+			expect(prompt).toContain("- Active worktrees:");
+			expect(prompt).toContain("  - `feature/issue-42-add-feature-x` → /home/user/repo-worktrees/issue-42");
+		});
+
+		test("empty worktrees does not render section", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+				gitRepoState: { ...fullState, worktrees: [] },
+			});
+
+			expect(prompt).not.toContain("Active worktrees:");
 		});
 
 		test("clean status", () => {

--- a/packages/coding-agent/test/web-search-queue.test.ts
+++ b/packages/coding-agent/test/web-search-queue.test.ts
@@ -100,7 +100,7 @@ describe("WebSearchQueue", () => {
 
 	it("error during search still updates timestamp", async () => {
 		const queue = new WebSearchQueue({
-			rateLimitMs: 100,
+			rateLimitMs: 500,
 			lockFilePath,
 			timeFilePath,
 		});
@@ -118,12 +118,13 @@ describe("WebSearchQueue", () => {
 		expect(typeof data.lastSearchTime).toBe("number");
 		expect(data.lastSearchTime).toBeGreaterThan(0);
 
-		// Second call should be delayed (proving timestamp was written by the failed call)
+		// Second call should be delayed (proving timestamp was written by the failed call).
+		// Use 500ms rate limit to avoid flakiness under heavy parallel test load,
+		// where overhead between calls can exceed smaller thresholds.
 		const start = performance.now();
 		await queue.enqueue(async () => "ok");
 		const elapsed = performance.now() - start;
-		// Should have waited ~100ms minus whatever already elapsed
-		expect(elapsed).toBeGreaterThanOrEqual(80);
+		expect(elapsed).toBeGreaterThanOrEqual(200);
 	});
 
 	it("uses custom lock and time file paths", async () => {

--- a/packages/coding-agent/test/worktree-guard.test.ts
+++ b/packages/coding-agent/test/worktree-guard.test.ts
@@ -1,0 +1,107 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _extractBranchTarget, clearWorktreeCache, isWorktreeConflictCommand } from "../src/core/worktree-guard.js";
+
+describe("_extractBranchTarget", () => {
+	it("extracts branch from git checkout", () => {
+		expect(_extractBranchTarget("git checkout main")).toBe("main");
+	});
+
+	it("extracts branch with slashes and dashes", () => {
+		expect(_extractBranchTarget("git checkout feature/foo-bar")).toBe("feature/foo-bar");
+	});
+
+	it("returns undefined for file checkout", () => {
+		expect(_extractBranchTarget("git checkout -- file.txt")).toBeUndefined();
+	});
+
+	it("returns undefined for git checkout -b (create branch)", () => {
+		expect(_extractBranchTarget("git checkout -b new-branch")).toBeUndefined();
+	});
+
+	it("extracts branch from git switch", () => {
+		expect(_extractBranchTarget("git switch develop")).toBe("develop");
+	});
+
+	it("returns undefined for git switch -c (create branch)", () => {
+		expect(_extractBranchTarget("git switch -c new-branch")).toBeUndefined();
+	});
+
+	it("returns marker for gh pr checkout", () => {
+		expect(_extractBranchTarget("gh pr checkout 42")).toBe("__gh_pr_checkout__");
+	});
+
+	it("returns undefined for non-git commands", () => {
+		expect(_extractBranchTarget("echo hello")).toBeUndefined();
+	});
+});
+
+describe("isWorktreeConflictCommand", () => {
+	let repoDir: string;
+	let worktreeDir: string;
+	const worktreeBranch = "feature/in-worktree";
+
+	beforeEach(() => {
+		clearWorktreeCache();
+		repoDir = mkdtempSync(path.join(tmpdir(), "wt-guard-repo-"));
+		// Remove GIT_* env vars inherited from git hooks (pre-commit sets GIT_DIR, GIT_INDEX_FILE)
+		// that would cause git to use the wrong repo.
+		const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;
+		const run = (cmd: string) => execSync(cmd, { cwd: repoDir, encoding: "utf-8", env: cleanEnv });
+		run("git init -q");
+		run("git config user.email test@test.com");
+		run("git config user.name test");
+		run("git config commit.gpgsign false");
+		writeFileSync(path.join(repoDir, "README.md"), "hello\n");
+		run("git add README.md");
+		run("git commit -q -m init");
+		// Create another local branch (no worktree)
+		run("git branch other-branch");
+		// Create a worktree on a new branch
+		worktreeDir = `${repoDir}-wt`;
+		run(`git worktree add -b ${worktreeBranch} "${worktreeDir}"`);
+	});
+
+	afterEach(() => {
+		clearWorktreeCache();
+		rmSync(repoDir, { recursive: true, force: true });
+		rmSync(worktreeDir, { recursive: true, force: true });
+	});
+
+	it("blocks checkout of a branch with an active worktree", () => {
+		const result = isWorktreeConflictCommand(`git checkout ${worktreeBranch}`, repoDir);
+		expect(result.blocked).toBe(true);
+		expect(result.worktreePath).toBeDefined();
+		expect(result.reason).toContain(worktreeBranch);
+	});
+
+	it("does not block checkout of a branch without a worktree", () => {
+		const result = isWorktreeConflictCommand("git checkout other-branch", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+
+	it("does not block file checkout", () => {
+		const result = isWorktreeConflictCommand("git checkout -- file.txt", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+
+	it("blocks gh pr checkout when worktrees exist", () => {
+		const result = isWorktreeConflictCommand("gh pr checkout 42", repoDir);
+		expect(result.blocked).toBe(true);
+		expect(result.reason).toContain("gh pr checkout");
+	});
+
+	it("passes through non-git commands", () => {
+		const result = isWorktreeConflictCommand("echo hello", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+});
+
+describe("clearWorktreeCache", () => {
+	it("does not throw", () => {
+		expect(() => clearWorktreeCache()).not.toThrow();
+	});
+});

--- a/packages/coding-agent/test/worktree-guard.test.ts
+++ b/packages/coding-agent/test/worktree-guard.test.ts
@@ -124,6 +124,12 @@ describe("_stripHeredocs", () => {
 		expect(_stripHeredocs(cmd)).not.toContain("gh pr checkout 99");
 	});
 
+	it("strips <<- heredoc with tab-indented closing delimiter", () => {
+		const cmd = "cat <<-EOF\n\tgit checkout main\n\tEOF\necho done";
+		expect(_stripHeredocs(cmd)).toContain("echo done");
+		expect(_stripHeredocs(cmd)).not.toContain("git checkout main");
+	});
+
 	it("preserves commands without heredocs", () => {
 		const cmd = "git checkout main && echo done";
 		expect(_stripHeredocs(cmd)).toBe(cmd);

--- a/packages/coding-agent/test/worktree-guard.test.ts
+++ b/packages/coding-agent/test/worktree-guard.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _extractBranchTarget, clearWorktreeCache, isWorktreeConflictCommand } from "../src/core/worktree-guard.js";
+import {
+	_extractBranchTarget,
+	_stripHeredocs,
+	clearWorktreeCache,
+	isWorktreeConflictCommand,
+} from "../src/core/worktree-guard.js";
 
 describe("_extractBranchTarget", () => {
 	it("extracts branch from git checkout", () => {
@@ -96,6 +101,120 @@ describe("isWorktreeConflictCommand", () => {
 
 	it("passes through non-git commands", () => {
 		const result = isWorktreeConflictCommand("echo hello", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+});
+
+describe("_stripHeredocs", () => {
+	it("strips single-quoted heredoc content", () => {
+		const cmd = `cat > /tmp/file.md << 'EOF'\ngh pr checkout 42\nEOF\ngh pr comment 260`;
+		expect(_stripHeredocs(cmd)).toContain("gh pr comment 260");
+		expect(_stripHeredocs(cmd)).not.toContain("gh pr checkout 42");
+	});
+
+	it("strips unquoted heredoc content", () => {
+		const cmd = `cat > /tmp/file.md <<EOF\ngit checkout main\nEOF\necho done`;
+		expect(_stripHeredocs(cmd)).toContain("echo done");
+		expect(_stripHeredocs(cmd)).not.toContain("git checkout main");
+	});
+
+	it("strips double-quoted heredoc content", () => {
+		const cmd = `cat > /tmp/file.md <<"MACH6_EOF"\ngh pr checkout 99\nMACH6_EOF\necho ok`;
+		expect(_stripHeredocs(cmd)).toContain("echo ok");
+		expect(_stripHeredocs(cmd)).not.toContain("gh pr checkout 99");
+	});
+
+	it("preserves commands without heredocs", () => {
+		const cmd = "git checkout main && echo done";
+		expect(_stripHeredocs(cmd)).toBe(cmd);
+	});
+});
+
+describe("_extractBranchTarget with heredocs", () => {
+	it("does not match gh pr checkout inside a heredoc body", () => {
+		const cmd = `cat > /tmp/gh-comment.md << 'MACH6_EOF'\ngh pr checkout is blocked\nMACH6_EOF\ngh pr comment 260 --body-file /tmp/gh-comment.md`;
+		expect(_extractBranchTarget(cmd)).toBeUndefined();
+	});
+
+	it("does not match git checkout inside a heredoc body", () => {
+		const cmd = `cat > /tmp/file.md <<EOF\ngit checkout feature/foo\nEOF\necho done`;
+		expect(_extractBranchTarget(cmd)).toBeUndefined();
+	});
+
+	it("still detects real gh pr checkout outside heredocs", () => {
+		const cmd = `echo hello\ngh pr checkout 42`;
+		expect(_extractBranchTarget(cmd)).toBe("__gh_pr_checkout__");
+	});
+});
+
+describe("isWorktreeConflictCommand — no worktrees", () => {
+	let repoDir: string;
+
+	beforeEach(() => {
+		clearWorktreeCache();
+		repoDir = mkdtempSync(path.join(tmpdir(), "wt-guard-no-wt-"));
+		const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;
+		const run = (cmd: string) => execSync(cmd, { cwd: repoDir, encoding: "utf-8", env: cleanEnv });
+		run("git init -q");
+		run("git config user.email test@test.com");
+		run("git config user.name test");
+		run("git config commit.gpgsign false");
+		writeFileSync(path.join(repoDir, "README.md"), "hello\n");
+		run("git add README.md");
+		run("git commit -q -m init");
+	});
+
+	afterEach(() => {
+		clearWorktreeCache();
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	it("allows gh pr checkout when no worktrees exist", () => {
+		const result = isWorktreeConflictCommand("gh pr checkout 42", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+
+	it("allows git checkout when no worktrees exist", () => {
+		const result = isWorktreeConflictCommand("git checkout main", repoDir);
+		expect(result.blocked).toBe(false);
+	});
+});
+
+describe("isWorktreeConflictCommand — git switch", () => {
+	let repoDir: string;
+	let worktreeDir: string;
+	const worktreeBranch = "feature/switch-test";
+
+	beforeEach(() => {
+		clearWorktreeCache();
+		repoDir = mkdtempSync(path.join(tmpdir(), "wt-guard-switch-"));
+		const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;
+		const run = (cmd: string) => execSync(cmd, { cwd: repoDir, encoding: "utf-8", env: cleanEnv });
+		run("git init -q");
+		run("git config user.email test@test.com");
+		run("git config user.name test");
+		run("git config commit.gpgsign false");
+		writeFileSync(path.join(repoDir, "README.md"), "hello\n");
+		run("git add README.md");
+		run("git commit -q -m init");
+		worktreeDir = `${repoDir}-wt`;
+		run(`git worktree add -b ${worktreeBranch} "${worktreeDir}"`);
+	});
+
+	afterEach(() => {
+		clearWorktreeCache();
+		rmSync(repoDir, { recursive: true, force: true });
+		rmSync(worktreeDir, { recursive: true, force: true });
+	});
+
+	it("blocks git switch to a branch with an active worktree", () => {
+		const result = isWorktreeConflictCommand(`git switch ${worktreeBranch}`, repoDir);
+		expect(result.blocked).toBe(true);
+		expect(result.worktreePath).toBeDefined();
+	});
+
+	it("allows git switch -c for creating a new branch", () => {
+		const result = isWorktreeConflictCommand("git switch -c new-feature", repoDir);
 		expect(result.blocked).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/worktree.test.ts
+++ b/packages/coding-agent/test/worktree.test.ts
@@ -1,0 +1,129 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorktree, findWorktreeForBranch, getWorktreePath, listWorktrees } from "../src/core/worktree.js";
+
+// Remove GIT_* env vars inherited from git hooks (pre-commit sets GIT_DIR, GIT_INDEX_FILE)
+// that would cause git to use the wrong repo in our temp directories.
+const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;
+
+function git(cwd: string, args: string): void {
+	execSync(`git ${args}`, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], env: cleanEnv });
+}
+
+function initRepo(cwd: string): void {
+	git(cwd, "init -q");
+	git(cwd, "config user.email test@example.com");
+	git(cwd, "config user.name Test");
+	git(cwd, "commit -q --allow-empty -m initial");
+}
+
+describe("worktree utilities", () => {
+	let tempDir: string;
+	let repoDir: string;
+
+	beforeEach(() => {
+		// realpathSync resolves macOS /var -> /private/var symlinks so path
+		// comparisons against git output are stable.
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "dreb-worktree-test-")));
+		repoDir = join(tempDir, "myrepo");
+		execSync(`mkdir -p ${JSON.stringify(repoDir)}`);
+		initRepo(repoDir);
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	describe("listWorktrees", () => {
+		it("lists the main worktree", () => {
+			const worktrees = listWorktrees(repoDir);
+			expect(worktrees).toHaveLength(1);
+			expect(worktrees[0].path).toBe(repoDir);
+			expect(worktrees[0].head).toMatch(/^[0-9a-f]{40}$/);
+		});
+
+		it("lists additional worktrees with their branches", () => {
+			git(repoDir, "branch feature-x");
+			const wtPath = join(tempDir, "wt-feature-x");
+			git(repoDir, `worktree add ${JSON.stringify(wtPath)} feature-x`);
+
+			const worktrees = listWorktrees(repoDir);
+			expect(worktrees).toHaveLength(2);
+
+			const feature = worktrees.find((w) => w.path === wtPath);
+			expect(feature).toBeDefined();
+			expect(feature?.branch).toBe("feature-x");
+			expect(feature?.head).toMatch(/^[0-9a-f]{40}$/);
+		});
+
+		it("returns an empty array when not in a git repo", () => {
+			const nonRepo = join(tempDir, "not-a-repo");
+			execSync(`mkdir -p ${JSON.stringify(nonRepo)}`);
+			expect(listWorktrees(nonRepo)).toEqual([]);
+		});
+	});
+
+	describe("findWorktreeForBranch", () => {
+		it("finds the path of an existing branch worktree", () => {
+			git(repoDir, "branch feature-y");
+			const wtPath = join(tempDir, "wt-feature-y");
+			git(repoDir, `worktree add ${JSON.stringify(wtPath)} feature-y`);
+
+			expect(findWorktreeForBranch(repoDir, "feature-y")).toBe(wtPath);
+		});
+
+		it("accepts a full refs/heads/ prefixed branch name", () => {
+			git(repoDir, "branch feature-z");
+			const wtPath = join(tempDir, "wt-feature-z");
+			git(repoDir, `worktree add ${JSON.stringify(wtPath)} feature-z`);
+
+			expect(findWorktreeForBranch(repoDir, "refs/heads/feature-z")).toBe(wtPath);
+		});
+
+		it("returns undefined when no worktree exists for the branch", () => {
+			expect(findWorktreeForBranch(repoDir, "nonexistent")).toBeUndefined();
+		});
+	});
+
+	describe("getWorktreePath", () => {
+		it("computes the conventional path", () => {
+			const result = getWorktreePath("/home/user/myrepo", 42);
+			expect(result).toBe(join("/home/user", "myrepo-worktrees", "issue-42"));
+		});
+
+		it("derives the repo name from the basename", () => {
+			const repoRoot = "/some/deep/path/cool-project";
+			const result = getWorktreePath(repoRoot, 7);
+			expect(basename(dirname(dirname(result)))).toBe("path");
+			expect(result).toBe(join("/some/deep/path", "cool-project-worktrees", "issue-7"));
+		});
+	});
+
+	describe("createWorktree", () => {
+		it("creates a worktree at the conventional path", () => {
+			git(repoDir, "branch issue-branch");
+
+			const path = createWorktree(repoDir, "issue-branch", 100);
+			const expected = getWorktreePath(repoDir, 100);
+
+			expect(path).toBe(expected);
+			expect(existsSync(path)).toBe(true);
+			expect(findWorktreeForBranch(repoDir, "issue-branch")).toBe(path);
+		});
+
+		it("reuses an existing worktree for the branch", () => {
+			git(repoDir, "branch dup-branch");
+			const existingPath = join(tempDir, "existing-wt");
+			git(repoDir, `worktree add ${JSON.stringify(existingPath)} dup-branch`);
+
+			const path = createWorktree(repoDir, "dup-branch", 200);
+			expect(path).toBe(existingPath);
+
+			// No new conventional worktree should have been created.
+			expect(existsSync(getWorktreePath(repoDir, 200))).toBe(false);
+		});
+	});
+});

--- a/packages/coding-agent/test/worktree.test.ts
+++ b/packages/coding-agent/test/worktree.test.ts
@@ -59,6 +59,17 @@ describe("worktree utilities", () => {
 			expect(feature?.head).toMatch(/^[0-9a-f]{40}$/);
 		});
 
+		it("handles detached HEAD worktrees with branch undefined", () => {
+			const wtPath = join(tempDir, "wt-detached");
+			git(repoDir, `worktree add --detach ${JSON.stringify(wtPath)}`);
+
+			const worktrees = listWorktrees(repoDir);
+			const detached = worktrees.find((w) => w.path === wtPath);
+			expect(detached).toBeDefined();
+			expect(detached?.branch).toBeUndefined();
+			expect(detached?.head).toMatch(/^[0-9a-f]{40}$/);
+		});
+
 		it("returns an empty array when not in a git repo", () => {
 			const nonRepo = join(tempDir, "not-a-repo");
 			execSync(`mkdir -p ${JSON.stringify(nonRepo)}`);

--- a/packages/semantic-search/test/db.test.ts
+++ b/packages/semantic-search/test/db.test.ts
@@ -4,13 +4,15 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isSqliteAvailable, SearchDatabase } from "../src/db.js";
 
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+
 describe("isSqliteAvailable", () => {
-	it("returns true on Node 22+", () => {
+	it.skipIf(nodeVersion < 22)("returns true on Node 22+", () => {
 		expect(isSqliteAvailable()).toBe(true);
 	});
 });
 
-describe("SearchDatabase", () => {
+describe.skipIf(nodeVersion < 22)("SearchDatabase", () => {
 	let db: SearchDatabase;
 	let tmpDir: string;
 

--- a/packages/semantic-search/test/index-manager.test.ts
+++ b/packages/semantic-search/test/index-manager.test.ts
@@ -38,7 +38,9 @@ function setMtime(filePath: string, date: Date): void {
 // Tests
 // ============================================================================
 
-describe("IndexManager", () => {
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+
+describe.skipIf(nodeVersion < 22)("IndexManager", () => {
 	let tmpDir: string;
 	let projectDir: string;
 	let indexDir: string;

--- a/packages/semantic-search/test/metrics.test.ts
+++ b/packages/semantic-search/test/metrics.test.ts
@@ -252,7 +252,9 @@ describe("computeGitRecencyScores", () => {
 // computeImportGraphScores
 // ============================================================================
 
-describe("computeImportGraphScores", () => {
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+
+describe.skipIf(nodeVersion < 22)("computeImportGraphScores", () => {
 	let db: SearchDatabase;
 	let tmpDir: string;
 
@@ -416,7 +418,7 @@ describe("computeImportGraphScores", () => {
 // computeBm25Scores
 // ============================================================================
 
-describe("computeBm25Scores", () => {
+describe.skipIf(nodeVersion < 22)("computeBm25Scores", () => {
 	let db: SearchDatabase;
 	let tmpDir: string;
 

--- a/packages/semantic-search/test/search-engine.test.ts
+++ b/packages/semantic-search/test/search-engine.test.ts
@@ -110,7 +110,9 @@ function createFixtureProject(dir: string): void {
 // Tests
 // ============================================================================
 
-describe("SearchEngine.search()", () => {
+const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+
+describe.skipIf(nodeVersion < 22)("SearchEngine.search()", () => {
 	let tmpDir: string;
 	let engine: SearchEngine;
 
@@ -481,7 +483,7 @@ describe("SearchEngine.search()", () => {
 // SearchEngineOptions
 // ============================================================================
 
-describe("SearchEngineOptions", () => {
+describe.skipIf(nodeVersion < 22)("SearchEngineOptions", () => {
 	// ================================================================
 	// indexDir — custom index location
 	// ================================================================

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -303,11 +303,18 @@ describe("matchesKey", () => {
 
 		it("should treat raw 0x08 as ctrl+backspace in Windows Terminal", () => {
 			setKittyProtocolActive(false);
-			withEnv("WT_SESSION", "test-session", () => {
-				assert.strictEqual(matchesKey("\x08", "ctrl+backspace"), true);
-				assert.strictEqual(matchesKey("\x08", "backspace"), false);
-				assert.strictEqual(parseKey("\x08"), "ctrl+backspace");
-				assert.strictEqual(matchesKey("\x08", "ctrl+h"), true);
+			// Clear SSH env vars so isWindowsTerminalSession() returns true
+			withEnv("SSH_CONNECTION", undefined, () => {
+				withEnv("SSH_CLIENT", undefined, () => {
+					withEnv("SSH_TTY", undefined, () => {
+						withEnv("WT_SESSION", "test-session", () => {
+							assert.strictEqual(matchesKey("\x08", "ctrl+backspace"), true);
+							assert.strictEqual(matchesKey("\x08", "backspace"), false);
+							assert.strictEqual(parseKey("\x08"), "ctrl+backspace");
+							assert.strictEqual(matchesKey("\x08", "ctrl+h"), true);
+						});
+					});
+				});
 			});
 		});
 


### PR DESCRIPTION
Closes #233

Use git worktrees for PR-related work instead of switching branches in the current directory. Adds a `chdir` tool for session cwd mutation, worktree utilities, a bash-level guard against accidental `git checkout` when worktrees exist, and updates all mach6 skills.

Implementation plan posted as a comment below.
