### PR TITLE
Suppress redundant nested-context injection when the tool already delivers the file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -8913,7 +8913,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -8942,7 +8942,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -8998,7 +8998,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -9127,7 +9127,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -9176,7 +9176,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -9209,7 +9209,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.31.0",
+			"version": "2.31.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"engines": {
 		"node": "^22.0.0"
 	},
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/nested-context.ts
+++ b/packages/coding-agent/src/core/nested-context.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { CONTEXT_FILE_CANDIDATES, loadContextFilesFromDir, type ResourceDiagnostic } from "./resource-loader.js";
+import { renderTerminalOutput } from "./tools/terminal-render.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./tools/truncate.js";
 
 /**
@@ -417,7 +418,11 @@ export function resolveBashDeliveredFiles(command: string, workingDir: string): 
 	if (segment.includes("|") || segment.includes(">") || segment.includes("<")) return [];
 	const tokens = segment.trim().split(/\s+/).filter(Boolean);
 	if (tokens.length === 0) return [];
-	const cmd = tokens[0].toLowerCase();
+	// Match the command verb case-sensitively: shell PATH lookup is case-sensitive on
+	// Linux, so `CAT`/`Bat` are command-not-found and emit nothing to stdout. Lowercasing
+	// would let them match the allowlist and falsely suppress a file they never printed —
+	// a silent context drop. Exact matching keeps the failure mode a harmless double-load.
+	const cmd = tokens[0];
 	if (!FULL_DUMP_COMMANDS.has(cmd)) return [];
 	// `bat -r 10:20` / `bat -r10:20` / `bat --line-range=10:20` shows only a range — not a full dump.
 	if (cmd === "bat" && tokens.slice(1).some(isBatRangeFlag)) return [];
@@ -452,13 +457,27 @@ export interface NestedContextState {
  * bytes, while {@link formatNestedContextBlock} is uncapped. If the file exceeds either limit
  * it is delivered truncated, so suppressing (and permanently marking loaded) would silently
  * drop the remainder. Any stat/read failure also returns `false` — the safe double-load.
+ *
+ * `rendered` selects which delivery the measure must mirror:
+ *  - `read` delivers the file's raw content unchanged (`truncateHead` with no transform), so
+ *    the raw byte/line count is exact.
+ *  - `bash` delivers `truncateTail(renderTerminalOutput(...))`, and terminal rendering expands
+ *    tabs to 8-column stops and resolves cursor/ANSI sequences — the rendered output can be
+ *    *larger* than the file on disk. A tab-dense file just under the budget on disk can render
+ *    past it and be tail-truncated (its head dropped) while the raw measure still reports a
+ *    full delivery. Measuring the rendered output keeps the failure mode a harmless double-load
+ *    rather than a silent context drop.
  */
-function deliveredInFull(realPath: string): boolean {
+function deliveredInFull(realPath: string, rendered: boolean): boolean {
 	try {
+		// Cheap early-out: the raw on-disk size is a lower bound on the delivered size
+		// (terminal rendering only ever grows the byte count), so a file already over the
+		// byte budget on disk is certainly delivered truncated.
 		if (statSync(realPath).size > DEFAULT_MAX_BYTES) return false;
-		// Size is within budget (<= 50KB), so reading to count lines is cheap.
-		const lineCount = readFileSync(realPath, "utf8").split("\n").length;
-		return lineCount <= DEFAULT_MAX_LINES;
+		const raw = readFileSync(realPath, "utf8");
+		const delivered = rendered ? renderTerminalOutput(raw) : raw;
+		if (Buffer.byteLength(delivered, "utf-8") > DEFAULT_MAX_BYTES) return false;
+		return delivered.split("\n").length <= DEFAULT_MAX_LINES;
 	} catch {
 		return false;
 	}
@@ -498,10 +517,14 @@ export function computeNestedContextBlock(
 		: null;
 	const suppress: SuppressPredicate = (file) => {
 		const realFile = safeRealpath(file.path);
-		const matched = realFile === realSelfReadFile || (bashDelivered?.has(realFile) ?? false);
 		// Only suppress when the file was delivered *in full*: a truncated delivery (oversized
 		// file) would drop the remainder if we marked it fully loaded and skipped injection.
-		return matched && deliveredInFull(realFile);
+		// `read` delivers the file's raw content unchanged; `bash` delivers it through terminal
+		// rendering (tab/ANSI expansion can grow it past the truncation budget), so each path
+		// measures fullness against what it actually emits.
+		if (realFile === realSelfReadFile) return deliveredInFull(realFile, false);
+		if (bashDelivered?.has(realFile)) return deliveredInFull(realFile, true);
+		return false;
 	};
 
 	const collected = collectNestedContext(targetDir, state.cwd, state.loaded, suppress);

--- a/packages/coding-agent/src/core/nested-context.ts
+++ b/packages/coding-agent/src/core/nested-context.ts
@@ -1,6 +1,6 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { CONTEXT_FILE_CANDIDATES, loadContextFilesFromDir, type ResourceDiagnostic } from "./resource-loader.js";
 
 /**
@@ -225,17 +225,31 @@ function dirHasContextFile(dir: string): boolean {
 }
 
 /**
+ * Predicate deciding whether a collected context file should be *suppressed* from the
+ * injected block because the triggering tool call already delivers its content (e.g. a
+ * `read` of the file itself, or a `bash` command that prints it). Suppressed files are
+ * still marked as loaded so they are never injected later — they are simply not
+ * duplicated into the result that already contains them.
+ */
+export type SuppressPredicate = (file: LoadedContextFile) => boolean;
+
+/**
  * Collect nested context files for `targetDir`, walking up to the ceiling described in
  * {@link resolveWalkDirs}. Files whose realpath is already in `alreadyLoaded` are skipped
  * (and not re-reported). Newly collected realpaths are added to `alreadyLoaded` so the
  * caller's per-session set stays authoritative and each file loads at most once. Also
  * reports whether an existing context file failed to read so callers can retry later
  * instead of negatively caching a transient failure.
+ *
+ * When `suppress` matches a newly-seen file, that file is marked loaded but excluded from
+ * the returned `files` — the triggering tool result already contains it, so re-injecting
+ * would duplicate the content and waste tokens.
  */
 export function collectNestedContext(
 	targetDir: string,
 	cwd: string,
 	alreadyLoaded: Set<string>,
+	suppress?: SuppressPredicate,
 ): NestedContextCollection {
 	const dirs = resolveWalkDirs(targetDir, cwd);
 	const collected: LoadedContextFile[] = [];
@@ -254,6 +268,8 @@ export function collectNestedContext(
 			const real = safeRealpath(file.path);
 			if (alreadyLoaded.has(real)) continue;
 			alreadyLoaded.add(real);
+			// Mark loaded but do not inject: the triggering tool already delivers this file.
+			if (suppress?.(file)) continue;
 			collected.push(file);
 		}
 	}
@@ -281,7 +297,51 @@ export function formatNestedContextBlock(targetDir: string, files: LoadedContext
 	return `${header}\n\n${sections.join("\n\n")}`;
 }
 
-/** Mutable per-session state threaded through {@link computeNestedContextBlock}. */
+/**
+ * Resolve the absolute file path a `read` tool call delivers, or `null` when the tool is
+ * not `read` or has no usable `path`. Only `read` returns the *full* file content, so it
+ * is the only path-tool whose result fully duplicates an injected context file. (`grep`
+ * returns matched lines, `ls`/`edit`/`write` do not echo the whole file — those still
+ * benefit from injection.)
+ */
+export function resolveSelfReadFile(
+	toolName: string,
+	args: Record<string, unknown> | undefined,
+	cwd: string,
+): string | null {
+	if (!args || toolName !== "read") return null;
+	const p = args.path;
+	if (typeof p !== "string" || p.trim() === "") return null;
+	let rawPath: string = p;
+
+	// Expand a leading `~` to the home directory.
+	if (rawPath === "~") {
+		rawPath = homedir();
+	} else if (rawPath.startsWith(`~${sep}`) || rawPath.startsWith("~/")) {
+		rawPath = join(homedir(), rawPath.slice(2));
+	}
+
+	return isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
+}
+
+/** Escape a string for safe use inside a `RegExp`. */
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Whether a `bash` command appears to print/reference a file with the given basename.
+ * Matched case-insensitively with conservative boundaries so an incidental substring
+ * (e.g. `my-agents.md-notes`) does not trigger a false suppression. Callers only ever
+ * test this against basenames of context files that genuinely exist in the walk, so the
+ * blast radius is bounded.
+ */
+export function bashReferencesFilename(command: string, basename: string): boolean {
+	if (typeof command !== "string" || !basename) return false;
+	const re = new RegExp(`(^|[^\\w.\\-])${escapeRegExp(basename)}([^\\w\\-]|$)`, "i");
+	return re.test(command);
+}
+
 export interface NestedContextState {
 	/** Whether auto-loading is enabled (the `context.autoLoadNested` setting). */
 	enabled: boolean;
@@ -312,7 +372,19 @@ export function computeNestedContextBlock(
 	const realTarget = safeRealpath(targetDir);
 	if (state.scannedDirs.has(realTarget)) return null;
 
-	const collected = collectNestedContext(targetDir, state.cwd, state.loaded);
+	// A context file the triggering tool already delivers should be marked loaded but not
+	// re-injected (the result already contains it). Two cases: a `read` of the file itself,
+	// or a `bash` command that prints it (`cat`/`head`/etc.).
+	const selfReadFile = resolveSelfReadFile(toolName, args, state.cwd);
+	const realSelfReadFile = selfReadFile ? safeRealpath(selfReadFile) : null;
+	const bashCommand = toolName === "bash" && typeof args?.command === "string" ? args.command : null;
+	const suppress: SuppressPredicate = (file) => {
+		if (realSelfReadFile && safeRealpath(file.path) === realSelfReadFile) return true;
+		if (bashCommand && bashReferencesFilename(bashCommand, basename(file.path))) return true;
+		return false;
+	};
+
+	const collected = collectNestedContext(targetDir, state.cwd, state.loaded, suppress);
 	if (!collected.hadReadError) {
 		state.scannedDirs.add(realTarget);
 	}

--- a/packages/coding-agent/src/core/nested-context.ts
+++ b/packages/coding-agent/src/core/nested-context.ts
@@ -1,7 +1,8 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { CONTEXT_FILE_CANDIDATES, loadContextFilesFromDir, type ResourceDiagnostic } from "./resource-loader.js";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./tools/truncate.js";
 
 /**
  * Auto-load of nested AGENTS.md/CLAUDE.md context files.
@@ -317,6 +318,11 @@ export function resolveSelfReadFile(
 	cwd: string,
 ): string | null {
 	if (!args || toolName !== "read") return null;
+	// A sliced read (`offset`/`limit`) delivers only a fragment of the file — the same
+	// hazard for which bash partial viewers (`head`/`tail`) are excluded. Treating it as a
+	// full delivery would suppress (and permanently mark loaded) a file the result only
+	// partially contains, silently dropping the rest. Fall back to the safe double-load.
+	if (args.offset !== undefined || args.limit !== undefined) return null;
 	const p = args.path;
 	if (typeof p !== "string" || p.trim() === "") return null;
 	return expandToAbsolute(p, cwd);
@@ -328,8 +334,15 @@ export function resolveSelfReadFile(
  * interactive pagers (`less`/`more`) are excluded — they may show only a fragment, so
  * treating them as "delivered" could silently drop the rest of a context file. The safe
  * failure mode is a harmless double-load (we still inject), never a silent context drop.
+ *
+ * `bat` is included but is *not* unconditionally a full dump: its `-r`/`--line-range` flag
+ * emits only a range (same hazard as `head`/`tail`). Segments carrying that flag are
+ * disqualified in {@link resolveBashDeliveredFiles}.
  */
 const FULL_DUMP_COMMANDS = new Set(["cat", "bat"]);
+
+/** `bat` flags that limit output to a partial range — disqualify the segment if present. */
+const BAT_RANGE_FLAGS = ["-r", "--line-range"];
 
 /** Strip a single layer of matching surrounding quotes from a shell token. */
 function unquoteToken(token: string): string {
@@ -348,23 +361,41 @@ function unquoteToken(token: string): string {
  * full-dump command (`cat`/`bat`). Path arguments are resolved against `workingDir` (the
  * command's effective cwd — e.g. a leading `cd` target). Conservative on purpose:
  *
- *  - Segments are split on `&&`, `||`, `;`. A segment containing a pipe (`|`) or output
- *    redirection (`>`) is skipped — its output is filtered or redirected, so the raw file
- *    is not what lands in the result.
+ *  - Segments are split on `&&`, `||`, `;`. A segment containing a pipe (`|`), output
+ *    redirection (`>`), or input redirection / here-doc / here-string (`<`, `<<`, `<<<`)
+ *    is skipped — its output is filtered/redirected, or its operands are stdin body words
+ *    rather than dumped files.
  *  - Only a segment whose first token is `cat`/`bat` contributes; flags (`-…`) are ignored.
+ *  - A `bat` segment carrying a partial-range flag (`-r`/`--line-range`) is skipped — it
+ *    emits only a fragment, like `head`/`tail`.
+ *  - If the command chains more than one `cd`, the effective cwd is ambiguous (we only
+ *    resolved the *first* `cd`), so operands cannot be resolved reliably — return nothing.
  *
  * Anything we cannot confidently classify as a full delivery is omitted, so the worst case
  * is a double-load rather than a silently dropped context file.
  */
 export function resolveBashDeliveredFiles(command: string, workingDir: string): string[] {
 	if (typeof command !== "string" || command.trim() === "") return [];
+	const segments = command.split(/&&|\|\||;/);
+
+	// More than one `cd` means the effective cwd differs from the first `cd` target we
+	// resolved as `workingDir`; resolving operands against it would suppress the wrong
+	// (same-named) file. Bail to the safe double-load.
+	const cdCount = segments.filter((s) => /^\s*cd(\s|$)/.test(s)).length;
+	if (cdCount > 1) return [];
+
 	const files: string[] = [];
-	for (const segment of command.split(/&&|\|\||;/)) {
-		// Output piped into another command or redirected to a file is not the raw file.
-		if (segment.includes("|") || segment.includes(">")) continue;
+	for (const segment of segments) {
+		// Output piped/redirected, or operands fed via input redirection / here-doc, are
+		// not raw file dumps to stdout.
+		if (segment.includes("|") || segment.includes(">") || segment.includes("<")) continue;
 		const tokens = segment.trim().split(/\s+/).filter(Boolean);
 		if (tokens.length === 0) continue;
-		if (!FULL_DUMP_COMMANDS.has(tokens[0].toLowerCase())) continue;
+		const cmd = tokens[0].toLowerCase();
+		if (!FULL_DUMP_COMMANDS.has(cmd)) continue;
+		// `bat -r 10:20` / `bat --line-range=10:20` shows only a range — not a full dump.
+		if (cmd === "bat" && tokens.slice(1).some((t) => BAT_RANGE_FLAGS.some((f) => t === f || t.startsWith(`${f}=`))))
+			continue;
 		for (const token of tokens.slice(1)) {
 			if (token.startsWith("-")) continue; // flag, not a file argument
 			const arg = unquoteToken(token);
@@ -384,6 +415,24 @@ export interface NestedContextState {
 	loaded: Set<string>;
 	/** Realpaths of directories already scanned (negative cache). Mutated. */
 	scannedDirs: Set<string>;
+}
+
+/**
+ * Whether a tool that delivers `realPath` actually delivers its *full* content. Both `read`
+ * and `bash` truncate their output at {@link DEFAULT_MAX_LINES} lines / {@link DEFAULT_MAX_BYTES}
+ * bytes, while {@link formatNestedContextBlock} is uncapped. If the file exceeds either limit
+ * it is delivered truncated, so suppressing (and permanently marking loaded) would silently
+ * drop the remainder. Any stat/read failure also returns `false` — the safe double-load.
+ */
+function deliveredInFull(realPath: string): boolean {
+	try {
+		if (statSync(realPath).size > DEFAULT_MAX_BYTES) return false;
+		// Size is within budget (<= 50KB), so reading to count lines is cheap.
+		const lineCount = readFileSync(realPath, "utf8").split("\n").length;
+		return lineCount <= DEFAULT_MAX_LINES;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -420,9 +469,10 @@ export function computeNestedContextBlock(
 		: null;
 	const suppress: SuppressPredicate = (file) => {
 		const realFile = safeRealpath(file.path);
-		if (realSelfReadFile && realFile === realSelfReadFile) return true;
-		if (bashDelivered?.has(realFile)) return true;
-		return false;
+		const matched = realFile === realSelfReadFile || (bashDelivered?.has(realFile) ?? false);
+		// Only suppress when the file was delivered *in full*: a truncated delivery (oversized
+		// file) would drop the remainder if we marked it fully loaded and skipped injection.
+		return matched && deliveredInFull(realFile);
 	};
 
 	const collected = collectNestedContext(targetDir, state.cwd, state.loaded, suppress);

--- a/packages/coding-agent/src/core/nested-context.ts
+++ b/packages/coding-agent/src/core/nested-context.ts
@@ -344,6 +344,18 @@ const FULL_DUMP_COMMANDS = new Set(["cat", "bat"]);
 /** `bat` flags that limit output to a partial range — disqualify the segment if present. */
 const BAT_RANGE_FLAGS = ["-r", "--line-range"];
 
+/**
+ * Whether a `bat` token requests a partial line range. Matches the space-separated form
+ * (`-r`, `--line-range`), the `=`-attached long form (`--line-range=10:20`), and the
+ * attached short form (`-r10:20`) — clap accepts an attached value on a short flag, so a
+ * bare `startsWith` check on each known range flag covers every spelling. A partial range
+ * is the same hazard as `head`/`tail`: only a fragment is emitted, so the segment must not
+ * be treated as a full dump.
+ */
+function isBatRangeFlag(token: string): boolean {
+	return BAT_RANGE_FLAGS.some((flag) => token.startsWith(flag));
+}
+
 /** Strip a single layer of matching surrounding quotes from a shell token. */
 function unquoteToken(token: string): string {
 	if (token.length >= 2) {
@@ -361,13 +373,22 @@ function unquoteToken(token: string): string {
  * full-dump command (`cat`/`bat`). Path arguments are resolved against `workingDir` (the
  * command's effective cwd — e.g. a leading `cd` target). Conservative on purpose:
  *
- *  - Segments are split on `&&`, `||`, `;`. A segment containing a pipe (`|`), output
- *    redirection (`>`), or input redirection / here-doc / here-string (`<`, `<<`, `<<<`)
- *    is skipped — its output is filtered/redirected, or its operands are stdin body words
- *    rather than dumped files.
- *  - Only a segment whose first token is `cat`/`bat` contributes; flags (`-…`) are ignored.
- *  - A `bat` segment carrying a partial-range flag (`-r`/`--line-range`) is skipped — it
- *    emits only a fragment, like `head`/`tail`.
+ *  - Segments are split on `&&`, `||`, `;`. Segments that are *only* a `cd` produce no
+ *    stdout and are ignored, but there must be **exactly one** remaining output-producing
+ *    segment. The bash tool truncates its *combined* command output from the **tail**
+ *    (keeping the last {@link DEFAULT_MAX_LINES} lines / {@link DEFAULT_MAX_BYTES} bytes and
+ *    dropping the head), so any *additional* output-producing segment could evict the dumped
+ *    file from the visible window while {@link deliveredInFull} — which measures the file
+ *    alone — still reports a full delivery. Bail to the safe double-load in that case.
+ *  - That sole segment must not contain a pipe (`|`), output redirection (`>`), or input
+ *    redirection / here-doc / here-string (`<`, `<<`, `<<<`) — its output is filtered /
+ *    redirected, or its operands are stdin body words rather than dumped files.
+ *  - Its first token must be `cat`/`bat`; flags (`-…`) are ignored.
+ *  - A `bat` segment carrying a partial-range flag (`-r`/`--line-range`, any spelling) is
+ *    skipped — it emits only a fragment, like `head`/`tail`.
+ *  - It must have **exactly one** file operand. A multi-file dump (`cat A.md B.md`)
+ *    concatenates several files; under tail truncation an earlier operand can be evicted
+ *    while still appearing fully sized on disk, so it is not a provable full delivery.
  *  - If the command chains more than one `cd`, the effective cwd is ambiguous (we only
  *    resolved the *first* `cd`), so operands cannot be resolved reliably — return nothing.
  *
@@ -377,33 +398,41 @@ function unquoteToken(token: string): string {
 export function resolveBashDeliveredFiles(command: string, workingDir: string): string[] {
 	if (typeof command !== "string" || command.trim() === "") return [];
 	const segments = command.split(/&&|\|\||;/);
+	const isCdSegment = (s: string) => /^\s*cd(\s|$)/.test(s);
 
 	// More than one `cd` means the effective cwd differs from the first `cd` target we
 	// resolved as `workingDir`; resolving operands against it would suppress the wrong
 	// (same-named) file. Bail to the safe double-load.
-	const cdCount = segments.filter((s) => /^\s*cd(\s|$)/.test(s)).length;
-	if (cdCount > 1) return [];
+	if (segments.filter(isCdSegment).length > 1) return [];
 
-	const files: string[] = [];
-	for (const segment of segments) {
-		// Output piped/redirected, or operands fed via input redirection / here-doc, are
-		// not raw file dumps to stdout.
-		if (segment.includes("|") || segment.includes(">") || segment.includes("<")) continue;
-		const tokens = segment.trim().split(/\s+/).filter(Boolean);
-		if (tokens.length === 0) continue;
-		const cmd = tokens[0].toLowerCase();
-		if (!FULL_DUMP_COMMANDS.has(cmd)) continue;
-		// `bat -r 10:20` / `bat --line-range=10:20` shows only a range — not a full dump.
-		if (cmd === "bat" && tokens.slice(1).some((t) => BAT_RANGE_FLAGS.some((f) => t === f || t.startsWith(`${f}=`))))
-			continue;
-		for (const token of tokens.slice(1)) {
-			if (token.startsWith("-")) continue; // flag, not a file argument
-			const arg = unquoteToken(token);
-			if (arg === "") continue;
-			files.push(expandToAbsolute(arg, workingDir));
-		}
+	// Segments that are only a `cd` emit no stdout. Everything else produces output, and
+	// because the bash tool tail-truncates the *combined* output, a context file is only
+	// provably delivered in full when it is the command's *sole* output-producing segment.
+	const outputSegments = segments.filter((s) => s.trim() !== "" && !isCdSegment(s));
+	if (outputSegments.length !== 1) return [];
+
+	const segment = outputSegments[0];
+	// Output piped/redirected, or operands fed via input redirection / here-doc, are not raw
+	// file dumps to stdout.
+	if (segment.includes("|") || segment.includes(">") || segment.includes("<")) return [];
+	const tokens = segment.trim().split(/\s+/).filter(Boolean);
+	if (tokens.length === 0) return [];
+	const cmd = tokens[0].toLowerCase();
+	if (!FULL_DUMP_COMMANDS.has(cmd)) return [];
+	// `bat -r 10:20` / `bat -r10:20` / `bat --line-range=10:20` shows only a range — not a full dump.
+	if (cmd === "bat" && tokens.slice(1).some(isBatRangeFlag)) return [];
+
+	const operands: string[] = [];
+	for (const token of tokens.slice(1)) {
+		if (token.startsWith("-")) continue; // flag, not a file argument
+		const arg = unquoteToken(token);
+		if (arg === "") continue;
+		operands.push(arg);
 	}
-	return files;
+	// A single operand is the only provable full delivery: multi-file dumps concatenate,
+	// and tail truncation can evict an earlier file while it still looks fully sized.
+	if (operands.length !== 1) return [];
+	return [expandToAbsolute(operands[0], workingDir)];
 }
 
 export interface NestedContextState {

--- a/packages/coding-agent/src/core/nested-context.ts
+++ b/packages/coding-agent/src/core/nested-context.ts
@@ -1,6 +1,6 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { CONTEXT_FILE_CANDIDATES, loadContextFilesFromDir, type ResourceDiagnostic } from "./resource-loader.js";
 
 /**
@@ -83,6 +83,20 @@ export function parseLeadingCd(command: string): string | null {
 }
 
 /**
+ * Expand a leading `~` to the home directory and resolve a raw path string to an absolute
+ * path against `baseDir`. Shared by every place that turns a user-supplied path token into
+ * an absolute path (`resolveTargetDir`, `resolveSelfReadFile`, bash argument resolution).
+ */
+function expandToAbsolute(rawPath: string, baseDir: string): string {
+	if (rawPath === "~") {
+		rawPath = homedir();
+	} else if (rawPath.startsWith(`~${sep}`) || rawPath.startsWith("~/")) {
+		rawPath = join(homedir(), rawPath.slice(2));
+	}
+	return isAbsolute(rawPath) ? rawPath : resolve(baseDir, rawPath);
+}
+
+/**
  * Resolve the absolute directory a tool call is about to operate in, or `null` when the
  * tool/argument shape does not identify a directory we should react to.
  */
@@ -106,14 +120,7 @@ export function resolveTargetDir(
 
 	if (!rawPath) return null;
 
-	// Expand a leading `~` to the home directory.
-	if (rawPath === "~") {
-		rawPath = homedir();
-	} else if (rawPath.startsWith(`~${sep}`) || rawPath.startsWith("~/")) {
-		rawPath = join(homedir(), rawPath.slice(2));
-	}
-
-	const absolute = isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
+	const absolute = expandToAbsolute(rawPath, cwd);
 
 	// For path-bearing tools the argument is usually a file; for bash `cd` it is a
 	// directory. Resolve to a directory: existing dirs are used as-is, everything else
@@ -312,34 +319,60 @@ export function resolveSelfReadFile(
 	if (!args || toolName !== "read") return null;
 	const p = args.path;
 	if (typeof p !== "string" || p.trim() === "") return null;
-	let rawPath: string = p;
-
-	// Expand a leading `~` to the home directory.
-	if (rawPath === "~") {
-		rawPath = homedir();
-	} else if (rawPath.startsWith(`~${sep}`) || rawPath.startsWith("~/")) {
-		rawPath = join(homedir(), rawPath.slice(2));
-	}
-
-	return isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
-}
-
-/** Escape a string for safe use inside a `RegExp`. */
-function escapeRegExp(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return expandToAbsolute(p, cwd);
 }
 
 /**
- * Whether a `bash` command appears to print/reference a file with the given basename.
- * Matched case-insensitively with conservative boundaries so an incidental substring
- * (e.g. `my-agents.md-notes`) does not trigger a false suppression. Callers only ever
- * test this against basenames of context files that genuinely exist in the walk, so the
- * blast radius is bounded.
+ * Bash commands that dump a file's *full* contents to stdout. Deliberately narrow: only
+ * commands that emit the whole file qualify. Partial viewers (`head`/`tail`) and
+ * interactive pagers (`less`/`more`) are excluded — they may show only a fragment, so
+ * treating them as "delivered" could silently drop the rest of a context file. The safe
+ * failure mode is a harmless double-load (we still inject), never a silent context drop.
  */
-export function bashReferencesFilename(command: string, basename: string): boolean {
-	if (typeof command !== "string" || !basename) return false;
-	const re = new RegExp(`(^|[^\\w.\\-])${escapeRegExp(basename)}([^\\w\\-]|$)`, "i");
-	return re.test(command);
+const FULL_DUMP_COMMANDS = new Set(["cat", "bat"]);
+
+/** Strip a single layer of matching surrounding quotes from a shell token. */
+function unquoteToken(token: string): string {
+	if (token.length >= 2) {
+		const first = token[0];
+		const last = token[token.length - 1];
+		if ((first === '"' || first === "'") && first === last) {
+			return token.slice(1, -1);
+		}
+	}
+	return token;
+}
+
+/**
+ * Resolve the absolute paths of files a bash command fully delivers to stdout via a
+ * full-dump command (`cat`/`bat`). Path arguments are resolved against `workingDir` (the
+ * command's effective cwd — e.g. a leading `cd` target). Conservative on purpose:
+ *
+ *  - Segments are split on `&&`, `||`, `;`. A segment containing a pipe (`|`) or output
+ *    redirection (`>`) is skipped — its output is filtered or redirected, so the raw file
+ *    is not what lands in the result.
+ *  - Only a segment whose first token is `cat`/`bat` contributes; flags (`-…`) are ignored.
+ *
+ * Anything we cannot confidently classify as a full delivery is omitted, so the worst case
+ * is a double-load rather than a silently dropped context file.
+ */
+export function resolveBashDeliveredFiles(command: string, workingDir: string): string[] {
+	if (typeof command !== "string" || command.trim() === "") return [];
+	const files: string[] = [];
+	for (const segment of command.split(/&&|\|\||;/)) {
+		// Output piped into another command or redirected to a file is not the raw file.
+		if (segment.includes("|") || segment.includes(">")) continue;
+		const tokens = segment.trim().split(/\s+/).filter(Boolean);
+		if (tokens.length === 0) continue;
+		if (!FULL_DUMP_COMMANDS.has(tokens[0].toLowerCase())) continue;
+		for (const token of tokens.slice(1)) {
+			if (token.startsWith("-")) continue; // flag, not a file argument
+			const arg = unquoteToken(token);
+			if (arg === "") continue;
+			files.push(expandToAbsolute(arg, workingDir));
+		}
+	}
+	return files;
 }
 
 export interface NestedContextState {
@@ -374,13 +407,21 @@ export function computeNestedContextBlock(
 
 	// A context file the triggering tool already delivers should be marked loaded but not
 	// re-injected (the result already contains it). Two cases: a `read` of the file itself,
-	// or a `bash` command that prints it (`cat`/`head`/etc.).
+	// or a `bash` command that dumps its full contents (`cat`/`bat`). Both are matched by
+	// full resolved realpath — never by basename — so printing one file never suppresses a
+	// same-named sibling/ancestor or a file in a different directory.
 	const selfReadFile = resolveSelfReadFile(toolName, args, state.cwd);
 	const realSelfReadFile = selfReadFile ? safeRealpath(selfReadFile) : null;
 	const bashCommand = toolName === "bash" && typeof args?.command === "string" ? args.command : null;
+	// Bash file arguments resolve against the command's effective cwd, which `resolveTargetDir`
+	// has already computed as `targetDir` (the leading `cd` destination).
+	const bashDelivered = bashCommand
+		? new Set(resolveBashDeliveredFiles(bashCommand, targetDir).map(safeRealpath))
+		: null;
 	const suppress: SuppressPredicate = (file) => {
-		if (realSelfReadFile && safeRealpath(file.path) === realSelfReadFile) return true;
-		if (bashCommand && bashReferencesFilename(bashCommand, basename(file.path))) return true;
+		const realFile = safeRealpath(file.path);
+		if (realSelfReadFile && realFile === realSelfReadFile) return true;
+		if (bashDelivered?.has(realFile)) return true;
 		return false;
 	};
 

--- a/packages/coding-agent/test/nested-context.test.ts
+++ b/packages/coding-agent/test/nested-context.test.ts
@@ -598,6 +598,33 @@ describe("computeNestedContextBlock (orchestration)", () => {
 		);
 	});
 
+	it("still injects a context file that is over the byte budget but under the line limit", () => {
+		// A few-line file larger than 50KB (one very long line) is delivered truncated by
+		// both `read` and `cat`, so the byte-size guard in deliveredInFull must still inject.
+		writeFileSync(join(sub, "CLAUDE.md"), `# sub context\n${"x".repeat(60_000)}`);
+		const readState = freshState();
+		expect(computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, readState)).toContain("# sub context");
+		const bashState = freshState();
+		expect(computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, bashState)).toContain(
+			"# sub context",
+		);
+	});
+
+	it("still injects when a bash dump is followed by other output (tail truncation hazard)", () => {
+		// `cat CLAUDE.md && npm test` can push the dumped file out of the tail-truncated
+		// window, so it must not be suppressed — only a sole single-file dump qualifies.
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md && echo done` }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("still injects when bat shows only a partial range via an attached short flag", () => {
+		// `bat -r10:20` (attached value) emits only a range, like `head`/`tail`.
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && bat -r10:20 CLAUDE.md` }, state);
+		expect(block).toContain("# sub context");
+	});
+
 	it("does not suppress a sibling .claude/CLAUDE.md when a top-level CLAUDE.md is dumped", () => {
 		// `.claude/CLAUDE.md`'s basename collapses to CLAUDE.md, but it is a different file
 		// than `sub/CLAUDE.md`; full-path matching must keep them distinct.
@@ -664,8 +691,18 @@ describe("resolveBashDeliveredFiles", () => {
 		expect(resolveBashDeliveredFiles("cat CLAUDE.md", "/proj/sub")).toEqual(["/proj/sub/CLAUDE.md"]);
 	});
 
-	it("resolves multiple files dumped by one command", () => {
-		expect(resolveBashDeliveredFiles("cat A.md B.md", "/proj")).toEqual(["/proj/A.md", "/proj/B.md"]);
+	it("does not treat a multi-file dump as a full delivery (tail truncation can evict an earlier file)", () => {
+		// The bash tool tail-truncates the *combined* output, so `cat A.md B.md` cannot
+		// guarantee A.md survived. Only a single-operand dump is a provable full delivery.
+		expect(resolveBashDeliveredFiles("cat A.md B.md", "/proj")).toEqual([]);
+	});
+
+	it("does not treat a dump followed by other output as a full delivery", () => {
+		// `cat CLAUDE.md && npm test` floods the tail with test output; the dumped file can
+		// be truncated away from the visible window, so it must not be suppressed.
+		expect(resolveBashDeliveredFiles("cat CLAUDE.md && npm test", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("cat CLAUDE.md && echo done", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("echo start && cat CLAUDE.md", "/proj")).toEqual([]);
 	});
 
 	it("returns an absolute argument unchanged", () => {
@@ -724,6 +761,8 @@ describe("resolveBashDeliveredFiles", () => {
 		expect(resolveBashDeliveredFiles("bat -r 10:20 CLAUDE.md", "/proj")).toEqual([]);
 		expect(resolveBashDeliveredFiles("bat --line-range 10:20 CLAUDE.md", "/proj")).toEqual([]);
 		expect(resolveBashDeliveredFiles("bat --line-range=10:20 CLAUDE.md", "/proj")).toEqual([]);
+		// Attached short-flag form (`-r10:20`) — clap accepts an attached value.
+		expect(resolveBashDeliveredFiles("bat -r10:20 CLAUDE.md", "/proj")).toEqual([]);
 	});
 
 	it("collects a cat that follows a leading cd segment", () => {

--- a/packages/coding-agent/test/nested-context.test.ts
+++ b/packages/coding-agent/test/nested-context.test.ts
@@ -3,11 +3,13 @@ import { homedir, tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	bashReferencesFilename,
 	collectNestedContext,
 	computeNestedContextBlock,
 	formatNestedContextBlock,
 	type NestedContextState,
 	parseLeadingCd,
+	resolveSelfReadFile,
 	resolveTargetDir,
 } from "../src/core/nested-context.js";
 
@@ -391,6 +393,124 @@ describe("computeNestedContextBlock (orchestration)", () => {
 	it("returns null for tool calls that do not resolve to a directory", () => {
 		expect(computeNestedContextBlock("bash", { command: "ls -la" }, freshState())).toBeNull();
 		expect(computeNestedContextBlock("tasks_update", { tasks: [] }, freshState())).toBeNull();
+	});
+
+	it("does not duplicate a context file the read tool itself delivers", () => {
+		const state = freshState();
+		// The first action in `sub` is to read its own CLAUDE.md — the read result already
+		// contains it, so the injected block must not duplicate it.
+		const block = computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, state);
+		expect(block).toBeNull();
+		// Still marked loaded (never re-injected) and the dir is still negatively cached.
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+		expect(state.scannedDirs.has(realpathSync(sub))).toBe(true);
+	});
+
+	it("still injects an ancestor context file when reading a nested context file", () => {
+		// Ancestor (cwd) also has an unloaded context file.
+		writeFileSync(join(cwd, "AGENTS.md"), "# root context");
+		const state = freshState();
+		const block = computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, state);
+		// sub/CLAUDE.md is suppressed (read delivers it) but the ancestor is still injected.
+		expect(block).not.toBeNull();
+		expect(block).toContain("# root context");
+		expect(block).not.toContain("# sub context");
+		// Both files end up marked loaded.
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+		expect(state.loaded.has(realpathSync(join(cwd, "AGENTS.md")))).toBe(true);
+	});
+
+	it("does not duplicate a context file a bash command prints", () => {
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, state);
+		expect(block).toBeNull();
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+		expect(state.scannedDirs.has(realpathSync(sub))).toBe(true);
+	});
+
+	it("only suppresses the context file a bash command names, injecting siblings", () => {
+		writeFileSync(join(sub, "AGENTS.md"), "# sub agents");
+		const state = freshState();
+		// Command prints AGENTS.md only — CLAUDE.md must still be injected.
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && head AGENTS.md` }, state);
+		expect(block).not.toBeNull();
+		expect(block).toContain("# sub context");
+		expect(block).not.toContain("# sub agents");
+		expect(state.loaded.has(realpathSync(join(sub, "AGENTS.md")))).toBe(true);
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+	});
+
+	it("still injects when a bash command only cds without printing the context file", () => {
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && ls -la` }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("still injects when the read tool targets a non-context file", () => {
+		const state = freshState();
+		const block = computeNestedContextBlock("read", { path: join(sub, "file.py") }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	itIfSymlinksApply("suppresses a context file read through a symlinked path", () => {
+		const realSub = join(cwd, "real-ctx");
+		const linkedSub = join(cwd, "linked-ctx");
+		mkdirSync(realSub, { recursive: true });
+		writeFileSync(join(realSub, "CLAUDE.md"), "# linked context");
+		symlinkSync(realSub, linkedSub, "dir");
+
+		const state = freshState();
+		const block = computeNestedContextBlock("read", { path: join(linkedSub, "CLAUDE.md") }, state);
+		expect(block).toBeNull();
+		expect(state.loaded.has(realpathSync(join(realSub, "CLAUDE.md")))).toBe(true);
+	});
+});
+
+describe("resolveSelfReadFile", () => {
+	it("resolves a relative read path against cwd", () => {
+		expect(resolveSelfReadFile("read", { path: "sub/CLAUDE.md" }, "/proj")).toBe("/proj/sub/CLAUDE.md");
+	});
+
+	it("returns an absolute read path unchanged", () => {
+		expect(resolveSelfReadFile("read", { path: "/a/AGENTS.md" }, "/proj")).toBe("/a/AGENTS.md");
+	});
+
+	it("expands a leading ~", () => {
+		expect(resolveSelfReadFile("read", { path: "~/x/CLAUDE.md" }, "/proj")).toBe(join(homedir(), "x/CLAUDE.md"));
+	});
+
+	it("returns null for non-read tools (they do not echo the full file)", () => {
+		expect(resolveSelfReadFile("grep", { path: "/a/CLAUDE.md" }, "/proj")).toBeNull();
+		expect(resolveSelfReadFile("ls", { path: "/a" }, "/proj")).toBeNull();
+		expect(resolveSelfReadFile("bash", { command: "cat x" }, "/proj")).toBeNull();
+	});
+
+	it("returns null when path is missing or empty", () => {
+		expect(resolveSelfReadFile("read", {}, "/proj")).toBeNull();
+		expect(resolveSelfReadFile("read", { path: "   " }, "/proj")).toBeNull();
+	});
+});
+
+describe("bashReferencesFilename", () => {
+	it("matches a filename printed by cat", () => {
+		expect(bashReferencesFilename("cd /x && cat CLAUDE.md", "CLAUDE.md")).toBe(true);
+	});
+
+	it("matches case-insensitively", () => {
+		expect(bashReferencesFilename("cat claude.md", "CLAUDE.md")).toBe(true);
+	});
+
+	it("matches a path-qualified reference", () => {
+		expect(bashReferencesFilename("head ./sub/AGENTS.md", "AGENTS.md")).toBe(true);
+	});
+
+	it("does not match an incidental longer token", () => {
+		expect(bashReferencesFilename("cat my-claude.md-notes.txt", "CLAUDE.md")).toBe(false);
+	});
+
+	it("returns false for an empty command or basename", () => {
+		expect(bashReferencesFilename("", "CLAUDE.md")).toBe(false);
+		expect(bashReferencesFilename("cat x", "")).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/nested-context.test.ts
+++ b/packages/coding-agent/test/nested-context.test.ts
@@ -3,12 +3,12 @@ import { homedir, tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	bashReferencesFilename,
 	collectNestedContext,
 	computeNestedContextBlock,
 	formatNestedContextBlock,
 	type NestedContextState,
 	parseLeadingCd,
+	resolveBashDeliveredFiles,
 	resolveSelfReadFile,
 	resolveTargetDir,
 } from "../src/core/nested-context.js";
@@ -428,16 +428,107 @@ describe("computeNestedContextBlock (orchestration)", () => {
 		expect(state.scannedDirs.has(realpathSync(sub))).toBe(true);
 	});
 
-	it("only suppresses the context file a bash command names, injecting siblings", () => {
+	it("only suppresses the context file a bash command dumps, injecting siblings", () => {
 		writeFileSync(join(sub, "AGENTS.md"), "# sub agents");
 		const state = freshState();
-		// Command prints AGENTS.md only — CLAUDE.md must still be injected.
-		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && head AGENTS.md` }, state);
+		// Command dumps AGENTS.md only — CLAUDE.md must still be injected.
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat AGENTS.md` }, state);
 		expect(block).not.toBeNull();
 		expect(block).toContain("# sub context");
 		expect(block).not.toContain("# sub agents");
 		expect(state.loaded.has(realpathSync(join(sub, "AGENTS.md")))).toBe(true);
 		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+	});
+
+	it("still injects when a bash command names a context file with a non-dumping verb", () => {
+		// grep/rm/wc/git-add/stat/ls reference the file but do NOT deliver its full content,
+		// so the context must still be injected rather than silently suppressed.
+		for (const command of [
+			`cd ${sub} && grep TODO CLAUDE.md`,
+			`cd ${sub} && rm CLAUDE.md`,
+			`cd ${sub} && wc -l CLAUDE.md`,
+			`cd ${sub} && git add CLAUDE.md`,
+			`cd ${sub} && stat CLAUDE.md`,
+			`cd ${sub} && ls -la CLAUDE.md`,
+		]) {
+			const state = freshState();
+			const block = computeNestedContextBlock("bash", { command }, state);
+			expect(block, command).toContain("# sub context");
+		}
+	});
+
+	it("still injects when a bash command only partially dumps the file (head/tail)", () => {
+		// head/tail/less/more may show only a fragment; suppressing would silently drop the rest.
+		for (const verb of ["head", "tail", "head -n 5", "less", "more"]) {
+			const state = freshState();
+			const block = computeNestedContextBlock("bash", { command: `cd ${sub} && ${verb} CLAUDE.md` }, state);
+			expect(block, verb).toContain("# sub context");
+		}
+	});
+
+	it("still injects when the dumped output is piped or redirected away", () => {
+		for (const command of [`cd ${sub} && cat CLAUDE.md | grep TODO`, `cd ${sub} && cat CLAUDE.md > out.txt`]) {
+			const state = freshState();
+			const block = computeNestedContextBlock("bash", { command }, state);
+			expect(block, command).toContain("# sub context");
+		}
+	});
+
+	it("does not drop a same-named ancestor when a nested context file is dumped", () => {
+		// Both cwd and sub have a CLAUDE.md (same basename, different dirs).
+		writeFileSync(join(cwd, "CLAUDE.md"), "# root context");
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, state);
+		// sub/CLAUDE.md is suppressed (the command dumped it) but the ancestor is still injected.
+		expect(block).not.toBeNull();
+		expect(block).toContain("# root context");
+		expect(block).not.toContain("# sub context");
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+		expect(state.loaded.has(realpathSync(join(cwd, "CLAUDE.md")))).toBe(true);
+	});
+
+	it("does not suppress a same-named file dumped from a different directory", () => {
+		// Command cds into sub but dumps a CLAUDE.md from an unrelated absolute path.
+		const other = join(tempDir, "other");
+		mkdirSync(other, { recursive: true });
+		writeFileSync(join(other, "CLAUDE.md"), "# other context");
+		const state = freshState();
+		const block = computeNestedContextBlock(
+			"bash",
+			{ command: `cd ${sub} && cat ${join(other, "CLAUDE.md")}` },
+			state,
+		);
+		// sub/CLAUDE.md was not the file dumped, so it must still be injected.
+		expect(block).toContain("# sub context");
+	});
+
+	it("does not suppress the real context file when a derived (.bak) copy is dumped", () => {
+		writeFileSync(join(sub, "CLAUDE.md.bak"), "# stale backup");
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md.bak` }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("does not suppress a .dreb/CONTEXT.md when a top-level CONTEXT.md is dumped", () => {
+		// The subdir candidate's basename collapses to CONTEXT.md, but it is a different
+		// file than `sub/CONTEXT.md`, so dumping the latter must not suppress the former.
+		mkdirSync(join(sub, ".dreb"), { recursive: true });
+		writeFileSync(join(sub, ".dreb", "CONTEXT.md"), "# dreb context");
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CONTEXT.md` }, state);
+		expect(block).toContain("# dreb context");
+	});
+
+	it("suppresses a .dreb/CONTEXT.md that is read directly", () => {
+		mkdirSync(join(sub, ".dreb"), { recursive: true });
+		writeFileSync(join(sub, ".dreb", "CONTEXT.md"), "# dreb context");
+		const state = freshState();
+		const block = computeNestedContextBlock("read", { path: join(sub, ".dreb", "CONTEXT.md") }, state);
+		// The read delivered the .dreb file; it must not be re-injected but the sibling
+		// CLAUDE.md the read did not touch must still appear.
+		expect(block).not.toContain("# dreb context");
+		expect(block).toContain("# sub context");
+		expect(state.loaded.has(realpathSync(join(sub, ".dreb", "CONTEXT.md")))).toBe(true);
 	});
 
 	it("still injects when a bash command only cds without printing the context file", () => {
@@ -491,26 +582,59 @@ describe("resolveSelfReadFile", () => {
 	});
 });
 
-describe("bashReferencesFilename", () => {
-	it("matches a filename printed by cat", () => {
-		expect(bashReferencesFilename("cd /x && cat CLAUDE.md", "CLAUDE.md")).toBe(true);
+describe("resolveBashDeliveredFiles", () => {
+	it("resolves a cat argument against the working directory", () => {
+		expect(resolveBashDeliveredFiles("cat CLAUDE.md", "/proj/sub")).toEqual(["/proj/sub/CLAUDE.md"]);
 	});
 
-	it("matches case-insensitively", () => {
-		expect(bashReferencesFilename("cat claude.md", "CLAUDE.md")).toBe(true);
+	it("resolves multiple files dumped by one command", () => {
+		expect(resolveBashDeliveredFiles("cat A.md B.md", "/proj")).toEqual(["/proj/A.md", "/proj/B.md"]);
 	});
 
-	it("matches a path-qualified reference", () => {
-		expect(bashReferencesFilename("head ./sub/AGENTS.md", "AGENTS.md")).toBe(true);
+	it("returns an absolute argument unchanged", () => {
+		expect(resolveBashDeliveredFiles("cat /a/CLAUDE.md", "/proj")).toEqual(["/a/CLAUDE.md"]);
 	});
 
-	it("does not match an incidental longer token", () => {
-		expect(bashReferencesFilename("cat my-claude.md-notes.txt", "CLAUDE.md")).toBe(false);
+	it("expands a leading ~ in an argument", () => {
+		expect(resolveBashDeliveredFiles("cat ~/x/CLAUDE.md", "/proj")).toEqual([join(homedir(), "x/CLAUDE.md")]);
 	});
 
-	it("returns false for an empty command or basename", () => {
-		expect(bashReferencesFilename("", "CLAUDE.md")).toBe(false);
-		expect(bashReferencesFilename("cat x", "")).toBe(false);
+	it("supports bat as a full-dump command", () => {
+		expect(resolveBashDeliveredFiles("bat CLAUDE.md", "/proj")).toEqual(["/proj/CLAUDE.md"]);
+	});
+
+	it("ignores flags and only collects file arguments", () => {
+		expect(resolveBashDeliveredFiles("cat -n CLAUDE.md", "/proj")).toEqual(["/proj/CLAUDE.md"]);
+	});
+
+	it("strips surrounding quotes from an argument", () => {
+		expect(resolveBashDeliveredFiles('cat "CLAUDE.md"', "/proj")).toEqual(["/proj/CLAUDE.md"]);
+	});
+
+	it("does not treat partial/interactive viewers as full delivery", () => {
+		expect(resolveBashDeliveredFiles("head CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("tail -n 5 CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("less CLAUDE.md", "/proj")).toEqual([]);
+	});
+
+	it("does not treat non-dumping verbs as delivery", () => {
+		expect(resolveBashDeliveredFiles("grep TODO CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("rm CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("git add CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("wc -l CLAUDE.md", "/proj")).toEqual([]);
+	});
+
+	it("skips a dump whose output is piped or redirected away", () => {
+		expect(resolveBashDeliveredFiles("cat CLAUDE.md | grep x", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("cat CLAUDE.md > out.txt", "/proj")).toEqual([]);
+	});
+
+	it("collects a cat that follows a leading cd segment", () => {
+		expect(resolveBashDeliveredFiles("cd /proj/sub && cat CLAUDE.md", "/proj/sub")).toEqual(["/proj/sub/CLAUDE.md"]);
+	});
+
+	it("returns an empty list for an empty command", () => {
+		expect(resolveBashDeliveredFiles("", "/proj")).toEqual([]);
 	});
 });
 

--- a/packages/coding-agent/test/nested-context.test.ts
+++ b/packages/coding-agent/test/nested-context.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveSelfReadFile,
 	resolveTargetDir,
 } from "../src/core/nested-context.js";
+import { DEFAULT_MAX_LINES } from "../src/core/tools/truncate.js";
 
 const itIfFilePermissionsApply =
 	process.platform === "win32" || (typeof process.getuid === "function" && process.getuid() === 0) ? it.skip : it;
@@ -610,6 +611,52 @@ describe("computeNestedContextBlock (orchestration)", () => {
 		);
 	});
 
+	it("still injects when a cat renders past the byte budget via tab expansion", () => {
+		// The bash tool delivers truncateTail(renderTerminalOutput(...)), which expands tabs
+		// to 8-column stops. A tab-dense file ~7KB on disk renders to ~56KB, so `cat` delivers
+		// it truncated even though the raw file is well under budget — measuring the raw file
+		// would falsely suppress it (silent drop). `read` delivers the raw content unchanged,
+		// so the same file IS fully delivered by read and is correctly suppressed there.
+		writeFileSync(join(sub, "CLAUDE.md"), `# sub context\n${"\t".repeat(7000)}X`);
+		const bashState = freshState();
+		expect(computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, bashState)).toContain(
+			"# sub context",
+		);
+		// read path: raw content is within budget, so it is delivered in full → suppressed.
+		const readState = freshState();
+		expect(computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, readState)).toBeNull();
+		expect(readState.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+	});
+
+	it("suppresses at exactly the line limit but injects one line over it", () => {
+		// Pin the deliveredInFull line-count boundary: a file whose split("\n") length is
+		// exactly DEFAULT_MAX_LINES is delivered in full (suppress); one line more is
+		// truncated by the tool (inject). Guards against a future off-by-one regression.
+		// `"line\n".repeat(n)` splits into n + 1 elements (trailing empty), so use n - 1 / n.
+		const atLimit = `${"line\n".repeat(DEFAULT_MAX_LINES - 1)}`;
+		writeFileSync(join(sub, "CLAUDE.md"), atLimit);
+		const atState = freshState();
+		expect(computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, atState)).toBeNull();
+		expect(atState.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+
+		const overLimit = `${"line\n".repeat(DEFAULT_MAX_LINES)}`;
+		writeFileSync(join(sub, "CLAUDE.md"), overLimit);
+		const overState = freshState();
+		const block = computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, overState);
+		expect(block).not.toBeNull();
+		expect(block).toContain("line");
+	});
+
+	it("still injects when a context file is dumped by an uppercase (non-existent) command", () => {
+		// `CAT`/`Bat` are command-not-found on Linux (case-sensitive PATH lookup) and emit
+		// nothing to stdout, so they must not suppress — the result never contained the file.
+		for (const verb of ["CAT", "Cat", "BAT", "Bat"]) {
+			const state = freshState();
+			const block = computeNestedContextBlock("bash", { command: `cd ${sub} && ${verb} CLAUDE.md` }, state);
+			expect(block, verb).toContain("# sub context");
+		}
+	});
+
 	it("still injects when a bash dump is followed by other output (tail truncation hazard)", () => {
 		// `cat CLAUDE.md && npm test` can push the dumped file out of the tail-truncated
 		// window, so it must not be suppressed — only a sole single-file dump qualifies.
@@ -767,6 +814,22 @@ describe("resolveBashDeliveredFiles", () => {
 
 	it("collects a cat that follows a leading cd segment", () => {
 		expect(resolveBashDeliveredFiles("cd /proj/sub && cat CLAUDE.md", "/proj/sub")).toEqual(["/proj/sub/CLAUDE.md"]);
+	});
+
+	it("does not treat an uppercase command as a full dump (case-sensitive verb match)", () => {
+		// Shell PATH lookup is case-sensitive on Linux: `CAT`/`Bat` are command-not-found and
+		// emit nothing, so they must not be treated as delivering the file.
+		expect(resolveBashDeliveredFiles("CAT CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("Cat CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("BAT CLAUDE.md", "/proj")).toEqual([]);
+	});
+
+	it("returns nothing for a full-dump command with no file operand", () => {
+		// `cat` / `cat -n` reading stdin (or a flag-only invocation) names no file, so there
+		// is nothing to suppress — the operand-count guard must keep it the safe direction.
+		expect(resolveBashDeliveredFiles("cat", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("cat -n", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("bat --plain", "/proj")).toEqual([]);
 	});
 
 	it("returns an empty list for an empty command", () => {

--- a/packages/coding-agent/test/nested-context.test.ts
+++ b/packages/coding-agent/test/nested-context.test.ts
@@ -555,6 +555,77 @@ describe("computeNestedContextBlock (orchestration)", () => {
 		expect(block).toBeNull();
 		expect(state.loaded.has(realpathSync(join(realSub, "CLAUDE.md")))).toBe(true);
 	});
+
+	it("still injects when a read is sliced via offset/limit (partial delivery)", () => {
+		// A sliced read delivers only a fragment, so the full context file must still inject.
+		const state = freshState();
+		const block = computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md"), offset: 1, limit: 1 }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("still injects when bat shows only a partial range", () => {
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && bat -r 1:2 CLAUDE.md` }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("still injects when a here-doc merely mentions a context filename", () => {
+		// `cat <<EOF ... CLAUDE.md ... EOF` outputs literal text, not the file.
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat <<EOF\nsee CLAUDE.md\nEOF` }, state);
+		expect(block).toContain("# sub context");
+	});
+
+	it("still injects when the command chains multiple cds (ambiguous cwd)", () => {
+		// The cat runs in the final cwd, not the first; resolving against the first would
+		// suppress the wrong same-named file, so suppression is skipped entirely.
+		writeFileSync(join(cwd, "CLAUDE.md"), "# root context");
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${cwd} && cd sub && cat CLAUDE.md` }, state);
+		// targetDir is cwd; cwd/CLAUDE.md must not be suppressed by the ambiguous chained cd.
+		expect(block).toContain("# root context");
+	});
+
+	it("still injects an oversized context file the tool can only deliver truncated", () => {
+		// Beyond the tool's truncation limit the delivered content is incomplete, while the
+		// injected block is uncapped — suppressing would silently drop the remainder.
+		writeFileSync(join(sub, "CLAUDE.md"), `# sub context\n${"x\n".repeat(2100)}`);
+		const readState = freshState();
+		expect(computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, readState)).toContain("# sub context");
+		const bashState = freshState();
+		expect(computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, bashState)).toContain(
+			"# sub context",
+		);
+	});
+
+	it("does not suppress a sibling .claude/CLAUDE.md when a top-level CLAUDE.md is dumped", () => {
+		// `.claude/CLAUDE.md`'s basename collapses to CLAUDE.md, but it is a different file
+		// than `sub/CLAUDE.md`; full-path matching must keep them distinct.
+		mkdirSync(join(sub, ".claude"), { recursive: true });
+		writeFileSync(join(sub, ".claude", "CLAUDE.md"), "# claude-dir context");
+		const state = freshState();
+		const block = computeNestedContextBlock("bash", { command: `cd ${sub} && cat CLAUDE.md` }, state);
+		expect(block).toContain("# claude-dir context");
+		expect(block).not.toContain("# sub context");
+	});
+
+	it("does not re-inject a suppressed context file when a deeper dir is later touched", () => {
+		// Exercises the permanent-loaded invariant across a later, deeper-dir call (the
+		// negative cache only short-circuits the *same* dir, not a child).
+		const deeper = join(sub, "deeper");
+		mkdirSync(deeper, { recursive: true });
+		writeFileSync(join(deeper, "AGENTS.md"), "# deeper context");
+		writeFileSync(join(deeper, "file.py"), "y = 2\n");
+		const state = freshState();
+		// First: read sub/CLAUDE.md → suppressed (delivered) + marked loaded, sub scanned.
+		expect(computeNestedContextBlock("read", { path: join(sub, "CLAUDE.md") }, state)).toBeNull();
+		expect(state.loaded.has(realpathSync(join(sub, "CLAUDE.md")))).toBe(true);
+		// Later: operate in sub/deeper (not yet scanned). The walk re-passes through sub but
+		// must not resurface the already-loaded sub/CLAUDE.md; only deeper's context is new.
+		const block = computeNestedContextBlock("read", { path: join(deeper, "file.py") }, state);
+		expect(block).toContain("# deeper context");
+		expect(block).not.toContain("# sub context");
+	});
 });
 
 describe("resolveSelfReadFile", () => {
@@ -579,6 +650,12 @@ describe("resolveSelfReadFile", () => {
 	it("returns null when path is missing or empty", () => {
 		expect(resolveSelfReadFile("read", {}, "/proj")).toBeNull();
 		expect(resolveSelfReadFile("read", { path: "   " }, "/proj")).toBeNull();
+	});
+
+	it("returns null for a sliced read (offset/limit delivers only a fragment)", () => {
+		expect(resolveSelfReadFile("read", { path: "CLAUDE.md", offset: 10 }, "/proj")).toBeNull();
+		expect(resolveSelfReadFile("read", { path: "CLAUDE.md", limit: 5 }, "/proj")).toBeNull();
+		expect(resolveSelfReadFile("read", { path: "CLAUDE.md", offset: 1, limit: 5 }, "/proj")).toBeNull();
 	});
 });
 
@@ -627,6 +704,26 @@ describe("resolveBashDeliveredFiles", () => {
 	it("skips a dump whose output is piped or redirected away", () => {
 		expect(resolveBashDeliveredFiles("cat CLAUDE.md | grep x", "/proj")).toEqual([]);
 		expect(resolveBashDeliveredFiles("cat CLAUDE.md > out.txt", "/proj")).toEqual([]);
+	});
+
+	it("skips a segment using a here-doc / here-string / input redirection", () => {
+		// Tokens after `<<`/`<<<`/`<` are stdin body words, not dumped files — a heredoc that
+		// merely mentions a context filename must not suppress it.
+		expect(resolveBashDeliveredFiles("cat <<EOF\nsee CLAUDE.md\nEOF", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("cat <<< CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("cat < CLAUDE.md", "/proj")).toEqual([]);
+	});
+
+	it("returns nothing when the command chains more than one cd (ambiguous cwd)", () => {
+		// Only the first `cd` is resolved into `workingDir`; a second `cd` makes operand
+		// resolution wrong, so bail to the safe double-load.
+		expect(resolveBashDeliveredFiles("cd /proj && cd sub && cat CLAUDE.md", "/proj")).toEqual([]);
+	});
+
+	it("does not treat bat's partial-range flag as a full dump", () => {
+		expect(resolveBashDeliveredFiles("bat -r 10:20 CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("bat --line-range 10:20 CLAUDE.md", "/proj")).toEqual([]);
+		expect(resolveBashDeliveredFiles("bat --line-range=10:20 CLAUDE.md", "/proj")).toEqual([]);
 	});
 
 	it("collects a cat that follows a leading cd segment", () => {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.31.0",
+	"version": "2.31.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #290

Fixes redundant nested-context injection: when a tool call already delivers a `CLAUDE.md`/`AGENTS.md` (a `read` of the file, or a `bash` `cat`/`head` of it), the auto-load no longer appends the same file again. The file is still marked as loaded so it never re-injects later.

Implementation plan posted as a comment below.
