### PR TITLE
/copy: exclude thinking by default + stop wl-copy stderr leak (285, 286)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8913,7 +8913,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8942,7 +8942,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8998,7 +8998,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9127,7 +9127,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9176,7 +9176,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9209,7 +9209,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.30.0",
+			"version": "2.30.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -173,7 +173,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/tree` | Jump to any point in the session and continue from there |
 | `/fork` | Create a new session from the current branch |
 | `/compact [prompt]` | Manually compact context, optional custom instructions |
-| `/copy` | Open multi-select message picker to copy any messages to clipboard |
+| `/copy` | Open multi-select message picker to copy any messages to clipboard. Assistant reasoning is excluded by default and offered as a separate, selectable `Thinking` row. |
 | `/dream` | Consolidate and prune memories — backs up, merges duplicates, scans sessions for patterns |
 | `/export [file]` | Export session to HTML file |
 | `/buddy` | Terminal companion — hatch, pet, reroll, set model, or hide. See [docs/buddy.md](docs/buddy.md) |

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/copy-selector.ts
@@ -3,9 +3,9 @@ import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
 export interface CopyMessageItem {
-	index: number; // Original index in messages array (for chronological ordering on copy)
-	roleLabel: string; // e.g. "You", "Assistant", "Tool: read", "Bash"
+	roleLabel: string; // e.g. "You", "Assistant", "Thinking", "Tool: read", "Bash"
 	preview: string; // Single-line preview text (no ANSI)
+	text: string; // Pre-extracted copyable text for this row (joined on copy in item order)
 }
 
 /**
@@ -17,7 +17,7 @@ class CopyMessageList implements Component {
 	private selected: Set<number>; // set of selected item array positions
 	private maxVisible: number;
 
-	public onCopy?: (selectedIndices: number[]) => void | Promise<void>;
+	public onCopy?: (selectedPositions: number[]) => void | Promise<void>;
 	public onCancel?: () => void;
 
 	constructor(items: CopyMessageItem[], maxVisible: number = 15) {
@@ -125,11 +125,10 @@ class CopyMessageList implements Component {
 		// Enter - confirm copy
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			if (this.onCopy) {
-				// Return original indices sorted chronologically
-				const selectedIndices = Array.from(this.selected)
-					.map((i) => this.items[i].index)
-					.sort((a, b) => a - b);
-				const result = this.onCopy(selectedIndices);
+				// Return selected item positions in chronological (list) order.
+				// Items are built in chronological order, so position order is correct.
+				const selectedPositions = Array.from(this.selected).sort((a, b) => a - b);
+				const result = this.onCopy(selectedPositions);
 				if (result instanceof Promise) {
 					result.catch(() => {
 						// Errors from the async copy callback are handled by the caller
@@ -154,7 +153,7 @@ export class CopySelectorComponent extends Container {
 
 	constructor(
 		items: CopyMessageItem[],
-		onCopy: (selectedIndices: number[]) => void | Promise<void>,
+		onCopy: (selectedPositions: number[]) => void | Promise<void>,
 		onCancel: () => void,
 		maxVisible?: number,
 	) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -80,7 +80,13 @@ import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/cha
 import { copyToClipboard } from "../../utils/clipboard.js";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.js";
 import { parseGitUrl } from "../../utils/git.js";
-import { extractCopyableText, getMessagePreview, getMessageRoleLabel } from "../../utils/message-text.js";
+import {
+	extractCopyableText,
+	extractThinkingText,
+	getMessagePreview,
+	getMessageRoleLabel,
+	toSingleLinePreview,
+} from "../../utils/message-text.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
@@ -4532,12 +4538,26 @@ export class InteractiveMode {
 			return;
 		}
 
-		// Build items from session messages
-		const items: CopyMessageItem[] = messages.map((msg, index) => ({
-			index,
-			roleLabel: getMessageRoleLabel(msg),
-			preview: getMessagePreview(msg),
-		}));
+		// Build items from session messages. Each assistant message that carries
+		// thinking gets an extra "Thinking" row listed directly ABOVE its message
+		// (matching the TUI's thinking-above-answer presentation), so when both are
+		// selected the reasoning lands at the top of the combined copy.
+		const items: CopyMessageItem[] = [];
+		for (const msg of messages) {
+			const thinking = extractThinkingText(msg);
+			if (thinking) {
+				items.push({
+					roleLabel: "Thinking",
+					preview: toSingleLinePreview(thinking),
+					text: thinking,
+				});
+			}
+			items.push({
+				roleLabel: getMessageRoleLabel(msg),
+				preview: getMessagePreview(msg),
+				text: extractCopyableText(msg),
+			});
+		}
 
 		// Hide buddy while selector is open to free vertical space
 		const hadBuddy = this.buddyComponent !== null;
@@ -4555,21 +4575,19 @@ export class InteractiveMode {
 		this.showSelector((done) => {
 			const selector = new CopySelectorComponent(
 				items,
-				async (selectedIndices) => {
+				async (selectedPositions) => {
 					done();
 					// Restore buddy
 					if (hadBuddy) this.renderWidgets();
 					this.ui.requestRender();
 
-					if (selectedIndices.length === 0) {
+					if (selectedPositions.length === 0) {
 						this.showWarning("No messages selected");
 						return;
 					}
 
-					// Extract text from selected messages in chronological order
-					const selectedTexts = selectedIndices
-						.map((i) => extractCopyableText(messages[i]))
-						.filter((text) => text.length > 0);
+					// Extract pre-built text from selected rows in chronological (list) order
+					const selectedTexts = selectedPositions.map((pos) => items[pos].text).filter((text) => text.length > 0);
 
 					if (selectedTexts.length === 0) {
 						this.showWarning("Selected messages have no copyable text");

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -63,8 +63,13 @@ export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 				try {
 					// Verify wl-copy exists (spawn errors are async and won't be caught)
 					execSync("which wl-copy", { stdio: "ignore" });
-					// wl-copy with execSync hangs due to fork behavior; use spawn instead
-					const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"] });
+					// wl-copy with execSync hangs due to fork behavior; use spawn instead.
+					// detached: true puts wl-copy in its own session (setsid) with no
+					// controlling terminal, so its "Somebody else owns the clipboard now"
+					// message cannot leak into the TUI even if it bypasses the ignored
+					// stderr by writing to /dev/tty (see issue 286). As a session leader it
+					// also keeps serving the clipboard after we exit.
+					const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"], detached: true });
 					proc.on("error", () => {
 						// Spawn failed after which check (TOCTOU, permissions, etc.)
 					});

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -20,22 +20,49 @@ function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
 
 export type ClipboardResult = { method: "native" | "platform" | "osc52" };
 
+/**
+ * Best-effort write to the native clipboard module. Returns true on success.
+ *
+ * On Linux this is the source of issue 286: the native module (clipboard-rs)
+ * uses an X11 backend whose in-process selection-serving thread calls
+ * `println!("Somebody else owns the clipboard now")` (clipboard-rs
+ * src/platform/x11.rs) on `SelectionClear` — i.e. whenever another app takes
+ * the clipboard. That write goes to the real stdout file descriptor from native
+ * code, so no JS-level stdout/stderr guard can intercept it; it lands in the TUI
+ * input region. Callers therefore use this only where it is safe (macOS/Windows,
+ * which have no serving thread) or as a Linux last resort when no CLI clipboard
+ * tool exists.
+ */
+async function tryNativeClipboard(text: string): Promise<boolean> {
+	try {
+		if (clipboard) {
+			await clipboard.setText(text);
+			return true;
+		}
+	} catch {
+		/* Native clipboard module threw — caller falls through to other methods */
+	}
+	return false;
+}
+
 export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 	// Always emit OSC 52 - works over SSH/mosh, harmless locally
 	const encoded = Buffer.from(text).toString("base64");
 	process.stdout.write(`\x1b]52;c;${encoded}\x07`);
 
-	try {
-		if (clipboard) {
-			await clipboard.setText(text);
+	const p = platform();
+
+	// On macOS/Windows the native module talks to OS clipboard APIs directly and
+	// does not spawn a background selection-serving thread, so prefer it there.
+	// On Linux we intentionally do NOT try the native module first — see
+	// tryNativeClipboard for why (issue 286) — and prefer controlled-stdio
+	// subprocess tools instead, falling back to native only as a last resort.
+	if (p !== "linux") {
+		if (await tryNativeClipboard(text)) {
 			return { method: "native" };
 		}
-	} catch {
-		/* Native clipboard module threw — fall through to platform-specific tools */
 	}
 
-	// Also try native tools (best effort for local sessions)
-	const p = platform();
 	const options: NativeClipboardExecOptions = { input: text, timeout: 5000, stdio: ["pipe", "ignore", "ignore"] };
 
 	try {
@@ -46,7 +73,10 @@ export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 			execSync("clip", options);
 			return { method: "platform" };
 		} else {
-			// Linux. Try Termux, Wayland, or X11 clipboard tools.
+			// Linux. Prefer controlled-stdio subprocess tools (Termux, Wayland,
+			// X11). Each owns the selection in its own process with stdout/stderr
+			// redirected to /dev/null, so its clipboard-ownership chatter cannot
+			// leak into the TUI — unlike the in-process native module (issue 286).
 			if (process.env.TERMUX_VERSION) {
 				try {
 					execSync("termux-clipboard-set", options);
@@ -64,11 +94,8 @@ export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 					// Verify wl-copy exists (spawn errors are async and won't be caught)
 					execSync("which wl-copy", { stdio: "ignore" });
 					// wl-copy with execSync hangs due to fork behavior; use spawn instead.
-					// detached: true puts wl-copy in its own session (setsid) with no
-					// controlling terminal, so its "Somebody else owns the clipboard now"
-					// message cannot leak into the TUI even if it bypasses the ignored
-					// stderr by writing to /dev/tty (see issue 286). As a session leader it
-					// also keeps serving the clipboard after we exit.
+					// detached: true puts wl-copy in its own session (setsid) so it keeps
+					// serving the clipboard after we exit and has no controlling terminal.
 					const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"], detached: true });
 					proc.on("error", () => {
 						// Spawn failed after which check (TOCTOU, permissions, etc.)
@@ -91,6 +118,14 @@ export async function copyToClipboard(text: string): Promise<ClipboardResult> {
 			} else if (hasX11Display) {
 				copyToX11Clipboard(options);
 				return { method: "platform" };
+			}
+
+			// Linux last resort: the native module. Only reached when no CLI
+			// clipboard tool is available. This can reintroduce the issue-286
+			// stdout leak on X11 ownership changes, but a working clipboard beats
+			// none, and OSC 52 was already emitted above regardless.
+			if (await tryNativeClipboard(text)) {
+				return { method: "native" };
 			}
 		}
 	} catch {

--- a/packages/coding-agent/src/utils/message-text.ts
+++ b/packages/coding-agent/src/utils/message-text.ts
@@ -127,10 +127,7 @@ function extractUserText(message: UserMessage): string {
 function extractAssistantText(message: AssistantMessage): string {
 	// Only visible text blocks. Thinking is excluded by default and surfaced
 	// separately via extractThinkingText (see issue 285).
-	return message.content
-		.filter((block): block is TextContent => block.type === "text")
-		.map((block) => block.text)
-		.join("\n");
+	return extractTextBlocks(message.content);
 }
 
 function extractToolResultText(message: ToolResultMessage): string {

--- a/packages/coding-agent/src/utils/message-text.ts
+++ b/packages/coding-agent/src/utils/message-text.ts
@@ -63,11 +63,32 @@ export function getMessageRoleLabel(message: AgentMessage): string {
 }
 
 /**
- * Get a single-line preview of a message's content (for display in selector).
- * Returns plain text, no ANSI, truncated to ~200 chars. Caller handles width truncation.
+ * Extract the thinking/reasoning text from a message, if any.
+ * Only assistant messages carry thinking blocks. Returns a single labeled block
+ * (`[thinking]\n<reasoning>`) suitable for copying, or an empty string when there
+ * is no thinking content (non-assistant role, or assistant with no thinking blocks).
  */
-export function getMessagePreview(message: AgentMessage): string {
-	const text = extractCopyableText(message);
+export function extractThinkingText(message: AgentMessage): string {
+	if (message.role !== "assistant") {
+		return "";
+	}
+	const thinkingParts = (message as AssistantMessage).content
+		.filter(
+			(block): block is { type: "thinking"; thinking: string } => block.type === "thinking" && "thinking" in block,
+		)
+		.map((block) => block.thinking);
+
+	if (thinkingParts.length === 0) {
+		return "";
+	}
+	return `[thinking]\n${thinkingParts.join("\n\n")}`;
+}
+
+/**
+ * Normalize text to a single-line preview: collapse whitespace, trim, truncate to ~200 chars.
+ * Caller handles further width truncation for display. Returns "[no text content]" for empty input.
+ */
+export function toSingleLinePreview(text: string): string {
 	if (!text) {
 		return "[no text content]";
 	}
@@ -77,6 +98,14 @@ export function getMessagePreview(message: AgentMessage): string {
 		return singleLine;
 	}
 	return singleLine.slice(0, 200);
+}
+
+/**
+ * Get a single-line preview of a message's content (for display in selector).
+ * Returns plain text, no ANSI, truncated to ~200 chars. Caller handles width truncation.
+ */
+export function getMessagePreview(message: AgentMessage): string {
+	return toSingleLinePreview(extractCopyableText(message));
 }
 
 // --- Internal helpers ---
@@ -96,25 +125,12 @@ function extractUserText(message: UserMessage): string {
 }
 
 function extractAssistantText(message: AssistantMessage): string {
-	const parts: string[] = [];
-
-	// Collect text blocks
-	const textParts = message.content
+	// Only visible text blocks. Thinking is excluded by default and surfaced
+	// separately via extractThinkingText (see issue 285).
+	return message.content
 		.filter((block): block is TextContent => block.type === "text")
-		.map((block) => block.text);
-
-	if (textParts.length > 0) {
-		parts.push(textParts.join("\n"));
-	}
-
-	// Collect thinking blocks with header
-	for (const block of message.content) {
-		if (block.type === "thinking" && "thinking" in block) {
-			parts.push(`[thinking]\n${block.thinking}`);
-		}
-	}
-
-	return parts.join("\n");
+		.map((block) => block.text)
+		.join("\n");
 }
 
 function extractToolResultText(message: ToolResultMessage): string {

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -1,16 +1,34 @@
 /**
- * Tests for copyToClipboard's Wayland path (issue 286).
- * Verifies wl-copy is spawned fully detached so its stderr ("Somebody else owns
- * the clipboard now") can never leak into the controlling terminal / TUI.
+ * Tests for copyToClipboard's clipboard-method selection (issue 286).
+ *
+ * Root cause of issue 286: on Linux the native clipboard module (clipboard-rs,
+ * X11 backend) runs an in-process selection-serving thread that prints
+ * "Somebody else owns the clipboard now" to stdout on SelectionClear, leaking
+ * into the TUI. The fix prefers controlled-stdio subprocess tools (wl-copy /
+ * xclip / xsel) on Linux and only falls back to the native module as a last
+ * resort. These tests pin that ordering.
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-// Native clipboard module → null so the platform-tool path is exercised.
-vi.mock("../src/utils/clipboard-native.js", () => ({ clipboard: null }));
+// Mutable state read by the mock factories (hoisted above the mocks).
+const { state } = vi.hoisted(() => ({
+	state: {
+		clipboard: null as null | { setText: (text: string) => Promise<void> },
+		platform: "linux" as NodeJS.Platform,
+		wayland: true,
+	},
+}));
 
-// Force the Wayland branch regardless of the host environment.
-vi.mock("../src/utils/clipboard-image.js", () => ({ isWaylandSession: () => true }));
+// Native clipboard module — getter so tests can toggle availability per case.
+vi.mock("../src/utils/clipboard-native.js", () => ({
+	get clipboard() {
+		return state.clipboard;
+	},
+}));
+
+// Wayland session detection — driven by state.wayland.
+vi.mock("../src/utils/clipboard-image.js", () => ({ isWaylandSession: () => state.wayland }));
 
 // Mock child_process spawn/execSync.
 const spawnMock = vi.fn();
@@ -20,10 +38,10 @@ vi.mock("child_process", () => ({
 	execSync: (...args: unknown[]) => execSyncMock(...args),
 }));
 
-// Force platform() to report linux.
+// platform() reads state.platform so individual tests can switch OS.
 vi.mock("os", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("os")>();
-	return { ...actual, platform: () => "linux" };
+	return { ...actual, platform: () => state.platform };
 });
 
 import { copyToClipboard } from "../src/utils/clipboard.js";
@@ -37,13 +55,18 @@ function makeFakeProc() {
 }
 
 const originalWaylandDisplay = process.env.WAYLAND_DISPLAY;
+const originalX11Display = process.env.DISPLAY;
 const originalTermux = process.env.TERMUX_VERSION;
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	state.clipboard = null;
+	state.platform = "linux";
+	state.wayland = true;
 	process.env.WAYLAND_DISPLAY = "wayland-0";
+	process.env.DISPLAY = ":0";
 	delete process.env.TERMUX_VERSION;
-	// `which wl-copy` succeeds.
+	// `which wl-copy` succeeds by default.
 	execSyncMock.mockReturnValue(Buffer.from(""));
 	// OSC 52 write to stdout — swallow.
 	vi.spyOn(process.stdout, "write").mockReturnValue(true);
@@ -52,6 +75,8 @@ beforeEach(() => {
 afterEach(() => {
 	if (originalWaylandDisplay === undefined) delete process.env.WAYLAND_DISPLAY;
 	else process.env.WAYLAND_DISPLAY = originalWaylandDisplay;
+	if (originalX11Display === undefined) delete process.env.DISPLAY;
+	else process.env.DISPLAY = originalX11Display;
 	if (originalTermux === undefined) delete process.env.TERMUX_VERSION;
 	else process.env.TERMUX_VERSION = originalTermux;
 	vi.restoreAllMocks();
@@ -68,7 +93,8 @@ describe("copyToClipboard — Wayland wl-copy spawn", () => {
 		const [cmd, args, options] = spawnMock.mock.calls[0];
 		expect(cmd).toBe("wl-copy");
 		expect(args).toEqual([]);
-		// detached: true → new session, no controlling terminal → stderr cannot leak.
+		// detached: true → own session, survives our exit; ignored stderr is the
+		// regression guard against any subprocess clipboard chatter.
 		expect(options).toMatchObject({
 			detached: true,
 			stdio: ["pipe", "ignore", "ignore"],
@@ -87,5 +113,50 @@ describe("copyToClipboard — Wayland wl-copy spawn", () => {
 		expect(proc.stdin.end).toHaveBeenCalledTimes(1);
 		// unref so the detached daemon does not keep our event loop alive.
 		expect(proc.unref).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("copyToClipboard — native module ordering (issue 286)", () => {
+	test("on Linux, the native module is NOT used when a CLI tool is available", async () => {
+		const setText = vi.fn().mockResolvedValue(undefined);
+		state.clipboard = { setText };
+		const proc = makeFakeProc();
+		spawnMock.mockReturnValue(proc);
+
+		const result = await copyToClipboard("hello");
+
+		// The leaky native path must be skipped in favor of wl-copy.
+		expect(setText).not.toHaveBeenCalled();
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(spawnMock.mock.calls[0][0]).toBe("wl-copy");
+		expect(result).toEqual({ method: "osc52" });
+	});
+
+	test("on Linux, the native module IS used as a last resort when no CLI tool exists", async () => {
+		const setText = vi.fn().mockResolvedValue(undefined);
+		state.clipboard = { setText };
+		// No Wayland/X11/Termux tooling available.
+		state.wayland = false;
+		delete process.env.WAYLAND_DISPLAY;
+		delete process.env.DISPLAY;
+
+		const result = await copyToClipboard("fallback text");
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("fallback text");
+		expect(result).toEqual({ method: "native" });
+	});
+
+	test("on macOS, the native module is preferred (no serving-thread leak there)", async () => {
+		const setText = vi.fn().mockResolvedValue(undefined);
+		state.clipboard = { setText };
+		state.platform = "darwin";
+
+		const result = await copyToClipboard("mac text");
+
+		expect(setText).toHaveBeenCalledWith("mac text");
+		// pbcopy not reached because native succeeded first.
+		expect(execSyncMock).not.toHaveBeenCalled();
+		expect(result).toEqual({ method: "native" });
 	});
 });

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for copyToClipboard's Wayland path (issue 286).
+ * Verifies wl-copy is spawned fully detached so its stderr ("Somebody else owns
+ * the clipboard now") can never leak into the controlling terminal / TUI.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Native clipboard module → null so the platform-tool path is exercised.
+vi.mock("../src/utils/clipboard-native.js", () => ({ clipboard: null }));
+
+// Force the Wayland branch regardless of the host environment.
+vi.mock("../src/utils/clipboard-image.js", () => ({ isWaylandSession: () => true }));
+
+// Mock child_process spawn/execSync.
+const spawnMock = vi.fn();
+const execSyncMock = vi.fn();
+vi.mock("child_process", () => ({
+	spawn: (...args: unknown[]) => spawnMock(...args),
+	execSync: (...args: unknown[]) => execSyncMock(...args),
+}));
+
+// Force platform() to report linux.
+vi.mock("os", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("os")>();
+	return { ...actual, platform: () => "linux" };
+});
+
+import { copyToClipboard } from "../src/utils/clipboard.js";
+
+function makeFakeProc() {
+	return {
+		stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
+		on: vi.fn(),
+		unref: vi.fn(),
+	};
+}
+
+const originalWaylandDisplay = process.env.WAYLAND_DISPLAY;
+const originalTermux = process.env.TERMUX_VERSION;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env.WAYLAND_DISPLAY = "wayland-0";
+	delete process.env.TERMUX_VERSION;
+	// `which wl-copy` succeeds.
+	execSyncMock.mockReturnValue(Buffer.from(""));
+	// OSC 52 write to stdout — swallow.
+	vi.spyOn(process.stdout, "write").mockReturnValue(true);
+});
+
+afterEach(() => {
+	if (originalWaylandDisplay === undefined) delete process.env.WAYLAND_DISPLAY;
+	else process.env.WAYLAND_DISPLAY = originalWaylandDisplay;
+	if (originalTermux === undefined) delete process.env.TERMUX_VERSION;
+	else process.env.TERMUX_VERSION = originalTermux;
+	vi.restoreAllMocks();
+});
+
+describe("copyToClipboard — Wayland wl-copy spawn", () => {
+	test("spawns wl-copy detached with ignored stdio", async () => {
+		const proc = makeFakeProc();
+		spawnMock.mockReturnValue(proc);
+
+		const result = await copyToClipboard("hello clipboard");
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		const [cmd, args, options] = spawnMock.mock.calls[0];
+		expect(cmd).toBe("wl-copy");
+		expect(args).toEqual([]);
+		// detached: true → new session, no controlling terminal → stderr cannot leak.
+		expect(options).toMatchObject({
+			detached: true,
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		// Reports osc52 since wl-copy success can't be confirmed before unref.
+		expect(result).toEqual({ method: "osc52" });
+	});
+
+	test("writes the payload to wl-copy stdin and unrefs the process", async () => {
+		const proc = makeFakeProc();
+		spawnMock.mockReturnValue(proc);
+
+		await copyToClipboard("payload text");
+
+		expect(proc.stdin.write).toHaveBeenCalledWith("payload text");
+		expect(proc.stdin.end).toHaveBeenCalledTimes(1);
+		// unref so the detached daemon does not keep our event loop alive.
+		expect(proc.unref).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -147,6 +147,38 @@ describe("copyToClipboard — native module ordering (issue 286)", () => {
 		expect(result).toEqual({ method: "native" });
 	});
 
+	test("on Linux with no CLI tool and no native module, degrades to osc52", async () => {
+		// No Wayland/X11/Termux tooling AND native module unavailable.
+		state.clipboard = null;
+		state.wayland = false;
+		delete process.env.WAYLAND_DISPLAY;
+		delete process.env.DISPLAY;
+
+		const result = await copyToClipboard("nowhere to go");
+
+		// Nothing to spawn/exec; the last-resort native branch finds no module and
+		// the function falls through to the always-emitted OSC 52.
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(execSyncMock).not.toHaveBeenCalled();
+		expect(result).toEqual({ method: "osc52" });
+	});
+
+	test("on Linux with no CLI tool and a throwing native module, degrades to osc52", async () => {
+		// Native present as last resort but setText rejects — must not escape; the
+		// swallowed failure falls through to OSC 52 rather than throwing.
+		const setText = vi.fn().mockRejectedValue(new Error("native clipboard unavailable"));
+		state.clipboard = { setText };
+		state.wayland = false;
+		delete process.env.WAYLAND_DISPLAY;
+		delete process.env.DISPLAY;
+
+		const result = await copyToClipboard("native throws");
+
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(setText).toHaveBeenCalledWith("native throws");
+		expect(result).toEqual({ method: "osc52" });
+	});
+
 	test("on macOS, the native module is preferred (no serving-thread leak there)", async () => {
 		const setText = vi.fn().mockResolvedValue(undefined);
 		state.clipboard = { setText };

--- a/packages/coding-agent/test/copy-selector-integration.test.ts
+++ b/packages/coding-agent/test/copy-selector-integration.test.ts
@@ -52,6 +52,29 @@ function makeAssistantMessage(text: string): AssistantMessage {
 	};
 }
 
+function makeAssistantWithThinking(text: string, thinking: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking },
+			{ type: "text", text },
+		],
+		api: "anthropic",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
 function makeImageOnlyMessage(): UserMessage {
 	return {
 		role: "user",
@@ -297,5 +320,46 @@ describe("InteractiveMode.showCopySelector", () => {
 		expect(getDone()).toHaveBeenCalledTimes(1);
 		expect(mockCopyToClipboard).toHaveBeenCalledWith("Text message\n\n---\n\nReply");
 		expect(statusMessages).toContain("Copied 2 messages to clipboard");
+	});
+
+	test("assistant thinking is a separate row; message row excludes thinking", async () => {
+		// Rows built: [0]=user, [1]=Thinking, [2]=Assistant answer
+		const messages = [makeUserMessage("Hi"), makeAssistantWithThinking("Answer", "Reasoning")];
+		const { fakeThis, captured, statusMessages, getDone } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		// Select only the assistant answer row — no thinking
+		await captured.onCopy!([2]);
+
+		expect(getDone()).toHaveBeenCalledTimes(1);
+		expect(mockCopyToClipboard).toHaveBeenCalledWith("Answer");
+		expect(statusMessages).toContain("Copied 1 message to clipboard");
+	});
+
+	test("thinking row copies only the labeled thinking block", async () => {
+		const messages = [makeAssistantWithThinking("Answer", "Reasoning")];
+		const { fakeThis, captured, getDone } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		// Rows: [0]=Thinking, [1]=Assistant answer. Select the thinking row.
+		await captured.onCopy!([0]);
+
+		expect(getDone()).toHaveBeenCalledTimes(1);
+		expect(mockCopyToClipboard).toHaveBeenCalledWith("[thinking]\nReasoning");
+	});
+
+	test("selecting both rows places thinking at the top of the combined copy", async () => {
+		const messages = [makeAssistantWithThinking("Answer", "Reasoning")];
+		const { fakeThis, captured, getDone } = createFakeContext(messages);
+		mockCopyToClipboard.mockResolvedValue({ method: "native" });
+
+		(InteractiveMode as any).prototype.showCopySelector.call(fakeThis);
+		// Rows: [0]=Thinking, [1]=Assistant answer. Select both.
+		await captured.onCopy!([0, 1]);
+
+		expect(getDone()).toHaveBeenCalledTimes(1);
+		expect(mockCopyToClipboard).toHaveBeenCalledWith("[thinking]\nReasoning\n\n---\n\nAnswer");
 	});
 });

--- a/packages/coding-agent/test/copy-selector.test.ts
+++ b/packages/coding-agent/test/copy-selector.test.ts
@@ -26,9 +26,9 @@ function makeItems(count: number): CopyMessageItem[] {
 	const items: CopyMessageItem[] = [];
 	for (let i = 0; i < count; i++) {
 		items.push({
-			index: i,
 			roleLabel: i % 2 === 0 ? "You" : "Assistant",
 			preview: `Message ${i} content here`,
+			text: `Message ${i} full text`,
 		});
 	}
 	return items;
@@ -133,7 +133,7 @@ describe("CopyMessageList", () => {
 		expect(deselectedCount).toBe(0);
 	});
 
-	test("confirm: Enter calls onCopy with sorted selected indices", () => {
+	test("confirm: Enter calls onCopy with sorted selected item positions", () => {
 		const items = makeItems(5);
 		const onCopy = vi.fn();
 		const onCancel = vi.fn();

--- a/packages/coding-agent/test/message-text.test.ts
+++ b/packages/coding-agent/test/message-text.test.ts
@@ -6,7 +6,13 @@ import type {
 	CompactionSummaryMessage,
 	CustomMessage,
 } from "../src/core/messages.js";
-import { extractCopyableText, getMessagePreview, getMessageRoleLabel } from "../src/utils/message-text.js";
+import {
+	extractCopyableText,
+	extractThinkingText,
+	getMessagePreview,
+	getMessageRoleLabel,
+	toSingleLinePreview,
+} from "../src/utils/message-text.js";
 
 // --- Helpers for creating test messages ---
 
@@ -115,21 +121,26 @@ describe("extractCopyableText", () => {
 			expect(extractCopyableText(msg)).toBe("First response\nSecond response");
 		});
 
-		test("thinking blocks included with header", () => {
+		test("thinking blocks are excluded from copyable text", () => {
 			const msg = makeAssistantMessage([
 				{ type: "text", text: "Visible reply" },
 				{ type: "thinking", thinking: "Internal reasoning here" },
 			]);
-			expect(extractCopyableText(msg)).toBe("Visible reply\n[thinking]\nInternal reasoning here");
+			expect(extractCopyableText(msg)).toBe("Visible reply");
 		});
 
-		test("multiple thinking blocks each get header", () => {
+		test("multiple thinking blocks are excluded, only text remains", () => {
 			const msg = makeAssistantMessage([
 				{ type: "thinking", thinking: "Step 1" },
 				{ type: "text", text: "Answer" },
 				{ type: "thinking", thinking: "Step 2" },
 			]);
-			expect(extractCopyableText(msg)).toBe("Answer\n[thinking]\nStep 1\n[thinking]\nStep 2");
+			expect(extractCopyableText(msg)).toBe("Answer");
+		});
+
+		test("thinking-only message has empty copyable text", () => {
+			const msg = makeAssistantMessage([{ type: "thinking", thinking: "Only reasoning, no answer" }]);
+			expect(extractCopyableText(msg)).toBe("");
 		});
 
 		test("toolCall blocks are skipped", () => {
@@ -283,5 +294,57 @@ describe("getMessagePreview", () => {
 	test("trims leading/trailing whitespace", () => {
 		const msg = makeUserMessage("  padded content  ");
 		expect(getMessagePreview(msg)).toBe("padded content");
+	});
+});
+
+// --- extractThinkingText tests ---
+
+describe("extractThinkingText", () => {
+	test("single thinking block returns labeled block", () => {
+		const msg = makeAssistantMessage([
+			{ type: "text", text: "Visible reply" },
+			{ type: "thinking", thinking: "Internal reasoning here" },
+		]);
+		expect(extractThinkingText(msg)).toBe("[thinking]\nInternal reasoning here");
+	});
+
+	test("multiple thinking blocks are joined under a single header", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "Step 1" },
+			{ type: "text", text: "Answer" },
+			{ type: "thinking", thinking: "Step 2" },
+		]);
+		expect(extractThinkingText(msg)).toBe("[thinking]\nStep 1\n\nStep 2");
+	});
+
+	test("assistant message with no thinking returns empty string", () => {
+		const msg = makeAssistantMessage([{ type: "text", text: "Just an answer" }]);
+		expect(extractThinkingText(msg)).toBe("");
+	});
+
+	test("non-assistant messages return empty string", () => {
+		expect(extractThinkingText(makeUserMessage("hello"))).toBe("");
+		expect(extractThinkingText(makeToolResult("read", [{ type: "text", text: "x" }]))).toBe("");
+		expect(extractThinkingText(makeBashExecution("ls", "out"))).toBe("");
+	});
+});
+
+// --- toSingleLinePreview tests ---
+
+describe("toSingleLinePreview", () => {
+	test("empty string returns '[no text content]'", () => {
+		expect(toSingleLinePreview("")).toBe("[no text content]");
+	});
+
+	test("collapses newlines and whitespace", () => {
+		expect(toSingleLinePreview("hello   world\n\n\ntest")).toBe("hello world test");
+	});
+
+	test("truncates to 200 chars", () => {
+		expect(toSingleLinePreview("x".repeat(300)).length).toBe(200);
+	});
+
+	test("trims leading/trailing whitespace", () => {
+		expect(toSingleLinePreview("  padded  ")).toBe("padded");
 	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.30.0",
+	"version": "2.30.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #285
Closes #286

Two tightly-coupled fixes to the `/copy` flow:

- **#285** — `/copy` no longer bundles `[thinking]` reasoning into copied assistant text by default. Thinking becomes its own selectable row in the copy picker.
- **#286** — `wl-copy`'s "Somebody else owns the clipboard now" stderr message no longer leaks into the TUI input region.

Implementation plan posted as a comment below.
