### PR TITLE
Remove /-prefix requirement from suggest_next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -2457,7 +2457,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.1",
@@ -2471,7 +2472,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.1",
@@ -2485,7 +2487,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.1",
@@ -2499,7 +2502,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.1",
@@ -2513,7 +2517,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.1",
@@ -2527,7 +2532,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.1",
@@ -2541,7 +2547,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.1",
@@ -2555,7 +2562,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.1",
@@ -2569,7 +2577,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.1",
@@ -2583,7 +2592,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.1",
@@ -2597,7 +2607,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.1",
@@ -2611,7 +2622,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.1",
@@ -2625,7 +2637,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.1",
@@ -2639,7 +2652,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.1",
@@ -2653,7 +2667,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.1",
@@ -2667,7 +2682,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.1",
@@ -2681,7 +2697,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.1",
@@ -2695,7 +2712,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.1",
@@ -2709,7 +2727,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.1",
@@ -2723,7 +2742,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.1",
@@ -2737,7 +2757,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.1",
@@ -2751,7 +2772,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.1",
@@ -2765,7 +2787,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.1",
@@ -2779,7 +2802,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.1",
@@ -2793,7 +2817,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
@@ -8888,7 +8913,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8917,7 +8942,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8973,7 +8998,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9102,7 +9127,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9151,7 +9176,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9184,7 +9209,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.27.2",
+			"version": "2.27.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/test/apply-copilot-base-url.test.ts
+++ b/packages/ai/test/apply-copilot-base-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { applyCopilotBaseUrl } from "./oauth.js";
+
+// Unit coverage for the E2E test helper that rewrites a github-copilot model's
+// baseUrl from the resolved OAuth token's proxy-ep. The E2E call sites only ever
+// exercise the rewrite branch, and only when a live token is present (they skip
+// otherwise), so the no-op branches have no coverage in CI without these tests.
+describe("applyCopilotBaseUrl", () => {
+	const INDIVIDUAL_URL = "https://api.individual.githubcopilot.com";
+
+	it("returns the model unchanged for non-copilot providers", () => {
+		const model = { provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" };
+		expect(applyCopilotBaseUrl(model, "tid=t;proxy-ep=proxy.business.githubcopilot.com;")).toBe(model);
+	});
+
+	it("returns the model unchanged when the token is missing", () => {
+		const model = { provider: "github-copilot", baseUrl: INDIVIDUAL_URL };
+		expect(applyCopilotBaseUrl(model, undefined)).toBe(model);
+	});
+
+	it("rewrites the baseUrl from the token's proxy-ep for business tokens", () => {
+		const model = { provider: "github-copilot", baseUrl: INDIVIDUAL_URL };
+		const token = "tid=abc;exp=9999999999;proxy-ep=proxy.business.githubcopilot.com;";
+
+		const result = applyCopilotBaseUrl(model, token);
+
+		expect(result.baseUrl).toBe("https://api.business.githubcopilot.com");
+		expect(result.provider).toBe("github-copilot");
+		// Original is not mutated — the helper returns a copy.
+		expect(model.baseUrl).toBe(INDIVIDUAL_URL);
+	});
+
+	it("falls back to the individual endpoint when the token lacks a proxy-ep", () => {
+		const model = { provider: "github-copilot", baseUrl: "https://stale.example.com" };
+
+		const result = applyCopilotBaseUrl(model, "tid=abc;exp=9999999999;");
+
+		expect(result.baseUrl).toBe(INDIVIDUAL_URL);
+	});
+});

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -20,7 +20,7 @@ import { isContextOverflow } from "../src/utils/overflow.js";
 import { hasAzureOpenAICredentials } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -121,7 +121,7 @@ describe("Context overflow error handling", () => {
 		it.skipIf(!githubCopilotToken)(
 			"gpt-4.1 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "gpt-4.1");
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 
@@ -136,7 +136,7 @@ describe("Context overflow error handling", () => {
 		it.skipIf(!githubCopilotToken)(
 			"claude-sonnet-4 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4.5");
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -8,7 +8,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -457,7 +457,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"gpt-4.1 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -466,7 +466,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"gpt-4.1 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -475,7 +475,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"gpt-4.1 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -484,7 +484,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"gpt-4.1 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -493,7 +493,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4.5 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -502,7 +502,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4.5 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -511,7 +511,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4.5 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -520,7 +520,7 @@ describe("AI Providers Empty Message Tests", () => {
 			"claude-sonnet-4.5 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -10,7 +10,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -333,7 +333,7 @@ describe("Tool Results with Images", () => {
 			"gpt-4.1 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -342,7 +342,7 @@ describe("Tool Results with Images", () => {
 			"gpt-4.1 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -351,7 +351,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4.5 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -360,7 +360,7 @@ describe("Tool Results with Images", () => {
 			"claude-sonnet-4.5 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/oauth.ts
+++ b/packages/ai/test/oauth.ts
@@ -8,8 +8,29 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { getOAuthApiKey } from "../src/utils/oauth/index.js";
+import { getGitHubCopilotBaseUrl, getOAuthApiKey } from "../src/utils/oauth/index.js";
 import type { OAuthCredentials, OAuthProvider } from "../src/utils/oauth/types.js";
+
+/**
+ * Override a github-copilot model's `baseUrl` with the API endpoint derived
+ * from the resolved OAuth token's `proxy-ep`.
+ *
+ * This mirrors the production `modifyModels` hook in `github-copilot.ts`, which
+ * rewrites the hardcoded `api.individual.githubcopilot.com` base URL to the
+ * correct proxy for the account type (individual / business / enterprise).
+ * Without this, business/enterprise tokens are routed to the individual
+ * endpoint and the API responds with `421 Misdirected Request`.
+ *
+ * No-ops for non-copilot models or when the token is unavailable (the matching
+ * E2E tests skip themselves when the token is absent).
+ */
+export function applyCopilotBaseUrl<T extends { provider: string; baseUrl: string }>(
+	model: T,
+	token: string | undefined,
+): T {
+	if (model.provider !== "github-copilot" || !token) return model;
+	return { ...model, baseUrl: getGitHubCopilotBaseUrl(token) };
+}
 
 const AUTH_PATH = join(homedir(), ".dreb", "agent", "auth.json");
 

--- a/packages/ai/test/openai-responses-tool-result-images.test.ts
+++ b/packages/ai/test/openai-responses-tool-result-images.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { Api, Context, Model, StreamOptions, Tool, ToolResultMessage } from "../src/index.js";
 import { complete, getModel } from "../src/index.js";
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 
@@ -168,8 +168,8 @@ describe("Responses API tool result images", () => {
 		});
 	});
 
-	describe("GitHub Copilot Responses Provider (gpt-5-mini)", () => {
-		const model = getModel("github-copilot", "gpt-5-mini");
+	describe("GitHub Copilot Responses Provider (gpt-5.4)", () => {
+		const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 
 		it.skipIf(!githubCopilotToken)(
 			"should send tool result images in function_call_output",

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -3,7 +3,7 @@ import { findModel, getModel } from "../src/models.js";
 import { complete } from "../src/stream.js";
 import type { Api, Context, Model, StreamOptions } from "../src/types.js";
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 
@@ -103,7 +103,7 @@ describe("responseId E2E Tests", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(!githubCopilotToken)("OpenAI path should expose responseId", { retry: 3, timeout: 30000 }, async () => {
-			const llm = getModel("github-copilot", "gpt-5.4");
+			const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 			await expectResponseId(llm, { apiKey: githubCopilotToken });
 		});
 
@@ -111,7 +111,7 @@ describe("responseId E2E Tests", () => {
 			"Anthropic path should expose responseId",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await expectResponseId(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -14,7 +14,7 @@ import { StringEnum } from "../src/utils/typebox-helpers.js";
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_5_EXTENDED } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -856,7 +856,7 @@ describe("Generate E2E Tests", () => {
 	// =========================================================================
 
 	describe("GitHub Copilot Provider (gpt-5.4 via OpenAI Completions)", () => {
-		const llm = getModel("github-copilot", "gpt-5.4");
+		const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 
 		it.skipIf(!githubCopilotToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: githubCopilotToken });
@@ -870,15 +870,17 @@ describe("Generate E2E Tests", () => {
 			await handleStreaming(llm, { apiKey: githubCopilotToken });
 		});
 
-		it.skipIf(!githubCopilotToken)("should handle thinking", { retry: 2 }, async () => {
-			const thinkingModel = getModel("github-copilot", "gpt-5-mini");
-			await handleThinking(thinkingModel, { apiKey: githubCopilotToken, reasoningEffort: "high" });
+		it.skipIf(!githubCopilotToken)("should handle thinking", { retry: 2, timeout: 60000 }, async () => {
+			await handleThinking(llm, { apiKey: githubCopilotToken, reasoningEffort: "high" });
 		});
 
-		it.skipIf(!githubCopilotToken)("should handle multi-turn with thinking and tools", { retry: 3 }, async () => {
-			const thinkingModel = getModel("github-copilot", "gpt-5-mini");
-			await multiTurn(thinkingModel, { apiKey: githubCopilotToken, reasoningEffort: "high" });
-		});
+		it.skipIf(!githubCopilotToken)(
+			"should handle multi-turn with thinking and tools",
+			{ retry: 3, timeout: 60000 },
+			async () => {
+				await multiTurn(llm, { apiKey: githubCopilotToken, reasoningEffort: "high" });
+			},
+		);
 
 		it.skipIf(!githubCopilotToken)("should handle image input", { retry: 3 }, async () => {
 			await handleImage(llm, { apiKey: githubCopilotToken });
@@ -886,7 +888,7 @@ describe("Generate E2E Tests", () => {
 	});
 
 	describe("GitHub Copilot Provider (claude-sonnet-4 via Anthropic Messages)", () => {
-		const llm = getModel("github-copilot", "claude-sonnet-4.5");
+		const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 
 		it.skipIf(!githubCopilotToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: githubCopilotToken });
@@ -900,13 +902,17 @@ describe("Generate E2E Tests", () => {
 			await handleStreaming(llm, { apiKey: githubCopilotToken });
 		});
 
-		it.skipIf(!githubCopilotToken)("should handle thinking", { retry: 2 }, async () => {
+		it.skipIf(!githubCopilotToken)("should handle thinking", { retry: 2, timeout: 60000 }, async () => {
 			await handleThinking(llm, { apiKey: githubCopilotToken, thinkingEnabled: true });
 		});
 
-		it.skipIf(!githubCopilotToken)("should handle multi-turn with thinking and tools", { retry: 3 }, async () => {
-			await multiTurn(llm, { apiKey: githubCopilotToken, thinkingEnabled: true });
-		});
+		it.skipIf(!githubCopilotToken)(
+			"should handle multi-turn with thinking and tools",
+			{ retry: 3, timeout: 60000 },
+			async () => {
+				await multiTurn(llm, { apiKey: githubCopilotToken, thinkingEnabled: true });
+			},
+		);
 
 		it.skipIf(!githubCopilotToken)("should handle image input", { retry: 3 }, async () => {
 			await handleImage(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -8,7 +8,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -216,7 +216,7 @@ describe("Token Statistics on Abort", () => {
 			"gpt-4.1 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -225,7 +225,7 @@ describe("Token Statistics on Abort", () => {
 			"claude-sonnet-4 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-id-normalization.test.ts
+++ b/packages/ai/test/tool-call-id-normalization.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
 import { getModel } from "../src/models.js";
 import { completeSimple, getEnvApiKey } from "../src/stream.js";
 import type { AssistantMessage, Message, Tool, ToolResultMessage } from "../src/types.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve API keys
 const copilotToken = await resolveApiKey("github-copilot");
@@ -46,7 +46,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !openrouterKey)(
 		"github-copilot -> openrouter should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.2-codex");
+			const copilotModel = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.2-codex"), copilotToken);
 			const openrouterModel = getModel("openrouter", "openai/gpt-5.2-codex");
 
 			// Step 1: Generate tool call with github-copilot
@@ -116,7 +116,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !codexToken)(
 		"github-copilot -> openai-codex should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.2-codex");
+			const copilotModel = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.2-codex"), copilotToken);
 			const codexModel = getModel("openai-codex", "gpt-5.4");
 
 			// Step 1: Generate tool call with github-copilot

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -9,7 +9,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -233,7 +233,7 @@ describe("Tool Call Without Result Tests", () => {
 			"gpt-4.1 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "gpt-4.1");
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);
@@ -242,7 +242,7 @@ describe("Tool Call Without Result Tests", () => {
 			"claude-sonnet-4 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = getModel("github-copilot", "claude-sonnet-4.5");
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -22,7 +22,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Resolve OAuth tokens at module level (async, runs before tests)
 const oauthTokens = await Promise.all([
@@ -513,7 +513,7 @@ describe("totalTokens field", () => {
 			"gpt-4.1 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });
@@ -530,7 +530,7 @@ describe("totalTokens field", () => {
 			"claude-sonnet-4 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -9,7 +9,7 @@ type StreamOptionsWithExtras = StreamOptions & Record<string, unknown>;
 import { hasAzureOpenAICredentials, resolveAzureDeploymentName } from "./azure-utils.js";
 import { hasBedrockCredentials } from "./bedrock-utils.js";
 import { ZAI_GLM_47_FLASH } from "./fixtures/zai-models.js";
-import { resolveApiKey } from "./oauth.js";
+import { applyCopilotBaseUrl, resolveApiKey } from "./oauth.js";
 
 // Empty schema for test tools - must be proper OBJECT type for Cloud Code Assist
 const emptySchema = Type.Object({});
@@ -376,7 +376,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"gpt-4.1 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -385,7 +385,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"gpt-4.1 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -394,7 +394,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"gpt-4.1 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "gpt-4.1");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -403,7 +403,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4.5 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -412,7 +412,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4.5 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
@@ -421,7 +421,7 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 			"claude-sonnet-4.5 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = getModel("github-copilot", "claude-sonnet-4.5");
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/suggest-next.ts
+++ b/packages/coding-agent/src/core/tools/suggest-next.ts
@@ -25,7 +25,7 @@ export type SuggestNextCallback = (suggestion: string) => void;
 
 const suggestNextSchema = Type.Object({
 	command: Type.String({
-		description: "The suggested command for the user to run next (e.g. /skill:mach6-push, /compact)",
+		description: "The suggested command for the user to run next (e.g. /skill:mach6-push, /compact, npm run build)",
 	}),
 	summary: Type.Optional(
 		Type.String({
@@ -63,7 +63,7 @@ export function createSuggestNextToolDefinition(
 
 		promptGuidelines: [
 			"Call suggest_next at the end of your turn when there's a clear next action the user might want",
-			"Use full command syntax: /skill:name args, /compact, etc.",
+			"Suggest a command the user can run: /skill:name args, /compact, npm run build, etc.",
 			"Only suggest one command — pick the most likely next step",
 			"Don't suggest if the conversation is open-ended with no obvious next action",
 			"Include a brief summary of work done in the `summary` parameter — this is your last chance to communicate before the turn ends",
@@ -73,10 +73,11 @@ export function createSuggestNextToolDefinition(
 		async execute(_toolCallId, { command: rawCommand, summary }: SuggestNextInput, _signal?, _onUpdate?, _ctx?) {
 			// Strip control characters (newlines, tabs, etc.) that would corrupt TUI rendering
 			const command = rawCommand?.replace(/[\x00-\x1f\x7f]/g, "").trim();
-			if (!command || !command.startsWith("/")) {
+			if (!command) {
 				return {
-					content: [{ type: "text" as const, text: "Error: command must start with /" }],
+					content: [{ type: "text" as const, text: "Error: command is empty" }],
 					details: undefined,
+					endTurn: true,
 				};
 			}
 

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -475,7 +475,15 @@ describe("AgentSession concurrent prompt guard", () => {
 
 		await session.prompt("hi");
 		await session.agent.waitForIdle();
-		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		// Wait deterministically for all four messages to persist rather than a fixed
+		// delay: the final assistant message_end runs through a deliberately slow (40ms)
+		// extension handler, and a fixed sleep is flaky under full-suite load.
+		const deadline = Date.now() + 2000;
+		const countMessageEntries = () => sessionManager.getEntries().filter((entry) => entry.type === "message").length;
+		while (countMessageEntries() < 4 && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
 
 		const messageEntries = sessionManager.getEntries().filter((entry) => entry.type === "message");
 		expect(messageEntries.map((entry) => entry.message.role)).toEqual([

--- a/packages/coding-agent/test/suggest-next.test.ts
+++ b/packages/coding-agent/test/suggest-next.test.ts
@@ -33,14 +33,14 @@ describe("suggest_next tool", () => {
 		expect(result.content[0]).toEqual({ type: "text", text: "Suggestion registered: /skill:mach6-push" });
 	});
 
-	it("rejects commands that don't start with /", async () => {
+	it("accepts plain shell commands", async () => {
 		const { execute, onSuggest } = createTool();
 
 		const result = await execute("call-2", { command: "npm run build" });
 
-		expect(onSuggest).not.toHaveBeenCalled();
-		expect(result.details).toBeUndefined();
-		expect(result.content[0]?.text).toContain("Error");
+		expect(onSuggest).toHaveBeenCalledWith("npm run build");
+		expect(result.details).toEqual({ suggestion: "npm run build" });
+		expect(result.content[0]).toEqual({ type: "text", text: "Suggestion registered: npm run build" });
 	});
 
 	it("rejects empty command", async () => {
@@ -63,6 +63,9 @@ describe("suggest_next tool", () => {
 
 		await execute("call-6", { command: "/skill:mach6-plan 201" });
 		expect(onSuggest).toHaveBeenCalledWith("/skill:mach6-plan 201");
+
+		await execute("call-6b", { command: "git push" });
+		expect(onSuggest).toHaveBeenCalledWith("git push");
 	});
 
 	describe("endTurn behavior", () => {
@@ -74,20 +77,20 @@ describe("suggest_next tool", () => {
 			expect(result.endTurn).toBe(true);
 		});
 
-		it("does not set endTurn on error (invalid command)", async () => {
+		it("sets endTurn: true on successful execution of plain shell command", async () => {
 			const { execute } = createTool();
 
 			const result = await execute("call-et-2", { command: "npm run build" });
 
-			expect(result.endTurn).toBeUndefined();
+			expect(result.endTurn).toBe(true);
 		});
 
-		it("does not set endTurn on error (empty command)", async () => {
+		it("sets endTurn: true on error (empty command)", async () => {
 			const { execute } = createTool();
 
 			const result = await execute("call-et-3", { command: "" });
 
-			expect(result.endTurn).toBeUndefined();
+			expect(result.endTurn).toBe(true);
 		});
 	});
 
@@ -209,6 +212,7 @@ describe("suggest_next tool", () => {
 
 			expect(onSuggest).not.toHaveBeenCalled();
 			expect(result.details).toBeUndefined();
+			expect(result.endTurn).toBe(true);
 		});
 
 		it("strips tabs and other control chars from middle of command", async () => {
@@ -249,7 +253,7 @@ describe("suggest_next tool", () => {
 		it("renders error message when no details present", () => {
 			const tool = createSuggestNextToolDefinition(() => {});
 			const result = {
-				content: [{ type: "text" as const, text: "Error: command must start with /" }],
+				content: [{ type: "text" as const, text: "Error: command is empty" }],
 				details: undefined,
 				isError: true,
 			};
@@ -258,7 +262,7 @@ describe("suggest_next tool", () => {
 
 			expect(component).toBeInstanceOf(Text);
 			const rendered = stripAnsi(component.render(120).join("\n"));
-			expect(rendered).toContain("Error: command must start with /");
+			expect(rendered).toContain("Error: command is empty");
 		});
 
 		it("renders arrow with suggestion when details present but no summary", () => {

--- a/packages/coding-agent/test/suggest-next.test.ts
+++ b/packages/coding-agent/test/suggest-next.test.ts
@@ -52,6 +52,19 @@ describe("suggest_next tool", () => {
 		expect(result.details).toBeUndefined();
 	});
 
+	it("rejects whitespace-only command", async () => {
+		const { execute, onSuggest } = createTool();
+
+		// Spaces survive the control-char strip (\x20 is outside [\x00-\x1f\x7f]) but
+		// trim() reduces them to "", so this hits the empty-command reject path.
+		const result = await execute("call-3b", { command: "   " });
+
+		expect(onSuggest).not.toHaveBeenCalled();
+		expect(result.details).toBeUndefined();
+		expect(result.endTurn).toBe(true);
+		expect(result.content[0]).toEqual({ type: "text", text: "Error: command is empty" });
+	});
+
 	it("accepts various command formats", async () => {
 		const { execute, onSuggest } = createTool();
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/telegram/test/events.test.ts
+++ b/packages/telegram/test/events.test.ts
@@ -327,12 +327,12 @@ describe("tool_execution_end", () => {
 			toolName: "suggest_next",
 			isError: true,
 			result: {
-				content: [{ type: "text", text: "Error: command must start with /" }],
+				content: [{ type: "text", text: "Error: command is empty" }],
 				details: undefined,
 			},
 		});
 
-		expect(send).toHaveBeenCalledWith("Error: command must start with /", true);
+		expect(send).toHaveBeenCalledWith("Error: command is empty", true);
 		expect(state.visibleToolResultCount).toBe(1);
 	});
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.27.2",
+	"version": "2.27.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #242

Removes the `/` prefix requirement from the `suggest_next` tool so it can suggest any command (including plain shell commands like `npm run build`). Empty/control-char-only commands are still rejected. Also fixes the empty-command error path so a failed suggestion ends the turn cleanly instead of leaving the agent spinning.

Implementation plan posted as a comment below.
