### PR TITLE
Anchor view to bottom after live-region shrink (fix jump-to-top)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -2457,7 +2457,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.1",
@@ -2471,7 +2472,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.1",
@@ -2485,7 +2487,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.1",
@@ -2499,7 +2502,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.1",
@@ -2513,7 +2517,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.1",
@@ -2527,7 +2532,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.1",
@@ -2541,7 +2547,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.1",
@@ -2555,7 +2562,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.1",
@@ -2569,7 +2577,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.1",
@@ -2583,7 +2592,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.1",
@@ -2597,7 +2607,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.1",
@@ -2611,7 +2622,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.1",
@@ -2625,7 +2637,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.1",
@@ -2639,7 +2652,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.1",
@@ -2653,7 +2667,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.1",
@@ -2667,7 +2682,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.1",
@@ -2681,7 +2697,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.1",
@@ -2695,7 +2712,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.1",
@@ -2709,7 +2727,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.1",
@@ -2723,7 +2742,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.1",
@@ -2737,7 +2757,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.1",
@@ -2751,7 +2772,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.1",
@@ -2765,7 +2787,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.1",
@@ -2779,7 +2802,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.1",
@@ -2793,7 +2817,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
@@ -8888,7 +8913,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8917,7 +8942,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8973,7 +8998,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9102,7 +9127,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9151,7 +9176,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9184,7 +9209,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.28.0",
+			"version": "2.29.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -462,7 +462,7 @@ The TUI uses a two-zone rendering architecture:
 
 1. `interactive-mode.ts` maintains a `committedChatContainer` (finalized messages/tools) and a live `chatContainer` (streaming + pending)
 2. When a message or tool finalizes, it moves from live → committed container, and `commit()` advances the boundary
-3. The differential renderer (`doRender`) only renders live children, so the "content shrank" full-redraw path (triggered by spinner removal) only replays the live region — not the whole transcript
+3. The differential renderer (`doRender`) only renders live children, so the "content shrank" full-redraw path (triggered by spinner removal) replays only the live region — not the whole transcript — **as long as the live region fit within the viewport**. If the live region had grown taller than the viewport (a big tool output, a long streaming message, overlay padding), the committed history and the live-region top were scrolled into unreachable scrollback; a relative redraw cannot pull them back, so the shrink/viewport-shift paths route through `recommitAll()` instead, restoring the committed tail and re-anchoring the editor at the bottom (see issue 277). The predicate is `prevViewportTop > 0`.
 4. Terminal width changes and other global mutations call `recommitAll()` for one deliberate repaint
 
 ### Prefix-commit ordering rule

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1032,8 +1032,10 @@ export class TUI extends Container {
 		const height = this.terminal.rows;
 		const widthChanged = this.previousWidth !== 0 && this.previousWidth !== width;
 		const heightChanged = this.previousHeight !== 0 && this.previousHeight !== height;
-		const previousBufferLength = this.previousHeight > 0 ? this.previousViewportTop + this.previousHeight : height;
-		let prevViewportTop = heightChanged ? Math.max(0, previousBufferLength - height) : this.previousViewportTop;
+		// On resize, derive the prior live-region viewport from live content height,
+		// not the old terminal row count. Blank space in a taller viewport must not be
+		// mistaken for scrolled live content that needs a transcript recommit.
+		let prevViewportTop = heightChanged ? Math.max(0, this.previousLines.length - height) : this.previousViewportTop;
 		let viewportTop = prevViewportTop;
 		let hardwareCursorRow = this.hardwareCursorRow;
 		const computeLineDiff = (targetRow: number): number => {
@@ -1141,11 +1143,13 @@ export class TUI extends Container {
 		}
 
 		// Height changes need a full re-render to keep the visible viewport aligned.
-		// With the committed-scrollback model, only the live region is re-rendered,
-		// so this is cheap and safe even on Termux (no transcript replay).
+		// Keep the cheap live-region-only redraw when the live-region start is still
+		// reachable (`prevViewportTop === 0`). If the prior live region exceeded the
+		// viewport, recommit the transcript tail so committed history is restored and
+		// the editor is anchored at the bottom instead of stranded at the top.
 		if (heightChanged) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
-			fullRender(true);
+			clearAndRedraw();
 			return;
 		}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1090,6 +1090,32 @@ export class TUI extends Container {
 			this.onPostRender?.();
 		};
 
+		// Choose the correct full-redraw strategy for shrink/viewport-shift paths.
+		//
+		// `fullRender(true)` clears and repaints ONLY the live region (cursor-up +
+		// `\r\x1b[J`). That is correct as long as the live region fit within the
+		// viewport (`prevViewportTop === 0`), because the live-region start is still
+		// on screen and reachable.
+		//
+		// But when the live region had grown taller than the viewport
+		// (`prevViewportTop > 0`), the terminal scrolled and pushed committed history
+		// — and the top of the live region — above the viewport into scrollback.
+		// Cursor-up cannot reach past the viewport top, so `fullRender(true)` would
+		// paint the (now smaller) live region anchored at the TOP of an otherwise
+		// empty viewport, with committed history stranded in scrollback. That is the
+		// "jump to the top" reported in issue 277.
+		//
+		// `recommitAll()` re-emits the committed tail + live region and re-anchors the
+		// editor at the BOTTOM of the viewport, matching the steady-state the
+		// differential renderer leaves on every keystroke.
+		const clearAndRedraw = (): void => {
+			if (prevViewportTop > 0) {
+				this.recommitAll();
+			} else {
+				fullRender(true);
+			}
+		};
+
 		const debugRedraw = process.env.DREB_DEBUG_REDRAW === "1";
 		const logRedraw = (reason: string): void => {
 			if (!debugRedraw) return;
@@ -1164,7 +1190,7 @@ export class TUI extends Container {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true);
+					clearAndRedraw();
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
@@ -1179,7 +1205,7 @@ export class TUI extends Container {
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					clearAndRedraw();
 					return;
 				}
 				if (extraLines > 0) {
@@ -1234,7 +1260,7 @@ export class TUI extends Container {
 			} else {
 				// Viewport needs to shift — full redraw without scrollback clear
 				logRedraw(`firstChanged < viewportTop with viewport shift (${firstChanged} < ${prevViewportTop})`);
-				fullRender(true);
+				clearAndRedraw();
 				return;
 			}
 		}

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -667,14 +667,19 @@ describe("TUI committed-scrollback region", () => {
 
 		const viewport = terminal.getViewport();
 		const editorRow = viewport.findIndex((l) => l.includes("EDITOR >"));
+		const footerRow = viewport.findIndex((l) => l.includes("footer"));
 
 		assert.ok(editorRow !== -1, "editor must be visible after the shrink");
 		// The bug anchored the editor at the very top (row 0) of an otherwise empty
-		// viewport. After the fix it sits near the bottom with committed history above.
-		assert.ok(
-			editorRow >= viewport.length - 3,
-			`editor should be anchored at the bottom of the viewport, was at row ${editorRow} of ${viewport.length}`,
+		// viewport. After the fix it sits exactly second-from-bottom (the editor) with
+		// the footer bottom-anchored and committed history above — matching the exact
+		// invariant asserted by the sibling recommit tests.
+		assert.strictEqual(
+			editorRow,
+			viewport.length - 2,
+			`editor should be second-from-bottom after recommit, was at row ${editorRow} of ${viewport.length}`,
 		);
+		assert.strictEqual(footerRow, viewport.length - 1, "last live line should be bottom-anchored after recommit");
 		assert.ok(
 			viewport.slice(0, editorRow).some((l) => l.includes("HIST")),
 			"committed history must be restored above the editor (not stranded in scrollback)",

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -561,6 +561,121 @@ describe("TUI committed-scrollback region", () => {
 
 		tui.stop();
 	});
+
+	// Regression for issue 277: when the live region grows taller than the viewport
+	// (big tool output, long streaming message, overlay padding) the terminal scrolls
+	// committed history into scrollback. When the live region later shrinks, the
+	// renderer must re-anchor the editor at the BOTTOM of the viewport. The old code
+	// took a live-region-only fullRender() path that could not restore committed
+	// history from scrollback, stranding the editor at the TOP of an empty viewport
+	// ("jump to the top").
+	it("live-region shrink past viewport re-anchors editor at the bottom (issue 277)", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		// Committed history taller than the 10-row viewport.
+		const history = new TestComponent();
+		history.lines = Array.from({ length: 20 }, (_, i) => `HIST ${i}`);
+		committed.addChild(history);
+
+		const liveComp = new TestComponent();
+		liveComp.lines = [];
+		live.addChild(liveComp);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		// 1. Live region grows taller than the viewport (e.g. a big tool output above
+		//    the editor). This scrolls committed history out of the viewport.
+		liveComp.lines = [...Array.from({ length: 11 }, (_, i) => `LIVE-BIG ${i}`), "EDITOR >", "footer"];
+		tui.requestRender();
+		await terminal.flush();
+
+		const redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		// 2. Live region shrinks back to just the editor (deferred post-turn render:
+		//    big output commits / spinner removed / pending content clears).
+		liveComp.lines = ["EDITOR >", "footer"];
+		tui.requestRender();
+		await terminal.flush();
+
+		const viewport = terminal.getViewport();
+		const editorRow = viewport.findIndex((l) => l.includes("EDITOR >"));
+
+		assert.ok(editorRow !== -1, "editor must be visible after the shrink");
+		// The bug anchored the editor at the very top (row 0) of an otherwise empty
+		// viewport. After the fix it sits near the bottom with committed history above.
+		assert.ok(
+			editorRow >= viewport.length - 3,
+			`editor should be anchored at the bottom of the viewport, was at row ${editorRow} of ${viewport.length}`,
+		);
+		assert.ok(
+			viewport.slice(0, editorRow).some((l) => l.includes("HIST")),
+			"committed history must be restored above the editor (not stranded in scrollback)",
+		);
+		// The fix re-anchors via recommitAll(), which clears scrollback and repaints.
+		assert.ok(
+			terminal.getWrites().includes("\x1b[3J"),
+			"exceeded-viewport shrink should re-anchor via recommitAll (scrollback clear)",
+		);
+		assert.ok(tui.fullRedraws > redrawsBefore, "exceeded-viewport shrink should perform a full redraw");
+
+		tui.stop();
+	});
+
+	// Companion guard: when the live region fit within the viewport, a shrink must NOT
+	// escalate to a full transcript replay — it stays on the cheap live-region-only
+	// path, preserving the committed-scrollback optimization from the original refactor.
+	it("live-region shrink within viewport stays on the cheap path (no scrollback clear)", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const history = new TestComponent();
+		history.lines = Array.from({ length: 20 }, (_, i) => `HIST ${i}`);
+		committed.addChild(history);
+
+		const liveComp = new TestComponent();
+		liveComp.lines = ["line a", "line b", "EDITOR >"];
+		live.addChild(liveComp);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		terminal.clearWrites();
+
+		// Shrink a small (fits-in-viewport) live region — should not clear scrollback.
+		liveComp.lines = ["EDITOR >"];
+		tui.requestRender();
+		await terminal.flush();
+
+		assert.ok(
+			!terminal.getWrites().includes("\x1b[3J"),
+			"within-viewport shrink must not clear scrollback (no transcript replay)",
+		);
+		assert.ok(
+			!terminal.getWrites().includes("HIST"),
+			"within-viewport shrink must not re-emit committed history (stays on live-region-only path)",
+		);
+
+		tui.stop();
+	});
 });
 
 describe("autocomplete + committed scrollback (ghost whitespace)", () => {

--- a/packages/tui/test/tui-committed-region.test.ts
+++ b/packages/tui/test/tui-committed-region.test.ts
@@ -253,7 +253,7 @@ describe("TUI committed-scrollback region", () => {
 		tui.stop();
 	});
 
-	it("height change only re-renders live region (no scrollback clear)", async () => {
+	it("height change only re-renders live region when live-region start is visible", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
 
@@ -278,13 +278,70 @@ describe("TUI committed-scrollback region", () => {
 
 		terminal.clearWrites();
 
-		// Height change should NOT clear scrollback
+		// prevViewportTop is 0, so clearAndRedraw() keeps the cheap live-region-only
+		// fullRender path and does not replay committed scrollback.
 		terminal.resize(40, 15);
 		await terminal.flush();
 
 		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
 		// Committed content should NOT be re-emitted
 		assert.ok(!terminal.getWrites().includes("Msg 0"), "Height change should not re-emit committed content");
+
+		tui.stop();
+	});
+
+	it("height shrink after a scrolled live region recommits and bottom-anchors", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const history = new TestComponent();
+		history.lines = Array.from({ length: 20 }, (_, i) => `HIST ${i}`);
+		committed.addChild(history);
+
+		const liveComp = new TestComponent();
+		liveComp.lines = ["EDITOR >", "footer"];
+		live.addChild(liveComp);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		// Grow the live region beyond the 10-row viewport, then coalesce a live-region
+		// shrink with a terminal height shrink. The heightChanged branch recomputes
+		// prevViewportTop from the previous live-region height, sees that the old
+		// live region had scrolled, and must recommit rather than live-region-only redraw.
+		liveComp.lines = [...Array.from({ length: 11 }, (_, i) => `TALL ${i}`), "EDITOR >", "footer"];
+		tui.requestRender();
+		await terminal.flush();
+
+		const redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		liveComp.lines = ["EDITOR >", "footer"];
+		terminal.resize(40, 8);
+		await terminal.flush();
+
+		const writes = terminal.getWrites();
+		const viewport = terminal.getViewport();
+		const editorRow = viewport.findIndex((l) => l.includes("EDITOR >"));
+		const footerRow = viewport.findIndex((l) => l.includes("footer"));
+
+		assert.ok(writes.includes("\x1b[3J"), "height shrink after scrolled live region should clear scrollback");
+		assert.ok(writes.includes("HIST 0"), "height shrink recommit should re-emit committed history");
+		assert.strictEqual(editorRow, viewport.length - 2, "editor should be second-from-bottom after recommit");
+		assert.strictEqual(footerRow, viewport.length - 1, "last live line should be bottom-anchored after recommit");
+		assert.ok(
+			viewport.slice(0, editorRow).some((l) => l.includes("HIST")),
+			"committed history must be restored above the editor after height shrink",
+		);
+		assert.ok(tui.fullRedraws > redrawsBefore, "height shrink after scrolled live region should full-redraw");
 
 		tui.stop();
 	});
@@ -632,10 +689,126 @@ describe("TUI committed-scrollback region", () => {
 		tui.stop();
 	});
 
-	// Companion guard: when the live region fit within the viewport, a shrink must NOT
-	// escalate to a full transcript replay — it stays on the cheap live-region-only
-	// path, preserving the committed-scrollback optimization from the original refactor.
-	it("live-region shrink within viewport stays on the cheap path (no scrollback clear)", async () => {
+	it("pure trailing deletion that moves the viewport up recommits and bottom-anchors", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const history = new TestComponent();
+		history.lines = Array.from({ length: 20 }, (_, i) => `HIST ${i}`);
+		committed.addChild(history);
+
+		const liveComp = new TestComponent();
+		liveComp.lines = ["EDITOR >", "footer"];
+		live.addChild(liveComp);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		// Grow by appending trailing rows after an unchanged editor/footer prefix. When
+		// this later shrinks back to the prefix, firstChanged >= newLines.length and
+		// targetRow (1) is above the previous viewport top (3), so doRender takes the
+		// "deleted lines moved viewport up" clearAndRedraw() branch.
+		liveComp.lines = ["EDITOR >", "footer", ...Array.from({ length: 11 }, (_, i) => `TRAILING ${i}`)];
+		tui.requestRender();
+		await terminal.flush();
+
+		const redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		liveComp.lines = ["EDITOR >", "footer"];
+		tui.requestRender();
+		await terminal.flush();
+
+		const writes = terminal.getWrites();
+		const viewport = terminal.getViewport();
+		const editorRow = viewport.findIndex((l) => l.includes("EDITOR >"));
+		const footerRow = viewport.findIndex((l) => l.includes("footer"));
+
+		assert.ok(writes.includes("\x1b[3J"), "viewport-up trailing deletion should recommit and clear scrollback");
+		assert.ok(writes.includes("HIST 0"), "recommit should re-emit committed history");
+		assert.strictEqual(editorRow, viewport.length - 2, "editor should be second-from-bottom after recommit");
+		assert.strictEqual(footerRow, viewport.length - 1, "last live line should be bottom-anchored after recommit");
+		assert.ok(
+			viewport.slice(0, editorRow).some((l) => l.includes("HIST")),
+			"committed history must be restored above the editor",
+		);
+		assert.ok(tui.fullRedraws > redrawsBefore, "viewport-up trailing deletion should perform a full redraw");
+
+		tui.stop();
+	});
+
+	it("oversized trailing deletion recommits from the extraLines > height branch", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+
+		const committed = new Container();
+		const live = new Container();
+		tui.addChild(committed);
+		tui.addChild(live);
+
+		const history = new TestComponent();
+		history.lines = Array.from({ length: 20 }, (_, i) => `HIST ${i}`);
+		committed.addChild(history);
+
+		const liveComp = new TestComponent();
+		liveComp.lines = ["EDITOR >", "footer"];
+		live.addChild(liveComp);
+
+		tui.start();
+		await terminal.flush();
+		tui.setCommittedChildCount(1);
+		tui.commit();
+		await terminal.flush();
+
+		liveComp.lines = ["EDITOR >", "footer", ...Array.from({ length: 13 }, (_, i) => `TRAILING ${i}`)];
+		tui.requestRender();
+		await terminal.flush();
+
+		// Under the normal bottom-anchored invariant, deleting more than one viewport
+		// of trailing rows also moves targetRow above prevViewportTop and is handled by
+		// the earlier "deleted lines moved viewport up" guard. Lower prevViewportTop to
+		// model a defensive/stale viewport-tracking state and exercise the sibling
+		// extraLines > height clearAndRedraw() route directly.
+		(tui as unknown as { previousViewportTop: number }).previousViewportTop = 1;
+
+		const redrawsBefore = tui.fullRedraws;
+		terminal.clearWrites();
+
+		liveComp.lines = ["EDITOR >", "footer"];
+		tui.requestRender();
+		await terminal.flush();
+
+		const writes = terminal.getWrites();
+		const viewport = terminal.getViewport();
+		const editorRow = viewport.findIndex((l) => l.includes("EDITOR >"));
+		const footerRow = viewport.findIndex((l) => l.includes("footer"));
+
+		assert.ok(writes.includes("\x1b[3J"), "oversized trailing deletion should recommit and clear scrollback");
+		assert.ok(writes.includes("HIST 0"), "recommit should re-emit committed history");
+		assert.strictEqual(editorRow, viewport.length - 2, "editor should be second-from-bottom after recommit");
+		assert.strictEqual(footerRow, viewport.length - 1, "last live line should be bottom-anchored after recommit");
+		assert.ok(
+			viewport.slice(0, editorRow).some((l) => l.includes("HIST")),
+			"committed history must be restored above the editor",
+		);
+		assert.ok(tui.fullRedraws > redrawsBefore, "oversized trailing deletion should perform a full redraw");
+
+		tui.stop();
+	});
+
+	// This small shrink intentionally does not cover clearAndRedraw(): with
+	// prevViewportTop === 0 and firstChanged === 0, it falls through to the older
+	// live-region-only content-shrank path. The clearAndRedraw() fullRender arm is
+	// guarded by the height-change-with-prevViewportTop-0 test above.
+	it("small live-region content shrink stays live-region-only (no scrollback clear)", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
 

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -95,17 +95,18 @@ describe("TUI resize handling", () => {
 		});
 	});
 
-	it("height changes in Termux only re-render live region (no transcript replay)", async () => {
-		// With committed-scrollback model, height changes only re-render the
-		// live region. This is cheap and safe even on Termux — no Termux
-		// special-case is needed since the live region is small.
+	it("height changes in Termux only re-render live region when the live-region start is visible", async () => {
+		// With the committed-scrollback model, height changes keep the cheap
+		// live-region redraw path only when the live-region start is still reachable
+		// (prevViewportTop === 0). Termux still avoids transcript replay for that
+		// common small-live-region case.
 		await withEnv({ TERMUX_VERSION: "1" }, async () => {
 			const terminal = new LoggingVirtualTerminal(40, 10);
 			const tui = new TUI(terminal);
 			const component = new TestComponent();
 			tui.addChild(component);
 
-			component.lines = Array.from({ length: 20 }, (_, i) => `Line ${i}`);
+			component.lines = Array.from({ length: 5 }, (_, i) => `Line ${i}`);
 			tui.start();
 			await terminal.flush();
 			terminal.clearWrites();
@@ -121,7 +122,7 @@ describe("TUI resize handling", () => {
 			assert.ok(!terminal.getWrites().includes("\x1b[3J"), "Height change should not clear scrollback");
 
 			const viewport = terminal.getViewport();
-			assert.ok(viewport.join("\n").includes("Line 19"), "Latest content remains visible after resize");
+			assert.ok(viewport.join("\n").includes("Line 4"), "Latest content remains visible after resize");
 
 			tui.stop();
 		});


### PR DESCRIPTION
Closes #277

Full TUI recommit leaves the view at the top of the conversation instead of anchored at the bottom near the editor. Root cause reproduced in the headless test harness: when the live region exceeds the viewport and then shrinks, `doRender()` routes through `fullRender(true)`, which cannot restore committed history from scrollback and anchors the editor at the top.

Implementation plan posted as a comment below.
