### PR TITLE
Tab title: reuse rolling context buffer and improve title prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dreb",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dreb",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "workspaces": [
         "packages/*",
         "packages/coding-agent/examples/extensions/with-deps",
@@ -8947,7 +8947,7 @@
     },
     "packages/agent": {
       "name": "@dreb/agent-core",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@dreb/ai": "*"
@@ -8976,7 +8976,7 @@
     },
     "packages/ai": {
       "name": "@dreb/ai",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -9032,7 +9032,7 @@
     },
     "packages/coding-agent": {
       "name": "@dreb/coding-agent",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@dreb/agent-core": "*",
@@ -9161,7 +9161,7 @@
     },
     "packages/semantic-search": {
       "name": "@dreb/semantic-search",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
@@ -9210,7 +9210,7 @@
     },
     "packages/telegram": {
       "name": "@dreb/telegram",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@dreb/coding-agent": "*",
@@ -9243,7 +9243,7 @@
     },
     "packages/tui": {
       "name": "@dreb/tui",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9211,6 +9211,7 @@
     "packages/telegram": {
       "name": "@dreb/telegram",
       "version": "2.27.0",
+      "license": "MIT",
       "dependencies": {
         "@dreb/coding-agent": "*",
         "grammy": "^1.35.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "engines": {
     "node": "^22.0.0"
   },
-  "version": "2.27.0",
+  "version": "2.27.1",
   "dependencies": {
     "@mariozechner/jiti": "^2.6.5",
     "@dreb/coding-agent": "*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -97,7 +97,7 @@ current model supports adaptive thinking).
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `tabTitle.enabled` | boolean | `true` | Auto-generate terminal tab title from session task |
-| `tabTitle.triggerAfter` | number | `12` | Number of tool calls before generating title |
+| `tabTitle.triggerAfter` | number | `9` | Number of tool calls before generating title |
 
 After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a short (≤30 character) terminal tab title, then sets it via OSC 0. Only fires once per session. If the LLM call fails, the default title remains.
 
@@ -105,7 +105,7 @@ After the configured number of tool calls, dreb fires a single background LLM ca
 {
   "tabTitle": {
     "enabled": true,
-    "triggerAfter": 12
+    "triggerAfter": 9
   }
 }
 ```

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -97,7 +97,7 @@ current model supports adaptive thinking).
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `tabTitle.enabled` | boolean | `true` | Auto-generate terminal tab title from session task |
-| `tabTitle.triggerAfter` | number | `3` | Number of tool calls before generating title |
+| `tabTitle.triggerAfter` | number | `5` | Number of tool calls before generating title |
 
 After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a short (≤30 character) terminal tab title, then sets it via OSC 0. Only fires once per session. If the LLM call fails, the default title remains.
 
@@ -105,7 +105,7 @@ After the configured number of tool calls, dreb fires a single background LLM ca
 {
   "tabTitle": {
     "enabled": true,
-    "triggerAfter": 3
+    "triggerAfter": 5
   }
 }
 ```

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -97,7 +97,7 @@ current model supports adaptive thinking).
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `tabTitle.enabled` | boolean | `true` | Auto-generate terminal tab title from session task |
-| `tabTitle.triggerAfter` | number | `5` | Number of tool calls before generating title |
+| `tabTitle.triggerAfter` | number | `12` | Number of tool calls before generating title |
 
 After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a short (≤30 character) terminal tab title, then sets it via OSC 0. Only fires once per session. If the LLM call fails, the default title remains.
 
@@ -105,7 +105,7 @@ After the configured number of tool calls, dreb fires a single background LLM ca
 {
   "tabTitle": {
     "enabled": true,
-    "triggerAfter": 5
+    "triggerAfter": 12
   }
 }
 ```

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/buddy/buddy-controller.ts
+++ b/packages/coding-agent/src/core/buddy/buddy-controller.ts
@@ -119,7 +119,7 @@ export class BuddyController {
 		if (this.contextBuffer.length === 0) {
 			return "No recent activity.";
 		}
-		return this.contextBuffer.join("\n").slice(0, 8000);
+		return this.contextBuffer.join("\n").slice(-8000);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/buddy/buddy-controller.ts
+++ b/packages/coding-agent/src/core/buddy/buddy-controller.ts
@@ -13,6 +13,7 @@
  * and Telegram (activity gating + reaction budget) can use different strategies.
  */
 
+import { labelMessageEnd, labelToolEnd } from "../context-buffer.js";
 import { log } from "../logger.js";
 import { type BuddyManager, checkOllama } from "./buddy-manager.js";
 import type { BuddyState } from "./buddy-types.js";
@@ -285,17 +286,8 @@ export class BuddyController {
 		switch (event.type) {
 			case "message_end": {
 				if (event.message?.role === "assistant") {
-					const textParts = event.message.content
-						?.filter((c: any) => c.type === "text")
-						?.map((c: any) => c.text)
-						?.join("");
-					if (textParts) {
-						this.appendContext(`Assistant: ${textParts}`);
-					}
-					const toolCalls = event.message.content?.filter((c: any) => c.type === "toolCall") ?? [];
-					if (toolCalls.length > 0) {
-						const tools = toolCalls.map((c: any) => c.name).join(", ");
-						this.appendContext(`Called tools: ${tools}`);
+					for (const entry of labelMessageEnd(event.message)) {
+						this.appendContext(entry);
 					}
 				}
 				break;
@@ -303,18 +295,9 @@ export class BuddyController {
 
 			case "tool_execution_end": {
 				// Context capture (always)
-				const status = event.isError ? "failed" : "completed";
-				const output = event.result?.output || event.result?.content;
-				const outputText =
-					typeof output === "string"
-						? output
-						: Array.isArray(output)
-							? output
-									.filter((c: any) => c.type === "text")
-									.map((c: any) => c.text)
-									.join("")
-							: "";
-				this.appendContext(`Tool ${event.toolName} ${status}${outputText ? `: ${outputText}` : ""}`);
+				this.appendContext(
+					labelToolEnd({ toolName: event.toolName, isError: event.isError, result: event.result }),
+				);
 
 				// Reaction on error (gated by enabled)
 				if (event.isError && this.enabled) {

--- a/packages/coding-agent/src/core/context-buffer.ts
+++ b/packages/coding-agent/src/core/context-buffer.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared rolling context buffer and event-labeling utilities.
+ *
+ * Extracted from buddy-controller.ts so that both the buddy companion and
+ * other consumers (e.g. tab-title updater) can reuse the same content-extraction
+ * and buffer management logic without duplication.
+ */
+
+/**
+ * A fixed-capacity ring buffer that stores labeled context entries.
+ * Entries are capped individually and the built output is capped to a total character limit.
+ */
+export class RollingContextBuffer {
+	private entries: string[] = [];
+	private readonly maxEntries: number;
+	private readonly maxChars: number;
+
+	constructor(opts?: { maxEntries?: number; maxChars?: number }) {
+		this.maxEntries = opts?.maxEntries ?? 20;
+		this.maxChars = opts?.maxChars ?? 8000;
+	}
+
+	/** Append an entry to the buffer (evicts oldest if at capacity). Individual entries are capped to 2000 chars. */
+	append(entry: string): void {
+		this.entries.push(entry.slice(0, 2000));
+		if (this.entries.length > this.maxEntries) {
+			this.entries.shift();
+		}
+	}
+
+	/** Clear all entries from the buffer. */
+	clear(): void {
+		this.entries = [];
+	}
+
+	/** Join all entries with newlines, capped to maxChars total. */
+	build(): string {
+		return this.entries.join("\n").slice(0, this.maxChars);
+	}
+
+	/** Current number of entries in the buffer. */
+	get size(): number {
+		return this.entries.length;
+	}
+}
+
+/**
+ * Label an assistant message_end event into 0-2 context entries.
+ *
+ * Returns labeled strings for text content and/or tool calls.
+ * Returns [] for non-assistant messages or messages with no usable content.
+ */
+export function labelMessageEnd(message: { role: string; content?: unknown }): string[] {
+	if (message.role !== "assistant" || !Array.isArray(message.content)) {
+		return [];
+	}
+
+	const results: string[] = [];
+
+	const textParts = message.content
+		?.filter((c: any) => c.type === "text")
+		?.map((c: any) => c.text)
+		?.join("");
+
+	if (textParts) {
+		results.push(`Assistant: ${textParts}`.slice(0, 2000));
+	}
+
+	const toolCalls = message.content?.filter((c: any) => c.type === "toolCall") ?? [];
+	if (toolCalls.length > 0) {
+		const tools = toolCalls.map((c: any) => c.name).join(", ");
+		results.push(`Called tools: ${tools}`);
+	}
+
+	return results;
+}
+
+/**
+ * Label a tool_execution_end event into a single context entry.
+ *
+ * Returns a string like "Tool bash completed" or "Tool bash failed: <output>".
+ */
+export function labelToolEnd(event: { toolName: string; isError?: boolean; result?: unknown }): string {
+	const output = (event.result as any)?.output || (event.result as any)?.content;
+	const outputText =
+		typeof output === "string"
+			? output
+			: Array.isArray(output)
+				? output
+						.filter((c: any) => c.type === "text")
+						.map((c: any) => c.text)
+						.join("")
+				: "";
+	const status = event.isError ? "failed" : "completed";
+	return `Tool ${event.toolName} ${status}${outputText ? `: ${outputText}` : ""}`;
+}

--- a/packages/coding-agent/src/core/context-buffer.ts
+++ b/packages/coding-agent/src/core/context-buffer.ts
@@ -33,9 +33,10 @@ export class RollingContextBuffer {
 		this.entries = [];
 	}
 
-	/** Join all entries with newlines, capped to maxChars total. */
+	/** Join all entries with newlines, capped to maxChars total. Newest entries are preferred. */
 	build(): string {
-		return this.entries.join("\n").slice(0, this.maxChars);
+		const joined = this.entries.join("\n");
+		return joined.length <= this.maxChars ? joined : joined.slice(-this.maxChars);
 	}
 
 	/** Current number of entries in the buffer. */

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -119,7 +119,7 @@ export interface Settings {
 
 export interface TabTitleSettings {
 	enabled?: boolean; // default: true — auto-generate terminal tab title from session task
-	triggerAfter?: number; // default: 3 — number of tool calls before generating title
+	triggerAfter?: number; // default: 5 — number of tool calls before generating title
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -119,7 +119,7 @@ export interface Settings {
 
 export interface TabTitleSettings {
 	enabled?: boolean; // default: true — auto-generate terminal tab title from session task
-	triggerAfter?: number; // default: 12 — number of tool calls before generating title
+	triggerAfter?: number; // default: 9 — number of tool calls before generating title
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -119,7 +119,7 @@ export interface Settings {
 
 export interface TabTitleSettings {
 	enabled?: boolean; // default: true — auto-generate terminal tab title from session task
-	triggerAfter?: number; // default: 5 — number of tool calls before generating title
+	triggerAfter?: number; // default: 12 — number of tool calls before generating title
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -691,6 +691,9 @@ export class InteractiveMode {
 			getModelRegistry: () => this.session.modelRegistry,
 			getProvider: () => this.session.model?.provider,
 			getAgentModelsOverride: (name) => this.settingsManager.getAgentModelsForAgent(name),
+			getBranch: () => this.footerDataProvider.getGitBranch(),
+			getRepo: () => path.basename(process.cwd()),
+			getCwd: () => process.cwd(),
 		});
 	}
 
@@ -2507,6 +2510,8 @@ export class InteractiveMode {
 				}
 				// Capture assistant response for buddy context
 				this.buddyController.handleEvent(event);
+				// Capture context for tab title generation
+				this.tabTitleGenerator?.onMessageEnd(event.message);
 				// Defer commit until after the next render paints the final state
 				this.commitNeeded = true;
 				this.ui.requestRender();
@@ -2560,7 +2565,7 @@ export class InteractiveMode {
 				// Buddy context + reaction for tool execution
 				this.buddyController.handleEvent(event);
 				// Tab title auto-generation
-				this.tabTitleGenerator?.onToolEnd();
+				this.tabTitleGenerator?.onToolEnd(event);
 				break;
 			}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -686,6 +686,9 @@ export class InteractiveMode {
 
 		this.tabTitleGenerator = new TabTitleGenerator(settings, {
 			setTitle: (title) => this.ui.terminal.setTitle(title),
+			setSessionName: (name) => {
+				this.sessionManager.appendSessionInfo(name);
+			},
 			getMessages: () => this.session.state.messages,
 			getModel: () => this.session.model,
 			getModelRegistry: () => this.session.modelRegistry,

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -37,6 +37,8 @@ const TITLE_PROMPT =
 export interface TabTitleDeps {
 	/** Set the terminal tab title (OSC 0). */
 	setTitle: (title: string) => void;
+	/** Persist the generated title as the session name. Called with the raw title (without "dreb - " prefix). */
+	setSessionName?: (name: string) => void;
 	/** Get the current session messages (for context). */
 	getMessages: () => Array<{ role: string; content?: unknown }>;
 	/** Get the current model (parent session model — used as fallback). */
@@ -141,6 +143,7 @@ export class TabTitleGenerator {
 		const title = this.sanitizeTitle(response);
 		if (title) {
 			this.deps.setTitle(`dreb - ${title}`);
+			this.deps.setSessionName?.(title);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -17,7 +17,7 @@ import type { ModelRegistry } from "../../core/model-registry.js";
 import type { TabTitleSettings } from "../../core/settings-manager.js";
 import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/tools/subagent.js";
 
-const DEFAULT_TRIGGER_AFTER = 5;
+const DEFAULT_TRIGGER_AFTER = 12;
 const MAX_TITLE_LENGTH = 30;
 const TITLE_GENERATION_TIMEOUT_MS = 60_000;
 

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -17,7 +17,7 @@ import type { ModelRegistry } from "../../core/model-registry.js";
 import type { TabTitleSettings } from "../../core/settings-manager.js";
 import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/tools/subagent.js";
 
-const DEFAULT_TRIGGER_AFTER = 12;
+const DEFAULT_TRIGGER_AFTER = 9;
 const MAX_TITLE_LENGTH = 30;
 const TITLE_GENERATION_TIMEOUT_MS = 60_000;
 

--- a/packages/coding-agent/src/modes/interactive/tab-title.ts
+++ b/packages/coding-agent/src/modes/interactive/tab-title.ts
@@ -12,17 +12,27 @@ import { join } from "node:path";
 import type { Api, Context, Model } from "@dreb/ai";
 import { completeSimple } from "@dreb/ai";
 import { CONFIG_DIR_NAME, getPackageDir } from "../../config.js";
+import { labelMessageEnd, labelToolEnd, RollingContextBuffer } from "../../core/context-buffer.js";
 import type { ModelRegistry } from "../../core/model-registry.js";
 import type { TabTitleSettings } from "../../core/settings-manager.js";
 import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "../../core/tools/subagent.js";
 
-const DEFAULT_TRIGGER_AFTER = 3;
+const DEFAULT_TRIGGER_AFTER = 5;
 const MAX_TITLE_LENGTH = 30;
 const TITLE_GENERATION_TIMEOUT_MS = 60_000;
 
 const TITLE_PROMPT =
-	"Summarize this session's task in ≤30 characters for a terminal tab title. " +
-	"Output ONLY the title text, nothing else. No quotes, no explanation.";
+	"You are a headless terminal-tab title generator. You are NOT the assistant in the session — " +
+	"you will never speak to the user. Your only job is to output a single short title string, nothing else. " +
+	"No quotes, no explanation, no preamble. " +
+	"The title disambiguates terminal windows for a human at a glance. " +
+	"Describe what is being DONE (e.g. 'Fix auth bug', 'Plan subagent refactor', 'Review modal'), " +
+	"not just label the invocation. " +
+	"If a branch name is present, abbreviate it to its semantic slug " +
+	"(e.g. feature/issue-217-copy-selector-modal → copy-selector) and combine with the action. " +
+	"Avoid reference-only formats like '#N' or 'mach6-X #N'. " +
+	"Do not include 'dreb' — the caller already adds it. " +
+	"Output ONLY the title text, ≤30 characters.";
 
 export interface TabTitleDeps {
 	/** Set the terminal tab title (OSC 0). */
@@ -40,18 +50,26 @@ export interface TabTitleDeps {
 	 * Returns a non-empty fallback list when the user has configured an override.
 	 */
 	getAgentModelsOverride?: (agentName: string) => string[] | undefined;
+	/** Current git branch name, or null/undefined if unavailable. */
+	getBranch?: () => string | null | undefined;
+	/** Repository name (e.g., dirname of cwd), or undefined. */
+	getRepo?: () => string | undefined;
+	/** Current working directory, or undefined. */
+	getCwd?: () => string | undefined;
 }
 
 export class TabTitleGenerator {
 	private toolCallCount = 0;
 	private fired = false;
 	private readonly threshold: number;
+	private readonly contextBuffer: RollingContextBuffer;
 
 	constructor(
 		private readonly settings: TabTitleSettings | undefined,
 		private readonly deps: TabTitleDeps,
 	) {
 		this.threshold = settings?.triggerAfter ?? DEFAULT_TRIGGER_AFTER;
+		this.contextBuffer = new RollingContextBuffer({ maxEntries: 30, maxChars: 6000 });
 	}
 
 	/** Whether this generator is enabled. */
@@ -60,10 +78,14 @@ export class TabTitleGenerator {
 	}
 
 	/**
-	 * Called on each tool_execution_end event. Increments the counter and fires
-	 * the title generation when threshold is reached.
+	 * Called on each tool_execution_end event. Captures context from the event,
+	 * increments the counter, and fires title generation when threshold is reached.
 	 */
-	onToolEnd(): void {
+	onToolEnd(event?: { toolName?: string; isError?: boolean; result?: unknown }): void {
+		if (event?.toolName) {
+			this.contextBuffer.append(labelToolEnd(event as { toolName: string; isError?: boolean; result?: unknown }));
+		}
+
 		if (this.fired || !this.enabled) return;
 
 		this.toolCallCount++;
@@ -71,6 +93,14 @@ export class TabTitleGenerator {
 			this.fired = true;
 			// Fire-and-forget — never surfaces errors to the user
 			this.generateTitle().catch(() => {});
+		}
+	}
+
+	/** Called on message_end events — captures labeled context. */
+	onMessageEnd(message: { role: string; content?: unknown }): void {
+		if (this.fired) return; // no need to accumulate after fired
+		for (const entry of labelMessageEnd(message)) {
+			this.contextBuffer.append(entry);
 		}
 	}
 
@@ -171,28 +201,22 @@ export class TabTitleGenerator {
 	}
 
 	private buildContext(): string | undefined {
-		const messages = this.deps.getMessages();
-		if (messages.length === 0) return undefined;
+		const lines: string[] = [];
 
-		// Extract the first user message for context
-		const firstUser = messages.find((m) => m.role === "user");
-		if (!firstUser) return undefined;
+		// Metadata block
+		const branch = this.deps.getBranch?.();
+		const repo = this.deps.getRepo?.();
+		const cwd = this.deps.getCwd?.();
+		if (branch) lines.push(`Branch: ${branch}`);
+		if (repo) lines.push(`Repo: ${repo}`);
+		if (cwd) lines.push(`Cwd: ${cwd}`);
 
-		const content =
-			typeof firstUser.content === "string"
-				? firstUser.content
-				: Array.isArray(firstUser.content)
-					? firstUser.content
-							.filter((c: any) => c.type === "text")
-							.map((c: any) => c.text)
-							.join("\n")
-					: "";
+		// Rolling buffer
+		const bufferContent = this.contextBuffer.build();
+		if (bufferContent) lines.push(bufferContent);
 
-		if (!content) return undefined;
-
-		// Truncate long messages — the LLM only needs a summary
-		const truncated = content.length > 500 ? `${content.slice(0, 500)}...` : content;
-		return `Session task:\n${truncated}`;
+		if (lines.length === 0) return undefined;
+		return lines.join("\n");
 	}
 
 	/** Clean up LLM response to a usable tab title. */

--- a/packages/coding-agent/test/context-buffer.test.ts
+++ b/packages/coding-agent/test/context-buffer.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the shared rolling context buffer and event-labeling utilities.
+ */
+import { describe, expect, it } from "vitest";
+import { labelMessageEnd, labelToolEnd, RollingContextBuffer } from "../src/core/context-buffer.js";
+
+describe("RollingContextBuffer", () => {
+	it("append adds entries", () => {
+		const buf = new RollingContextBuffer();
+		buf.append("hello");
+		buf.append("world");
+		expect(buf.size).toBe(2);
+	});
+
+	it("build() joins entries with newline", () => {
+		const buf = new RollingContextBuffer();
+		buf.append("one");
+		buf.append("two");
+		buf.append("three");
+		expect(buf.build()).toBe("one\ntwo\nthree");
+	});
+
+	it("evicts oldest when maxEntries exceeded (default 20)", () => {
+		const buf = new RollingContextBuffer();
+		for (let i = 0; i < 25; i++) {
+			buf.append(`entry-${i}`);
+		}
+		expect(buf.size).toBe(20);
+		// Oldest entries (0-4) should be evicted
+		const built = buf.build();
+		expect(built).not.toContain("entry-0");
+		expect(built).not.toContain("entry-4");
+		expect(built).toContain("entry-5");
+		expect(built).toContain("entry-24");
+	});
+
+	it("evicts oldest with custom maxEntries", () => {
+		const buf = new RollingContextBuffer({ maxEntries: 3 });
+		buf.append("a");
+		buf.append("b");
+		buf.append("c");
+		buf.append("d");
+		expect(buf.size).toBe(3);
+		expect(buf.build()).toBe("b\nc\nd");
+	});
+
+	it("build() caps total output to maxChars", () => {
+		const buf = new RollingContextBuffer({ maxChars: 50 });
+		buf.append("a".repeat(30));
+		buf.append("b".repeat(30));
+		const result = buf.build();
+		expect(result.length).toBe(50);
+	});
+
+	it("individual entries are capped to 2000 chars", () => {
+		const buf = new RollingContextBuffer();
+		const longEntry = "x".repeat(5000);
+		buf.append(longEntry);
+		const result = buf.build();
+		expect(result.length).toBe(2000);
+	});
+
+	it("clear() empties the buffer", () => {
+		const buf = new RollingContextBuffer();
+		buf.append("one");
+		buf.append("two");
+		expect(buf.size).toBe(2);
+		buf.clear();
+		expect(buf.size).toBe(0);
+		expect(buf.build()).toBe("");
+	});
+
+	it("size getter reflects entry count", () => {
+		const buf = new RollingContextBuffer();
+		expect(buf.size).toBe(0);
+		buf.append("a");
+		expect(buf.size).toBe(1);
+		buf.append("b");
+		expect(buf.size).toBe(2);
+	});
+});
+
+describe("labelMessageEnd", () => {
+	it("returns [] for non-assistant role messages", () => {
+		expect(labelMessageEnd({ role: "user", content: [{ type: "text", text: "hi" }] })).toEqual([]);
+		expect(labelMessageEnd({ role: "system", content: [{ type: "text", text: "hi" }] })).toEqual([]);
+	});
+
+	it("returns [] for non-array content", () => {
+		expect(labelMessageEnd({ role: "assistant", content: "just a string" })).toEqual([]);
+		expect(labelMessageEnd({ role: "assistant", content: undefined })).toEqual([]);
+		expect(labelMessageEnd({ role: "assistant" })).toEqual([]);
+	});
+
+	it("returns ['Assistant: <text>'] for text-only assistant message", () => {
+		const result = labelMessageEnd({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Hello " },
+				{ type: "text", text: "world" },
+			],
+		});
+		expect(result).toEqual(["Assistant: Hello world"]);
+	});
+
+	it("returns ['Called tools: foo, bar'] for tool-call-only assistant message", () => {
+		const result = labelMessageEnd({
+			role: "assistant",
+			content: [
+				{ type: "toolCall", name: "foo" },
+				{ type: "toolCall", name: "bar" },
+			],
+		});
+		expect(result).toEqual(["Called tools: foo, bar"]);
+	});
+
+	it("returns both entries (text + tools) for mixed content", () => {
+		const result = labelMessageEnd({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Let me help" },
+				{ type: "toolCall", name: "bash" },
+				{ type: "toolCall", name: "read" },
+			],
+		});
+		expect(result).toEqual(["Assistant: Let me help", "Called tools: bash, read"]);
+	});
+
+	it("returns [] when message has no text parts and no tool-call parts", () => {
+		const result = labelMessageEnd({
+			role: "assistant",
+			content: [{ type: "image", url: "https://example.com/img.png" }],
+		});
+		expect(result).toEqual([]);
+	});
+
+	it("caps text at 2000 chars", () => {
+		const longText = "x".repeat(3000);
+		const result = labelMessageEnd({
+			role: "assistant",
+			content: [{ type: "text", text: longText }],
+		});
+		expect(result.length).toBe(1);
+		expect(result[0].length).toBe(2000);
+	});
+});
+
+describe("labelToolEnd", () => {
+	it("returns 'Tool bash completed' for success with no output", () => {
+		expect(labelToolEnd({ toolName: "bash" })).toBe("Tool bash completed");
+	});
+
+	it("returns 'Tool bash failed' for error with no output", () => {
+		expect(labelToolEnd({ toolName: "bash", isError: true })).toBe("Tool bash failed");
+	});
+
+	it("returns 'Tool bash completed: <text>' for string output", () => {
+		const result = labelToolEnd({ toolName: "bash", result: { output: "hello world" } });
+		expect(result).toBe("Tool bash completed: hello world");
+	});
+
+	it("returns 'Tool bash completed: <text>' for array-of-content output", () => {
+		const result = labelToolEnd({
+			toolName: "bash",
+			result: {
+				content: [
+					{ type: "text", text: "line 1\n" },
+					{ type: "text", text: "line 2" },
+				],
+			},
+		});
+		expect(result).toBe("Tool bash completed: line 1\nline 2");
+	});
+
+	it("returns 'Tool bash failed: <error>' for error with output", () => {
+		const result = labelToolEnd({
+			toolName: "bash",
+			isError: true,
+			result: { output: "command not found" },
+		});
+		expect(result).toBe("Tool bash failed: command not found");
+	});
+});

--- a/packages/coding-agent/test/context-buffer.test.ts
+++ b/packages/coding-agent/test/context-buffer.test.ts
@@ -44,12 +44,15 @@ describe("RollingContextBuffer", () => {
 		expect(buf.build()).toBe("b\nc\nd");
 	});
 
-	it("build() caps total output to maxChars", () => {
+	it("build() caps total output to maxChars, preferring newest entries", () => {
 		const buf = new RollingContextBuffer({ maxChars: 50 });
-		buf.append("a".repeat(30));
-		buf.append("b".repeat(30));
+		buf.append("a".repeat(30)); // oldest
+		buf.append("b".repeat(30)); // newest
 		const result = buf.build();
 		expect(result.length).toBe(50);
+		// newest entry ("b"s) must be present; oldest ("a"s) are partially/fully dropped
+		expect(result).toContain("b");
+		expect(result.endsWith("b".repeat(30))).toBe(true);
 	});
 
 	it("individual entries are capped to 2000 chars", () => {

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -76,6 +76,8 @@ function createMockDeps(overrides: Partial<TabTitleDeps> = {}): TabTitleDeps {
 				getAvailable: () => [MOCK_MODEL],
 			}) as any,
 		getProvider: () => "test-provider",
+		getBranch: () => "main",
+		getRepo: () => "test-repo",
 		...overrides,
 	};
 }
@@ -115,21 +117,18 @@ describe("TabTitleGenerator", () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			gen.onToolEnd();
-			gen.onToolEnd();
+			for (let i = 0; i < 4; i++) gen.onToolEnd();
 
 			expect(deps.setTitle).not.toHaveBeenCalled();
 			expect(gen.hasFired).toBe(false);
-			expect(gen.currentCount).toBe(2);
+			expect(gen.currentCount).toBe(4);
 		});
 
-		it("fires exactly at the default threshold (3)", async () => {
+		it("fires exactly at the default threshold (5)", async () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			gen.onToolEnd();
-			gen.onToolEnd();
-			gen.onToolEnd();
+			for (let i = 0; i < 5; i++) gen.onToolEnd();
 
 			// Wait for async generation
 			await vi.waitFor(() => {
@@ -235,8 +234,14 @@ describe("TabTitleGenerator", () => {
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 
-		it("handles empty messages gracefully", async () => {
-			const deps = createMockDeps({ getMessages: () => [] });
+		it("handles empty context gracefully", async () => {
+			// No metadata deps and no events sent → buildContext returns undefined
+			const deps = createMockDeps({
+				getMessages: () => [],
+				getBranch: () => null,
+				getRepo: () => undefined,
+				getCwd: () => undefined,
+			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
 			gen.onToolEnd();
@@ -249,11 +254,24 @@ describe("TabTitleGenerator", () => {
 	});
 
 	describe("prompt construction", () => {
-		it("includes first user message in context", async () => {
-			const deps = createMockDeps();
+		it("includes buffer content in context payload", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "feature/fix-auth",
+				getRepo: () => "my-project",
+			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
-			gen.onToolEnd();
+			// Feed an assistant message into the buffer
+			gen.onMessageEnd({
+				role: "assistant",
+				content: [{ type: "text", text: "I'll look into that." }],
+			});
+
+			gen.onToolEnd({
+				toolName: "bash",
+				isError: false,
+				result: { output: "ls output" },
+			});
 
 			await vi.waitFor(() => {
 				expect(mockCompleteSimple).toHaveBeenCalled();
@@ -261,20 +279,18 @@ describe("TabTitleGenerator", () => {
 
 			const callArgs = mockCompleteSimple.mock.calls[0];
 			const context = callArgs[1] as any;
-			expect(context.messages[0].content).toContain("Fix the authentication bug in login.ts");
+			const content = context.messages[0].content;
+			expect(content).toContain("Branch: feature/fix-auth");
+			expect(content).toContain("Repo: my-project");
+			expect(content).toContain("Assistant: I'll look into that.");
+			expect(content).toContain("Tool bash completed: ls output");
 		});
 
-		it("handles array content in user messages", async () => {
+		it("includes only metadata when no events have been sent", async () => {
 			const deps = createMockDeps({
-				getMessages: () => [
-					{
-						role: "user",
-						content: [
-							{ type: "text", text: "Refactor the parser" },
-							{ type: "image", source: { data: "abc" } },
-						],
-					},
-				],
+				getBranch: () => "main",
+				getRepo: () => "dreb",
+				getCwd: () => "/home/user/dreb",
 			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
@@ -286,27 +302,10 @@ describe("TabTitleGenerator", () => {
 
 			const callArgs = mockCompleteSimple.mock.calls[0];
 			const context = callArgs[1] as any;
-			expect(context.messages[0].content).toContain("Refactor the parser");
-		});
-
-		it("truncates very long user messages", async () => {
-			const longMessage = "x".repeat(1000);
-			const deps = createMockDeps({
-				getMessages: () => [{ role: "user", content: longMessage }],
-			});
-			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
-
-			gen.onToolEnd();
-
-			await vi.waitFor(() => {
-				expect(mockCompleteSimple).toHaveBeenCalled();
-			});
-
-			const callArgs = mockCompleteSimple.mock.calls[0];
-			const context = callArgs[1] as any;
-			// Should be truncated to 500 + "..."
-			expect(context.messages[0].content.length).toBeLessThan(600);
-			expect(context.messages[0].content).toContain("...");
+			const content = context.messages[0].content;
+			expect(content).toContain("Branch: main");
+			expect(content).toContain("Repo: dreb");
+			expect(content).toContain("Cwd: /home/user/dreb");
 		});
 	});
 
@@ -381,6 +380,151 @@ describe("TabTitleGenerator", () => {
 			await vi.waitFor(() => {
 				expect(gen.hasFired).toBe(true);
 			});
+			expect(deps.setTitle).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("rolling context buffer", () => {
+		it("onMessageEnd with assistant text → LLM payload includes labeled entry", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onMessageEnd({
+				role: "assistant",
+				content: [{ type: "text", text: "Looking at the code now." }],
+			});
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.messages[0].content).toContain("Assistant: Looking at the code now.");
+		});
+
+		it("onMessageEnd with user message → no entry (filtered out)", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onMessageEnd({
+				role: "user",
+				content: [{ type: "text", text: "Please fix the bug" }],
+			});
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.messages[0].content).not.toContain("User:");
+			expect(context.messages[0].content).not.toContain("Please fix the bug");
+		});
+
+		it("onToolEnd(event) → LLM payload includes tool result", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd({
+				toolName: "bash",
+				isError: false,
+				result: { output: "file.ts" },
+			});
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.messages[0].content).toContain("Tool bash completed: file.ts");
+		});
+
+		it("combines onMessageEnd + onToolEnd accumulating multiple entries", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "feature/test",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 2 }, deps);
+
+			gen.onMessageEnd({
+				role: "assistant",
+				content: [{ type: "text", text: "Starting fix" }],
+			});
+
+			gen.onToolEnd({
+				toolName: "read",
+				isError: false,
+				result: { output: "file content" },
+			});
+
+			gen.onMessageEnd({
+				role: "assistant",
+				content: [{ type: "text", text: "Now editing" }],
+			});
+
+			gen.onToolEnd({
+				toolName: "edit",
+				isError: false,
+				result: { output: "done" },
+			});
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			const content = context.messages[0].content;
+			expect(content).toContain("Assistant: Starting fix");
+			expect(content).toContain("Tool read completed: file content");
+			expect(content).toContain("Assistant: Now editing");
+			expect(content).toContain("Tool edit completed: done");
+			expect(content).toContain("Branch: feature/test");
+		});
+
+		it("buildContext includes branch/repo/cwd metadata", async () => {
+			const deps = createMockDeps({
+				getBranch: () => "feature/cool-thing",
+				getRepo: () => "my-repo",
+				getCwd: () => "/home/user/my-repo",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			const content = context.messages[0].content;
+			expect(content).toContain("Branch: feature/cool-thing");
+			expect(content).toContain("Repo: my-repo");
+			expect(content).toContain("Cwd: /home/user/my-repo");
+		});
+
+		it("buildContext returns undefined when buffer is empty and no metadata", async () => {
+			// Explicitly nullify all metadata getters and send no events
+			const deps = createMockDeps({
+				getBranch: () => null,
+				getRepo: () => undefined,
+				getCwd: () => undefined,
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
+			// buildContext() returned undefined → generateTitle bails out
 			expect(deps.setTitle).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -117,18 +117,18 @@ describe("TabTitleGenerator", () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			for (let i = 0; i < 4; i++) gen.onToolEnd();
+			for (let i = 0; i < 11; i++) gen.onToolEnd();
 
 			expect(deps.setTitle).not.toHaveBeenCalled();
 			expect(gen.hasFired).toBe(false);
-			expect(gen.currentCount).toBe(4);
+			expect(gen.currentCount).toBe(11);
 		});
 
-		it("fires exactly at the default threshold (5)", async () => {
+		it("fires exactly at the default threshold (12)", async () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			for (let i = 0; i < 5; i++) gen.onToolEnd();
+			for (let i = 0; i < 12; i++) gen.onToolEnd();
 
 			// Wait for async generation
 			await vi.waitFor(() => {

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -118,18 +118,18 @@ describe("TabTitleGenerator", () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			for (let i = 0; i < 11; i++) gen.onToolEnd();
+			for (let i = 0; i < 8; i++) gen.onToolEnd();
 
 			expect(deps.setTitle).not.toHaveBeenCalled();
 			expect(gen.hasFired).toBe(false);
-			expect(gen.currentCount).toBe(11);
+			expect(gen.currentCount).toBe(8);
 		});
 
-		it("fires exactly at the default threshold (12)", async () => {
+		it("fires exactly at the default threshold (9)", async () => {
 			const deps = createMockDeps();
 			const gen = new TabTitleGenerator(undefined, deps);
 
-			for (let i = 0; i < 12; i++) gen.onToolEnd();
+			for (let i = 0; i < 9; i++) gen.onToolEnd();
 
 			// Wait for async generation
 			await vi.waitFor(() => {

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -65,6 +65,7 @@ const MOCK_MODEL = {
 function createMockDeps(overrides: Partial<TabTitleDeps> = {}): TabTitleDeps {
 	return {
 		setTitle: vi.fn(),
+		setSessionName: vi.fn(),
 		getMessages: () => [
 			{ role: "user", content: "Fix the authentication bug in login.ts" },
 			{ role: "assistant", content: [{ type: "text", text: "I'll look into that." }] },
@@ -649,6 +650,56 @@ describe("TabTitleGenerator", () => {
 			// Should still have been called with the parent model
 			const callArgs = mockCompleteSimple.mock.calls[0];
 			expect((callArgs[0] as any).id).toBe("test-model");
+		});
+	});
+
+	describe("session name persistence", () => {
+		it("calls setSessionName with the raw title (no prefix) on success", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("Fix auth bug") as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+			expect(deps.setSessionName).toHaveBeenCalledWith("Fix auth bug");
+		});
+
+		it("does not throw when setSessionName is not provided (undefined)", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("Fix auth bug") as any);
+
+			const deps = createMockDeps({ setSessionName: undefined });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			// setTitle still works, and no error was thrown
+			expect(deps.setTitle).toHaveBeenCalledWith("dreb - Fix auth bug");
+		});
+
+		it("does not call setSessionName when title generation fails", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("") as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
+
+			expect(deps.setTitle).not.toHaveBeenCalled();
+			expect(deps.setSessionName).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/telegram/src/commands/sessions.ts
+++ b/packages/telegram/src/commands/sessions.ts
@@ -36,7 +36,7 @@ export async function cmdSessions(ctx: Context, userState: UserState, config: Co
 			" " +
 			date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
 		const sid = s.id.slice(0, 8);
-		const preview = s.firstMessage.slice(0, 60);
+		const preview = s.name ? s.name : s.firstMessage.slice(0, 60);
 		lines.push(`\`${sid}\` (${ts})\n  ${preview}`);
 	}
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.27.0",
+	"version": "2.27.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #236

Reuse the buddy system's rolling labeled context buffer in the tab-title generator, include branch/repo/cwd as labeled metadata, bump the trigger threshold, and rewrite the title prompt for human-useful window titles.

Implementation plan posted as a comment below.
