### PR TITLE
RpcClient: forward uid/gid spawn options to run agent child as a specific OS user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8913,7 +8913,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8942,7 +8942,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8998,7 +8998,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9127,7 +9127,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9176,7 +9176,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9209,7 +9209,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.29.0",
+			"version": "2.30.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -4,6 +4,21 @@ RPC mode enables headless operation of the coding agent via a JSON protocol over
 
 **Note for Node.js/TypeScript users**: If you're building a Node.js application, consider using `AgentSession` directly from `@dreb/coding-agent` instead of spawning a subprocess. See [`src/core/agent-session.ts`](../src/core/agent-session.ts) for the API. For a subprocess-based TypeScript client, see [`src/modes/rpc/rpc-client.ts`](../src/modes/rpc/rpc-client.ts).
 
+### Running the agent child as a specific OS user
+
+When using the `RpcClient` from `@dreb/coding-agent`, `RpcClientOptions` accepts optional `uid` and `gid` fields. When set, they are forwarded directly to `child_process.spawn`, so the agent child (and every subprocess it spawns, including `bash`) runs under that OS user/group. When unset they are omitted entirely, leaving spawn behavior unchanged.
+
+```ts
+import { RpcClient } from "@dreb/coding-agent";
+
+// Parent must hold CAP_SETUID / CAP_SETGID (e.g. run as root) for this to succeed.
+const client = new RpcClient({ cwd: "/srv/users/alice", uid: 4001, gid: 4001 });
+await client.start();
+```
+
+This enables per-user filesystem isolation by plain Unix DAC: give each authenticated user a dedicated UID and a working directory owned by that UID at mode `0700`. If the parent lacks the required capability (or the platform doesn't support `uid`/`gid`, e.g. Windows), the spawn fails and `start()` rejects rather than silently running as the parent user.
+
+
 ## Starting RPC Mode
 
 ```bash

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -36,6 +36,20 @@ export interface RpcClientOptions {
 	model?: string;
 	/** Additional CLI arguments */
 	args?: string[];
+	/**
+	 * Run the agent child process under this OS user id.
+	 * Forwarded directly to `child_process.spawn`. The parent process must hold
+	 * `CAP_SETUID` (typically by running as root) for this to succeed; otherwise
+	 * the spawn fails and `start()` rejects. Omitted when unset (default behavior).
+	 */
+	uid?: number;
+	/**
+	 * Run the agent child process under this OS group id.
+	 * Forwarded directly to `child_process.spawn`. The parent process must hold
+	 * `CAP_SETGID` (typically by running as root) for this to succeed; otherwise
+	 * the spawn fails and `start()` rejects. Omitted when unset (default behavior).
+	 */
+	gid?: number;
 }
 
 export interface ModelInfo {
@@ -60,6 +74,7 @@ export class RpcClient {
 	private requestId = 0;
 	private stderr = "";
 	private _dead = false;
+	private spawnError: Error | null = null;
 
 	constructor(private options: RpcClientOptions = {}) {}
 
@@ -88,9 +103,12 @@ export class RpcClient {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
+			...(this.options.uid != null ? { uid: this.options.uid } : {}),
+			...(this.options.gid != null ? { gid: this.options.gid } : {}),
 		});
 
 		this._dead = false;
+		this.spawnError = null;
 
 		// Collect stderr for debugging
 		this.process.stderr?.on("data", (data) => {
@@ -111,6 +129,22 @@ export class RpcClient {
 			this.pendingRequests.clear();
 		});
 
+		// Detect spawn failures — these surface asynchronously as an 'error' event
+		// rather than a thrown exception (e.g. EPERM when dropping to a uid/gid the
+		// parent lacks CAP_SETUID/CAP_SETGID for, or unsupported on Windows). Without
+		// a listener an 'error' event would crash the process; capture it so start()
+		// can fail loudly and pending requests reject instead of hanging.
+		procRef.on("error", (err) => {
+			// Guard: skip if this handler belongs to an old, already-stopped process
+			if (this.process !== procRef) return;
+			this._dead = true;
+			this.spawnError = err;
+			for (const pending of this.pendingRequests.values()) {
+				pending.reject(new Error(`RPC process failed to spawn: ${err.message}`));
+			}
+			this.pendingRequests.clear();
+		});
+
 		// Set up strict JSONL reader for stdout.
 		this.stopReadingStdout = attachJsonlLineReader(this.process.stdout!, (line) => {
 			this.handleLine(line);
@@ -118,6 +152,12 @@ export class RpcClient {
 
 		// Wait a moment for process to initialize
 		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		// Surface async spawn failures (e.g. uid/gid privilege drop denied) loudly.
+		const spawnError = this.takeSpawnError();
+		if (spawnError) {
+			throw new Error(`Agent process failed to spawn: ${spawnError.message}. Stderr: ${this.stderr}`);
+		}
 
 		if (this.process.exitCode !== null) {
 			throw new Error(`Agent process exited immediately with code ${this.process.exitCode}. Stderr: ${this.stderr}`);
@@ -512,6 +552,17 @@ export class RpcClient {
 	// =========================================================================
 	// Internal
 	// =========================================================================
+
+	/**
+	 * Read and clear any captured spawn error. Accessed through a method boundary
+	 * so it isn't narrowed away by control-flow analysis (the field is only ever
+	 * assigned a non-null value inside the async 'error' handler).
+	 */
+	private takeSpawnError(): Error | null {
+		const err = this.spawnError;
+		this.spawnError = null;
+		return err;
+	}
 
 	private handleLine(line: string): void {
 		try {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -17,6 +17,12 @@ import type { RpcCommand, RpcResponse, RpcSessionInfo, RpcSessionState, RpcSlash
 // Types
 // ============================================================================
 
+/**
+ * Grace period (ms) start() waits for the child to initialize before treating
+ * it as alive. An 'error'/'exit' event during this window rejects start() early.
+ */
+const INIT_GRACE_MS = 100;
+
 /** Distributive Omit that works with union types */
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 
@@ -115,34 +121,28 @@ export class RpcClient {
 			this.stderr += data.toString();
 		});
 
-		// Detect process exit — reject pending requests so callers don't hang.
-		// Capture the process reference so stale handlers from a previous process
-		// don't clobber state after a stop()/start() cycle.
+		// Detect process exit and spawn failures for the whole session lifecycle —
+		// reject pending requests so callers don't hang. Capture the process
+		// reference so stale handlers from a previous process don't clobber state
+		// after a stop()/start() cycle.
 		const procRef = this.process;
 		procRef.on("exit", (code, signal) => {
 			// Guard: skip if this handler belongs to an old, already-stopped process
 			if (this.process !== procRef) return;
-			this._dead = true;
-			for (const pending of this.pendingRequests.values()) {
-				pending.reject(new Error(`RPC process exited with code ${code}, signal ${signal}`));
-			}
-			this.pendingRequests.clear();
+			this.failPendingRequests(`RPC process exited with code ${code}, signal ${signal}`);
 		});
 
-		// Detect spawn failures — these surface asynchronously as an 'error' event
-		// rather than a thrown exception (e.g. EPERM when dropping to a uid/gid the
-		// parent lacks CAP_SETUID/CAP_SETGID for, or unsupported on Windows). Without
-		// a listener an 'error' event would crash the process; capture it so start()
-		// can fail loudly and pending requests reject instead of hanging.
+		// Spawn failures surface asynchronously as an 'error' event rather than a
+		// thrown exception (e.g. EPERM when dropping to a uid/gid the parent lacks
+		// CAP_SETUID/CAP_SETGID for, or unsupported on Windows). Without a listener
+		// an 'error' event would crash the process; record the cause so start() can
+		// fail loudly and a later send() can report the real reason instead of a
+		// generic "not running".
 		procRef.on("error", (err) => {
 			// Guard: skip if this handler belongs to an old, already-stopped process
 			if (this.process !== procRef) return;
-			this._dead = true;
 			this.spawnError = err;
-			for (const pending of this.pendingRequests.values()) {
-				pending.reject(new Error(`RPC process failed to spawn: ${err.message}`));
-			}
-			this.pendingRequests.clear();
+			this.failPendingRequests(`RPC process failed to spawn: ${err.message}`);
 		});
 
 		// Set up strict JSONL reader for stdout.
@@ -150,15 +150,40 @@ export class RpcClient {
 			this.handleLine(line);
 		});
 
-		// Wait a moment for process to initialize
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		// Give the process a moment to initialize, but settle as soon as an
+		// 'error' or 'exit' event arrives. Racing the grace period against those
+		// events (instead of a blind fixed sleep) guarantees that a failed
+		// privilege drop (uid/gid EPERM) rejects start() loudly no matter when
+		// libuv delivers the event — a fixed sleep could expire first and let
+		// start() resolve despite the child never running.
+		await new Promise<void>((resolve, reject) => {
+			const onError = (err: Error) => {
+				cleanup();
+				reject(new Error(`Agent process failed to spawn: ${err.message}. Stderr: ${this.stderr}`));
+			};
+			const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+				cleanup();
+				reject(
+					new Error(
+						`Agent process exited immediately with code ${code}, signal ${signal}. Stderr: ${this.stderr}`,
+					),
+				);
+			};
+			const timer = setTimeout(() => {
+				cleanup();
+				resolve();
+			}, INIT_GRACE_MS);
+			const cleanup = () => {
+				clearTimeout(timer);
+				procRef.off("error", onError);
+				procRef.off("exit", onExit);
+			};
+			procRef.once("error", onError);
+			procRef.once("exit", onExit);
+		});
 
-		// Surface async spawn failures (e.g. uid/gid privilege drop denied) loudly.
-		const spawnError = this.takeSpawnError();
-		if (spawnError) {
-			throw new Error(`Agent process failed to spawn: ${spawnError.message}. Stderr: ${this.stderr}`);
-		}
-
+		// Belt-and-suspenders: a process that exited exactly as the grace timer
+		// fired (so the race resolved instead of rejecting) still surfaces loudly.
 		if (this.process.exitCode !== null) {
 			throw new Error(`Agent process exited immediately with code ${this.process.exitCode}. Stderr: ${this.stderr}`);
 		}
@@ -554,14 +579,16 @@ export class RpcClient {
 	// =========================================================================
 
 	/**
-	 * Read and clear any captured spawn error. Accessed through a method boundary
-	 * so it isn't narrowed away by control-flow analysis (the field is only ever
-	 * assigned a non-null value inside the async 'error' handler).
+	 * Mark the client dead and reject every in-flight request with `message`.
+	 * Shared by the 'exit' and 'error' handlers so both failure paths surface
+	 * loudly and consistently instead of leaving callers hanging.
 	 */
-	private takeSpawnError(): Error | null {
-		const err = this.spawnError;
-		this.spawnError = null;
-		return err;
+	private failPendingRequests(message: string): void {
+		this._dead = true;
+		for (const pending of this.pendingRequests.values()) {
+			pending.reject(new Error(message));
+		}
+		this.pendingRequests.clear();
 	}
 
 	private handleLine(line: string): void {
@@ -587,7 +614,11 @@ export class RpcClient {
 
 	private async send(command: RpcCommandBody): Promise<RpcResponse> {
 		if (this._dead || !this.process?.stdin) {
-			throw new Error("RPC process not running");
+			// Surface the real spawn cause (e.g. uid/gid EPERM) if one was captured,
+			// rather than a generic message that hides why the process is gone.
+			throw new Error(
+				this.spawnError ? `RPC process not running: ${this.spawnError.message}` : "RPC process not running",
+			);
 		}
 
 		const id = `req_${++this.requestId}`;

--- a/packages/coding-agent/test/rpc-client-spawn.test.ts
+++ b/packages/coding-agent/test/rpc-client-spawn.test.ts
@@ -127,4 +127,37 @@ describe("RpcClient spawn failure handling", () => {
 
 		await expect(pending).rejects.toThrow(/failed to spawn/i);
 	});
+
+	test("a spawn 'error' after start() resolves surfaces loudly on the next call", async () => {
+		// The race in start() resolves once the grace window elapses with the child
+		// alive. A spawn/runtime 'error' that arrives later must still fail loudly:
+		// the client is marked dead and the next request rejects with the real
+		// cause rather than hanging or silently running.
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js", uid: 1234 });
+		await client.start();
+
+		child.emit("error", new Error("EACCES: setuid not permitted"));
+
+		// Subsequent calls reject loudly and carry the captured cause.
+		await expect(client.getState()).rejects.toThrow(/not running.*setuid not permitted/i);
+	});
+
+	test("in-flight requests reject when the child emits 'exit'", async () => {
+		// Sibling path to the 'error' case: a process that crashes mid-request must
+		// reject the pending call with the exit reason, not leave it hanging.
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js" });
+		await client.start();
+
+		const pending = client.getState();
+		child.exitCode = 1;
+		child.emit("exit", 1, "SIGKILL");
+
+		await expect(pending).rejects.toThrow(/exited with code 1/i);
+	});
 });

--- a/packages/coding-agent/test/rpc-client-spawn.test.ts
+++ b/packages/coding-agent/test/rpc-client-spawn.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for RpcClient spawn-option handling (issue 279).
+ *
+ * Verifies that optional `uid`/`gid` are:
+ *  - omitted from the spawn options object when unset (default unchanged), and
+ *  - forwarded verbatim when set,
+ * and that asynchronous spawn failures (the 'error' event — e.g. EPERM when a
+ * non-privileged parent tries to drop to a uid/gid) surface loudly through
+ * `start()` and reject in-flight requests rather than crashing or hanging.
+ */
+
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { RpcClient } from "../src/modes/rpc/rpc-client.js";
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return {
+		...actual,
+		spawn: vi.fn(),
+	};
+});
+
+type FakeChild = ReturnType<typeof spawn> & {
+	stdout: PassThrough;
+	stderr: PassThrough;
+	stdin: PassThrough;
+	exitCode: number | null;
+};
+
+function makeFakeChild(): FakeChild {
+	const proc = new EventEmitter() as FakeChild;
+	proc.stdout = new PassThrough();
+	proc.stderr = new PassThrough();
+	proc.stdin = new PassThrough();
+	proc.exitCode = null;
+	proc.kill = vi.fn(() => {
+		proc.exitCode = 0;
+		process.nextTick(() => proc.emit("exit", 0, null));
+		return true;
+	}) as unknown as FakeChild["kill"];
+	return proc;
+}
+
+/** Options object passed as the third argument to spawn(). */
+function lastSpawnOptions(): Record<string, unknown> {
+	const calls = vi.mocked(spawn).mock.calls;
+	return calls[calls.length - 1][2] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+	vi.mocked(spawn).mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("RpcClient spawn uid/gid forwarding", () => {
+	test("omits uid/gid from spawn options when unset", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js" });
+		await client.start();
+
+		const opts = lastSpawnOptions();
+		expect(opts).not.toHaveProperty("uid");
+		expect(opts).not.toHaveProperty("gid");
+
+		await client.stop();
+	});
+
+	test("forwards uid and gid to spawn when set", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js", uid: 1234, gid: 5678 });
+		await client.start();
+
+		const opts = lastSpawnOptions();
+		expect(opts.uid).toBe(1234);
+		expect(opts.gid).toBe(5678);
+
+		await client.stop();
+	});
+
+	test("forwards uid alone without injecting gid", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js", uid: 1000 });
+		await client.start();
+
+		const opts = lastSpawnOptions();
+		expect(opts.uid).toBe(1000);
+		expect(opts).not.toHaveProperty("gid");
+
+		await client.stop();
+	});
+});
+
+describe("RpcClient spawn failure handling", () => {
+	test("start() rejects loudly when the child emits an 'error' (e.g. EPERM)", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js", uid: 1234 });
+		// The spawn failure surfaces asynchronously after start() has attached its
+		// 'error' listener.
+		process.nextTick(() => child.emit("error", new Error("EACCES: setuid not permitted")));
+
+		await expect(client.start()).rejects.toThrow(/failed to spawn/i);
+	});
+
+	test("in-flight requests reject when the child emits an 'error'", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js" });
+		await client.start();
+
+		const pending = client.getState();
+		child.emit("error", new Error("boom"));
+
+		await expect(pending).rejects.toThrow(/failed to spawn/i);
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.29.0",
+	"version": "2.30.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #279

Add optional `uid`/`gid` fields to `RpcClientOptions` and forward them to the agent child `spawn()`, so a privileged parent can drop each agent child to a dedicated OS user for per-user filesystem isolation. Additive and backward-compatible. Paired with loud error surfacing for privilege-drop failures.

Implementation plan posted as a comment below.
