### PR TITLE
Support mobile-friendly /new path shorthand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8888,7 +8888,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8917,7 +8917,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8973,7 +8973,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9102,7 +9102,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9151,7 +9151,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9184,7 +9184,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.27.3",
+			"version": "2.28.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,8 +2457,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.1",
@@ -2472,8 +2471,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.1",
@@ -2487,8 +2485,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.1",
@@ -2502,8 +2499,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.1",
@@ -2517,8 +2513,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.1",
@@ -2532,8 +2527,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.1",
@@ -2547,8 +2541,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.1",
@@ -2562,8 +2555,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.1",
@@ -2577,8 +2569,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.1",
@@ -2592,8 +2583,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.1",
@@ -2607,8 +2597,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.1",
@@ -2622,8 +2611,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.1",
@@ -2637,8 +2625,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.1",
@@ -2652,8 +2639,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.1",
@@ -2667,8 +2653,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.1",
@@ -2682,8 +2667,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.1",
@@ -2697,8 +2681,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.1",
@@ -2712,8 +2695,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.1",
@@ -2727,8 +2709,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.1",
@@ -2742,8 +2723,7 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.1",
@@ -2757,8 +2737,7 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.1",
@@ -2772,8 +2751,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.1",
@@ -2787,8 +2765,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.1",
@@ -2802,8 +2779,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.1",
@@ -2817,8 +2793,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -348,8 +348,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras", () => {
-		it("llama3.1-8b - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("cerebras", "llama3.1-8b");
+		it("gpt-oss-120b - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("cerebras", "gpt-oss-120b");
 			const result = await testContextOverflow(model, process.env.CEREBRAS_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -152,7 +152,7 @@ describe("Token Statistics on Abort", () => {
 	});
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras Provider", () => {
-		const llm = getModel("cerebras", "llama3.1-8b");
+		const llm = getModel("cerebras", "gpt-oss-120b");
 
 		it("should include token stats when aborted mid-stream", { retry: 3, timeout: 30000 }, async () => {
 			await testTokensOnAbort(llm);

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.27.3",
+  "version": "2.28.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -78,6 +78,7 @@ systemctl --user enable --now dreb-telegram
 - `/start` — Help & command list
 - `/new` — Start fresh session (preserves current working directory)
 - `/new <path>` — Start fresh session in the specified directory
+- `/new <segment> ...` — Mobile shorthand for home-relative paths, e.g. `/new projects dreb` resolves to `~/projects/dreb`; quoted spans work for segments containing spaces, e.g. `/new "My Projects" dreb`
 - `/sessions` — List recent sessions
 - `/resume <id>` — Resume by session ID prefix
 - `/recent [N]` — Resend last N assistant messages

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/telegram/src/commands/core.ts
+++ b/packages/telegram/src/commands/core.ts
@@ -4,11 +4,10 @@
 
 import { execSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
 import type { Api, Context } from "grammy";
 import type { Config } from "../config.js";
 import type { UserState } from "../types.js";
+import { resolveNewPath } from "../util/path.js";
 import { log, safeSend } from "../util/telegram.js";
 
 export async function cmdStart(ctx: Context): Promise<void> {
@@ -18,6 +17,7 @@ export async function cmdStart(ctx: Context): Promise<void> {
 			"*Session:*\n" +
 			"/new — Start a fresh session (keeps current directory)\n" +
 			"/new <path> — Start a fresh session in a different directory\n" +
+			"/new <segment> ... — Mobile shorthand: `projects dreb` -> `~/projects/dreb`\n" +
 			"/sessions — List recent sessions\n" +
 			"/resume <id> — Resume a session\n" +
 			"/recent \\[N\\] — Resend last N messages\n\n" +
@@ -76,9 +76,8 @@ export async function cmdNew(ctx: Context, userState: UserState, args: string): 
 	const pathArg = args.trim();
 
 	if (pathArg) {
-		// Resolve path (expand ~ and make absolute)
-		const expanded = pathArg.startsWith("~") ? pathArg.replace("~", homedir()) : pathArg;
-		const resolved = resolve(expanded);
+		// Resolve explicit paths or shorthand tokens to an absolute candidate.
+		const resolved = resolveNewPath(pathArg);
 
 		if (!existsSync(resolved)) {
 			await safeSend(ctx.api, ctx.chat!.id, `❌ Directory not found: \`${resolved}\``);

--- a/packages/telegram/src/commands/core.ts
+++ b/packages/telegram/src/commands/core.ts
@@ -3,7 +3,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { type Stats, statSync } from "node:fs";
 import type { Api, Context } from "grammy";
 import type { Config } from "../config.js";
 import type { UserState } from "../types.js";
@@ -86,11 +86,20 @@ export async function cmdNew(ctx: Context, userState: UserState, args: string): 
 			return;
 		}
 
-		if (!existsSync(resolved)) {
+		let stats: Stats | undefined;
+		try {
+			stats = statSync(resolved, { throwIfNoEntry: false });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			await safeSend(ctx.api, ctx.chat!.id, `❌ Cannot access directory: \`${resolved}\` (${message})`);
+			return;
+		}
+
+		if (!stats) {
 			await safeSend(ctx.api, ctx.chat!.id, `❌ Directory not found: \`${resolved}\``);
 			return;
 		}
-		if (!statSync(resolved).isDirectory()) {
+		if (!stats.isDirectory()) {
 			await safeSend(ctx.api, ctx.chat!.id, `❌ Not a directory: \`${resolved}\``);
 			return;
 		}

--- a/packages/telegram/src/commands/core.ts
+++ b/packages/telegram/src/commands/core.ts
@@ -77,7 +77,14 @@ export async function cmdNew(ctx: Context, userState: UserState, args: string): 
 
 	if (pathArg) {
 		// Resolve explicit paths or shorthand tokens to an absolute candidate.
-		const resolved = resolveNewPath(pathArg);
+		let resolved: string;
+		try {
+			resolved = resolveNewPath(pathArg);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			await safeSend(ctx.api, ctx.chat!.id, `❌ ${message}`);
+			return;
+		}
 
 		if (!existsSync(resolved)) {
 			await safeSend(ctx.api, ctx.chat!.id, `❌ Directory not found: \`${resolved}\``);

--- a/packages/telegram/src/commands/core.ts
+++ b/packages/telegram/src/commands/core.ts
@@ -104,17 +104,35 @@ export async function cmdNew(ctx: Context, userState: UserState, args: string): 
 			return;
 		}
 
+		const messageId = await safeSend(
+			ctx.api,
+			ctx.chat!.id,
+			`🆕 Next message will start a fresh session in \`${resolved}\``,
+		);
+		if (messageId === 0) {
+			log(`[WARN] /new confirmation failed for \`${resolved}\`; leaving session state unchanged`);
+			return;
+		}
+
 		userState.newSessionFlag = true;
 		userState.newSessionCwd = resolved;
-		await ctx.reply(`🆕 Next message will start a fresh session in \`${resolved}\``);
 	} else {
 		// Eagerly resolve CWD — never store null as a sentinel.
 		// After /restart, effectiveCwd is null (in-memory state is lost),
 		// so this falls back to config.workingDir deterministically.
 		const cwd = userState.effectiveCwd ?? userState.config.workingDir;
+		const messageId = await safeSend(
+			ctx.api,
+			ctx.chat!.id,
+			`🆕 Next message will start a fresh session in \`${cwd}\``,
+		);
+		if (messageId === 0) {
+			log(`[WARN] /new confirmation failed for \`${cwd}\`; leaving session state unchanged`);
+			return;
+		}
+
 		userState.newSessionFlag = true;
 		userState.newSessionCwd = cwd;
-		await ctx.reply(`🆕 Next message will start a fresh session in \`${cwd}\``);
 	}
 }
 

--- a/packages/telegram/src/util/path.ts
+++ b/packages/telegram/src/util/path.ts
@@ -1,0 +1,61 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+/**
+ * Parse a `/new` command path argument into an absolute path.
+ *
+ * Rules:
+ * - Empty input is not handled here; callers should treat it as bare `/new`.
+ * - Arguments that already look like explicit paths (start with `~` or `/`, or
+ *   contain any `/`) are resolved as-is, expanding `~` to the user's home dir.
+ * - Otherwise, whitespace-separated tokens are treated as shorthand path
+ *   segments under `~`. Double-quoted spans are kept as a single segment,
+ *   allowing directory names that contain spaces:
+ *     `"My Projects" dreb` -> `~/My Projects/dreb`
+ */
+export function resolveNewPath(pathArg: string, getHome = homedir): string {
+	const trimmed = pathArg.trim();
+
+	if (!trimmed) {
+		throw new Error("resolveNewPath does not handle bare /new; pass a non-empty path argument");
+	}
+
+	// Explicit path forms: keep existing behavior.
+	if (trimmed.startsWith("~") || trimmed.startsWith("/") || trimmed.includes("/")) {
+		const expanded = trimmed.startsWith("~") ? trimmed.replace("~", getHome()) : trimmed;
+		return resolve(expanded);
+	}
+
+	// Shorthand form: tokens under the home directory.
+	const segments = parseShorthandTokens(trimmed);
+	const homeRelative = ["~", ...segments].join("/");
+	return resolve(homeRelative.replace("~", getHome()));
+}
+
+/**
+ * Split shorthand input into path segments, respecting double-quoted spans.
+ */
+function parseShorthandTokens(input: string): string[] {
+	const tokens: string[] = [];
+	let current = "";
+	let inQuote = false;
+
+	for (const char of input) {
+		if (char === '"') {
+			inQuote = !inQuote;
+		} else if (char === " " && !inQuote) {
+			if (current.length > 0) {
+				tokens.push(current);
+				current = "";
+			}
+		} else {
+			current += char;
+		}
+	}
+
+	if (current.length > 0) {
+		tokens.push(current);
+	}
+
+	return tokens;
+}

--- a/packages/telegram/src/util/path.ts
+++ b/packages/telegram/src/util/path.ts
@@ -28,6 +28,13 @@ export function resolveNewPath(pathArg: string, getHome = homedir): string {
 
 	// Shorthand form: tokens under the home directory.
 	const segments = parseShorthandTokens(trimmed);
+	if (segments.length === 0) {
+		throw new Error("Invalid /new shorthand: no path segments were provided");
+	}
+	if (segments.some((segment) => segment === "." || segment === "..")) {
+		throw new Error("Invalid /new shorthand: path segments cannot be '.' or '..'");
+	}
+
 	const homeRelative = ["~", ...segments].join("/");
 	return resolve(homeRelative.replace("~", getHome()));
 }
@@ -43,17 +50,21 @@ function parseShorthandTokens(input: string): string[] {
 	for (const char of input) {
 		if (char === '"') {
 			inQuote = !inQuote;
-		} else if (char === " " && !inQuote) {
-			if (current.length > 0) {
+		} else if (/\s/.test(char) && !inQuote) {
+			if (current.trim().length > 0) {
 				tokens.push(current);
-				current = "";
 			}
+			current = "";
 		} else {
 			current += char;
 		}
 	}
 
-	if (current.length > 0) {
+	if (inQuote) {
+		throw new Error("Invalid /new shorthand: missing closing quote");
+	}
+
+	if (current.trim().length > 0) {
 		tokens.push(current);
 	}
 

--- a/packages/telegram/test/commands.test.ts
+++ b/packages/telegram/test/commands.test.ts
@@ -118,6 +118,43 @@ describe("cmdNew", () => {
 			// Should be an absolute path containing the home dir
 			expect(userState.newSessionCwd).toMatch(/^\//);
 		});
+
+		it("expands mobile shorthand tokens to a home-relative path", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
+
+			const userState = createUserState();
+			await cmdNew(ctx, userState, "projects dreb");
+
+			expect(userState.newSessionFlag).toBe(true);
+			expect(userState.newSessionCwd).toMatch(/^\//);
+			expect(userState.newSessionCwd).toMatch(/projects\/dreb$/);
+			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("projects/dreb"));
+		});
+
+		it("respects quoted spans in shorthand", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
+
+			const userState = createUserState();
+			await cmdNew(ctx, userState, '"My Projects" dreb');
+
+			expect(userState.newSessionFlag).toBe(true);
+			expect(userState.newSessionCwd).toMatch(/My Projects\/dreb$/);
+		});
+
+		it("reports the resolved candidate when shorthand path does not exist", async () => {
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			const userState = createUserState();
+			await cmdNew(ctx, userState, "projects missing");
+
+			expect(userState.newSessionFlag).toBe(false);
+			expect(userState.newSessionCwd).toBeNull();
+			const sent = mockSafeSend.mock.calls[0][2] as string;
+			expect(sent).toContain("not found");
+			expect(sent).toContain("projects/missing");
+		});
 	});
 
 	describe("bare /new (no path argument)", () => {

--- a/packages/telegram/test/commands.test.ts
+++ b/packages/telegram/test/commands.test.ts
@@ -143,6 +143,20 @@ describe("cmdNew", () => {
 			expect(userState.newSessionCwd).toMatch(/My Projects\/dreb$/);
 		});
 
+		it("reports invalid shorthand without setting flag", async () => {
+			const userState = createUserState();
+			await cmdNew(ctx, userState, "..");
+
+			expect(userState.newSessionFlag).toBe(false);
+			expect(userState.newSessionCwd).toBeNull();
+			expect(existsSync).not.toHaveBeenCalled();
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				expect.anything(),
+				100,
+				expect.stringContaining("Invalid /new shorthand"),
+			);
+		});
+
 		it("reports the resolved candidate when shorthand path does not exist", async () => {
 			vi.mocked(existsSync).mockReturnValue(false);
 

--- a/packages/telegram/test/commands.test.ts
+++ b/packages/telegram/test/commands.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../src/config.js";
 import type { UserState } from "../src/types.js";
@@ -14,11 +15,19 @@ vi.mock("../src/util/telegram.js", () => ({
 
 // Mock fs operations for path validation
 vi.mock("node:fs", () => ({
-	existsSync: vi.fn(),
 	statSync: vi.fn(),
 }));
 
-import { existsSync, statSync } from "node:fs";
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return {
+		...actual,
+		homedir: vi.fn(() => "/home/testuser"),
+	};
+});
+
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
 import { cmdStats } from "../src/commands/agent.js";
 // Import after mock setup
 import { cmdNew } from "../src/commands/core.js";
@@ -67,11 +76,11 @@ describe("cmdNew", () => {
 	beforeEach(() => {
 		ctx = createMockContext();
 		vi.clearAllMocks();
+		vi.mocked(statSync).mockReset();
 	});
 
 	describe("with path argument", () => {
 		it("sets flag and resolved CWD, replies with path", async () => {
-			vi.mocked(existsSync).mockReturnValue(true);
 			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
 
 			const userState = createUserState();
@@ -83,7 +92,7 @@ describe("cmdNew", () => {
 		});
 
 		it("rejects nonexistent path without setting flag", async () => {
-			vi.mocked(existsSync).mockReturnValue(false);
+			vi.mocked(statSync).mockReturnValue(undefined as any);
 
 			const userState = createUserState();
 			await cmdNew(ctx, userState, "/nonexistent");
@@ -93,8 +102,36 @@ describe("cmdNew", () => {
 			expect(mockSafeSend).toHaveBeenCalledWith(expect.anything(), 100, expect.stringContaining("not found"));
 		});
 
+		it("reports statSync errors without setting flag", async () => {
+			vi.mocked(statSync).mockImplementation(() => {
+				throw new Error("EACCES: permission denied");
+			});
+
+			const userState = createUserState();
+			await cmdNew(ctx, userState, "/forbidden");
+
+			expect(userState.newSessionFlag).toBe(false);
+			expect(userState.newSessionCwd).toBeNull();
+			const sent = mockSafeSend.mock.calls[0][2] as string;
+			expect(sent).toContain("Cannot access directory");
+			expect(sent).toContain("EACCES");
+		});
+
+		it("rejects file path (not a directory) from shorthand without setting flag", async () => {
+			vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as any);
+
+			const expectedPath = join(homedir(), "projects", "file.txt");
+			const userState = createUserState();
+			await cmdNew(ctx, userState, "projects file.txt");
+
+			expect(userState.newSessionFlag).toBe(false);
+			expect(userState.newSessionCwd).toBeNull();
+			const sent = mockSafeSend.mock.calls[0][2] as string;
+			expect(sent).toContain("Not a directory");
+			expect(sent).toContain(expectedPath);
+		});
+
 		it("rejects file path (not a directory) without setting flag", async () => {
-			vi.mocked(existsSync).mockReturnValue(true);
 			vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as any);
 
 			const userState = createUserState();
@@ -106,7 +143,6 @@ describe("cmdNew", () => {
 		});
 
 		it("expands ~ to home directory", async () => {
-			vi.mocked(existsSync).mockReturnValue(true);
 			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
 
 			const userState = createUserState();
@@ -120,27 +156,27 @@ describe("cmdNew", () => {
 		});
 
 		it("expands mobile shorthand tokens to a home-relative path", async () => {
-			vi.mocked(existsSync).mockReturnValue(true);
 			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
 
+			const expectedPath = join(homedir(), "projects", "dreb");
 			const userState = createUserState();
 			await cmdNew(ctx, userState, "projects dreb");
 
 			expect(userState.newSessionFlag).toBe(true);
-			expect(userState.newSessionCwd).toMatch(/^\//);
-			expect(userState.newSessionCwd).toMatch(/projects\/dreb$/);
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("projects/dreb"));
+			expect(userState.newSessionCwd).toBe(expectedPath);
+			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining(expectedPath));
 		});
 
 		it("respects quoted spans in shorthand", async () => {
-			vi.mocked(existsSync).mockReturnValue(true);
 			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
 
+			const expectedPath = join(homedir(), "My Projects", "dreb");
 			const userState = createUserState();
 			await cmdNew(ctx, userState, '"My Projects" dreb');
 
 			expect(userState.newSessionFlag).toBe(true);
-			expect(userState.newSessionCwd).toMatch(/My Projects\/dreb$/);
+			expect(userState.newSessionCwd).toBe(expectedPath);
+			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining(expectedPath));
 		});
 
 		it("reports invalid shorthand without setting flag", async () => {
@@ -149,7 +185,7 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(false);
 			expect(userState.newSessionCwd).toBeNull();
-			expect(existsSync).not.toHaveBeenCalled();
+			expect(statSync).not.toHaveBeenCalled();
 			expect(mockSafeSend).toHaveBeenCalledWith(
 				expect.anything(),
 				100,
@@ -158,7 +194,7 @@ describe("cmdNew", () => {
 		});
 
 		it("reports the resolved candidate when shorthand path does not exist", async () => {
-			vi.mocked(existsSync).mockReturnValue(false);
+			vi.mocked(statSync).mockReturnValue(undefined as any);
 
 			const userState = createUserState();
 			await cmdNew(ctx, userState, "projects missing");
@@ -168,6 +204,20 @@ describe("cmdNew", () => {
 			const sent = mockSafeSend.mock.calls[0][2] as string;
 			expect(sent).toContain("not found");
 			expect(sent).toContain("projects/missing");
+		});
+
+		it("reports the resolved candidate when quoted shorthand path does not exist", async () => {
+			vi.mocked(statSync).mockReturnValue(undefined as any);
+
+			const expectedPath = join(homedir(), "My Projects", "missing");
+			const userState = createUserState();
+			await cmdNew(ctx, userState, '"My Projects" missing');
+
+			expect(userState.newSessionFlag).toBe(false);
+			expect(userState.newSessionCwd).toBeNull();
+			const sent = mockSafeSend.mock.calls[0][2] as string;
+			expect(sent).toContain("not found");
+			expect(sent).toContain(expectedPath);
 		});
 	});
 

--- a/packages/telegram/test/commands.test.ts
+++ b/packages/telegram/test/commands.test.ts
@@ -88,7 +88,27 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(true);
 			expect(userState.newSessionCwd).toBe("/some/path");
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("/some/path"));
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				"🆕 Next message will start a fresh session in `/some/path`",
+			);
+		});
+
+		it("preserves state when success confirmation cannot be delivered", async () => {
+			vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
+			mockSafeSend.mockResolvedValueOnce(0);
+
+			const userState = createUserState({ newSessionFlag: true, newSessionCwd: "/previous/path" });
+			await cmdNew(ctx, userState, "/some/path");
+
+			expect(userState.newSessionFlag).toBe(true);
+			expect(userState.newSessionCwd).toBe("/previous/path");
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				"🆕 Next message will start a fresh session in `/some/path`",
+			);
 		});
 
 		it("rejects nonexistent path without setting flag", async () => {
@@ -149,10 +169,7 @@ describe("cmdNew", () => {
 			await cmdNew(ctx, userState, "~/projects");
 
 			expect(userState.newSessionFlag).toBe(true);
-			// Should not start with ~
-			expect(userState.newSessionCwd).not.toMatch(/^~/);
-			// Should be an absolute path containing the home dir
-			expect(userState.newSessionCwd).toMatch(/^\//);
+			expect(userState.newSessionCwd).toBe("/home/testuser/projects");
 		});
 
 		it("expands mobile shorthand tokens to a home-relative path", async () => {
@@ -164,7 +181,11 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(true);
 			expect(userState.newSessionCwd).toBe(expectedPath);
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining(expectedPath));
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				`🆕 Next message will start a fresh session in \`${expectedPath}\``,
+			);
 		});
 
 		it("respects quoted spans in shorthand", async () => {
@@ -176,7 +197,11 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(true);
 			expect(userState.newSessionCwd).toBe(expectedPath);
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining(expectedPath));
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				`🆕 Next message will start a fresh session in \`${expectedPath}\``,
+			);
 		});
 
 		it("reports invalid shorthand without setting flag", async () => {
@@ -228,7 +253,11 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(true);
 			expect(userState.newSessionCwd).toBe("/current/project");
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("/current/project"));
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				"🆕 Next message will start a fresh session in `/current/project`",
+			);
 		});
 
 		it("falls back to config.workingDir when effectiveCwd is null", async () => {
@@ -237,7 +266,30 @@ describe("cmdNew", () => {
 
 			expect(userState.newSessionFlag).toBe(true);
 			expect(userState.newSessionCwd).toBe("/default/dir");
-			expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining("/default/dir"));
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				"🆕 Next message will start a fresh session in `/default/dir`",
+			);
+		});
+
+		it("preserves state when success confirmation cannot be delivered", async () => {
+			mockSafeSend.mockResolvedValueOnce(0);
+
+			const userState = createUserState({
+				effectiveCwd: "/current/project",
+				newSessionFlag: true,
+				newSessionCwd: "/previous/path",
+			});
+			await cmdNew(ctx, userState, "");
+
+			expect(userState.newSessionFlag).toBe(true);
+			expect(userState.newSessionCwd).toBe("/previous/path");
+			expect(mockSafeSend).toHaveBeenCalledWith(
+				ctx.api,
+				100,
+				"🆕 Next message will start a fresh session in `/current/project`",
+			);
 		});
 
 		it("never sets newSessionCwd to null", async () => {
@@ -251,7 +303,7 @@ describe("cmdNew", () => {
 			const userState = createUserState({ effectiveCwd: "/my/project" });
 			await cmdNew(ctx, userState, "");
 
-			const reply = ctx.reply.mock.calls[0][0] as string;
+			const reply = mockSafeSend.mock.calls[0][2] as string;
 			expect(reply).toContain("/my/project");
 			// Should NOT be the generic "fresh session" message without a path
 			expect(reply).not.toBe("🆕 Next message will start a fresh session.");

--- a/packages/telegram/test/util/path.test.ts
+++ b/packages/telegram/test/util/path.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { resolveNewPath } from "../../src/util/path.js";
+
+const fakeHome = "/home/testuser";
+
+function resolve(input: string) {
+	return resolveNewPath(input, () => fakeHome);
+}
+
+describe("resolveNewPath", () => {
+	describe("explicit paths", () => {
+		it("expands ~ to home directory", () => {
+			expect(resolve("~/projects")).toBe("/home/testuser/projects");
+		});
+
+		it("keeps absolute paths unchanged", () => {
+			expect(resolve("/usr/local/bin")).toBe("/usr/local/bin");
+		});
+
+		it("resolves relative paths containing a slash", () => {
+			expect(resolve("./relative")).toMatch(/\/relative$/);
+		});
+
+		it("resolves slash-separated paths as a single path", () => {
+			expect(resolve("projects/dreb")).toMatch(/\/projects\/dreb$/);
+		});
+
+		it("does not apply shorthand when the argument contains a slash", () => {
+			expect(resolve("foo/bar baz")).toMatch(/\/foo\/bar baz$/);
+		});
+	});
+
+	describe("shorthand paths", () => {
+		it("treats space-separated tokens as home-relative segments", () => {
+			expect(resolve("projects dreb")).toBe("/home/testuser/projects/dreb");
+		});
+
+		it("supports a single bare token", () => {
+			expect(resolve("documents")).toBe("/home/testuser/documents");
+		});
+
+		it("respects double-quoted spans as a single segment", () => {
+			expect(resolve('"My Projects" dreb')).toBe("/home/testuser/My Projects/dreb");
+		});
+
+		it("handles multiple quoted segments", () => {
+			expect(resolve('"My Projects" "deep yellow"')).toBe("/home/testuser/My Projects/deep yellow");
+		});
+
+		it("ignores extra whitespace between tokens", () => {
+			expect(resolve("projects   dreb")).toBe("/home/testuser/projects/dreb");
+		});
+
+		it("keeps inner spaces inside a quoted segment", () => {
+			expect(resolve('"a b c" d')).toBe("/home/testuser/a b c/d");
+		});
+
+		it("preserves unclosed quotes as literal text", () => {
+			expect(resolve('"My Projects')).toBe("/home/testuser/My Projects");
+		});
+
+		it("ignores empty quoted segments", () => {
+			expect(resolve('"" projects')).toBe("/home/testuser/projects");
+		});
+	});
+
+	describe("edge cases", () => {
+		it("trims leading and trailing whitespace", () => {
+			expect(resolve("  projects dreb  ")).toBe("/home/testuser/projects/dreb");
+		});
+
+		it("throws on empty input", () => {
+			expect(() => resolve("")).toThrow();
+		});
+	});
+});

--- a/packages/telegram/test/util/path.test.ts
+++ b/packages/telegram/test/util/path.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveNewPath } from "../../src/util/path.js";
 
@@ -18,15 +19,15 @@ describe("resolveNewPath", () => {
 		});
 
 		it("resolves relative paths containing a slash", () => {
-			expect(resolve("./relative")).toMatch(/\/relative$/);
+			expect(resolve("./relative")).toBe(path.resolve("./relative"));
 		});
 
 		it("resolves slash-separated paths as a single path", () => {
-			expect(resolve("projects/dreb")).toMatch(/\/projects\/dreb$/);
+			expect(resolve("projects/dreb")).toBe(path.resolve("projects/dreb"));
 		});
 
 		it("does not apply shorthand when the argument contains a slash", () => {
-			expect(resolve("foo/bar baz")).toMatch(/\/foo\/bar baz$/);
+			expect(resolve("foo/bar baz")).toBe(path.resolve("foo/bar baz"));
 		});
 	});
 

--- a/packages/telegram/test/util/path.test.ts
+++ b/packages/telegram/test/util/path.test.ts
@@ -59,6 +59,11 @@ describe("resolveNewPath", () => {
 			expect(resolve('"a b c" d')).toBe("/home/testuser/a b c/d");
 		});
 
+		it("preserves leading and trailing spaces inside quoted segments", () => {
+			expect(resolve('" foo "')).toBe("/home/testuser/ foo ");
+			expect(resolve('" foo " bar')).toBe("/home/testuser/ foo /bar");
+		});
+
 		it("throws on unclosed quotes", () => {
 			expect(() => resolve('"My Projects')).toThrow("missing closing quote");
 		});

--- a/packages/telegram/test/util/path.test.ts
+++ b/packages/telegram/test/util/path.test.ts
@@ -51,16 +51,21 @@ describe("resolveNewPath", () => {
 			expect(resolve("projects   dreb")).toBe("/home/testuser/projects/dreb");
 		});
 
+		it("treats tabs and newlines as shorthand separators", () => {
+			expect(resolve("projects\tdreb\ntelegram")).toBe("/home/testuser/projects/dreb/telegram");
+		});
+
 		it("keeps inner spaces inside a quoted segment", () => {
 			expect(resolve('"a b c" d')).toBe("/home/testuser/a b c/d");
 		});
 
-		it("preserves unclosed quotes as literal text", () => {
-			expect(resolve('"My Projects')).toBe("/home/testuser/My Projects");
+		it("throws on unclosed quotes", () => {
+			expect(() => resolve('"My Projects')).toThrow("missing closing quote");
 		});
 
-		it("ignores empty quoted segments", () => {
+		it("ignores empty quoted segments when other segments are present", () => {
 			expect(resolve('"" projects')).toBe("/home/testuser/projects");
+			expect(resolve('" " projects')).toBe("/home/testuser/projects");
 		});
 	});
 
@@ -71,6 +76,18 @@ describe("resolveNewPath", () => {
 
 		it("throws on empty input", () => {
 			expect(() => resolve("")).toThrow();
+		});
+
+		it("throws on empty or quote-only shorthand", () => {
+			expect(() => resolve('""')).toThrow("no path segments");
+			expect(() => resolve('" "')).toThrow("no path segments");
+			expect(() => resolve('"')).toThrow("missing closing quote");
+		});
+
+		it("throws on current-directory or parent-directory shorthand segments", () => {
+			expect(() => resolve(".")).toThrow("cannot be '.' or '..'");
+			expect(() => resolve("..")).toThrow("cannot be '.' or '..'");
+			expect(() => resolve("projects ..")).toThrow("cannot be '.' or '..'");
 		});
 	});
 });

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.27.3",
+	"version": "2.28.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #269

Support mobile-friendly /new path shorthand so whitespace-separated tokens are treated as home-relative path segments.

Implementation plan posted as a comment below.
