### PR TITLE
fix: add license metadata to @dreb/telegram

### DIFF
--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -2,6 +2,7 @@
 	"name": "@dreb/telegram",
 	"version": "2.27.0",
 	"description": "Telegram bot frontend for dreb coding agent",
+	"license": "MIT",
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
Applies the fix from #259 (by @tolga-tom-nook) after rebasing onto master.

Adds the missing `"license": "MIT"` field to `packages/telegram/package.json`, consistent with all other published packages in this repo.

Closes #259.