### PR TITLE
Expose cross-project session listing and session deletion over RPC

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -136,12 +136,12 @@ describe("Context overflow error handling", () => {
 		it.skipIf(!githubCopilotToken)(
 			"claude-sonnet-4 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 
 				expect(result.stopReason).toBe("error");
-				expect(result.errorMessage).toMatch(/exceeds the limit of \d+|input is too long/i);
+				expect(result.errorMessage).toMatch(/exceeds the limit of \d+|input is too long|prompt is too long/i);
 				expect(isContextOverflow(result.response, model.contextWindow)).toBe(true);
 			},
 			120000,

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -70,7 +70,7 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	{ provider: "google-antigravity", model: "gemini-3-flash", label: "antigravity-gemini-3-flash" },
 	{ provider: "google-antigravity", model: "claude-sonnet-4-5", label: "antigravity-claude-sonnet-4-5" },
 	// GitHub Copilot
-	{ provider: "github-copilot", model: "claude-sonnet-4.5", label: "copilot-claude-sonnet-4.5" },
+	{ provider: "github-copilot", model: "claude-opus-4.5", label: "copilot-claude-opus-4.5" },
 	{ provider: "github-copilot", model: "gpt-5.1-codex", label: "copilot-gpt-5.1-codex" },
 	{ provider: "github-copilot", model: "gemini-3-flash-preview", label: "copilot-gemini-3-flash-preview" },
 	{ provider: "github-copilot", model: "grok-code-fast-1", label: "copilot-grok-code-fast-1" },

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -490,37 +490,37 @@ describe("AI Providers Empty Message Tests", () => {
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle empty content array",
+			"claude-opus-4.5 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle empty string content",
+			"claude-opus-4.5 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle whitespace-only content",
+			"claude-opus-4.5 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle empty assistant message in conversation",
+			"claude-opus-4.5 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -43,7 +43,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 });
 
 describe("Copilot Claude via Anthropic Messages", () => {
-	const copilotClaudeModelId = "claude-sonnet-4.5";
+	const copilotClaudeModelId = "claude-opus-4.5";
 	const context: Context = {
 		systemPrompt: "You are a helpful assistant.",
 		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -348,19 +348,19 @@ describe("Tool Results with Images", () => {
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle tool result with only image",
+			"claude-opus-4.5 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle tool result with text and image",
+			"claude-opus-4.5 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/lazy-module-load.test.ts
+++ b/packages/ai/test/lazy-module-load.test.ts
@@ -72,8 +72,8 @@ describe("lazy provider module loading", () => {
 	it("loads only the Anthropic SDK when calling the root lazy wrapper", () => {
 		const result = runProbe(`
 			const model = {
-				id: "claude-sonnet-4-20250514",
-				name: "Claude Sonnet 4",
+				id: "claude-sonnet-5",
+				name: "Claude Sonnet 5",
 				api: "anthropic-messages",
 				provider: "anthropic",
 				baseUrl: "https://api.anthropic.com",
@@ -92,7 +92,7 @@ describe("lazy provider module loading", () => {
 
 	it("loads only the Anthropic SDK when dispatching through streamSimple", () => {
 		const result = runProbe(`
-			const model = mod.getModel("anthropic", "claude-sonnet-4-20250514");
+			const model = mod.getModel("anthropic", "claude-sonnet-5");
 			const context = { messages: [{ role: "user", content: "hi" }] };
 			await mod.streamSimple(model, context).result();
 		`);

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -111,7 +111,7 @@ describe("responseId E2E Tests", () => {
 			"Anthropic path should expose responseId",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await expectResponseId(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -888,7 +888,7 @@ describe("Generate E2E Tests", () => {
 	});
 
 	describe("GitHub Copilot Provider (claude-sonnet-4 via Anthropic Messages)", () => {
-		const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+		const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 
 		it.skipIf(!githubCopilotToken)("should complete basic text generation", { retry: 3 }, async () => {
 			await basicTextGeneration(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -20,8 +20,8 @@ describe("supportsXhigh", () => {
 		expect(supportsXhigh(model!)).toBe(false);
 	});
 
-	it("returns false for base Opus 4 dated model (opus-4-20250514)", () => {
-		const model = getModel("anthropic", "claude-opus-4-20250514");
+	it("returns false for Opus 4.1 (below threshold)", () => {
+		const model = getModel("anthropic", "claude-opus-4-1");
 		expect(model).toBeDefined();
 		expect(supportsXhigh(model!)).toBe(false);
 	});

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -225,7 +225,7 @@ describe("Token Statistics on Abort", () => {
 			"claude-sonnet-4 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -242,7 +242,7 @@ describe("Tool Call Without Result Tests", () => {
 			"claude-sonnet-4 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -530,7 +530,7 @@ describe("totalTokens field", () => {
 			"claude-sonnet-4 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -400,28 +400,28 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle emoji in tool results",
+			"claude-opus-4.5 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle real-world LinkedIn comment data with emoji",
+			"claude-opus-4.5 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(!githubCopilotToken)(
-			"claude-sonnet-4.5 - should handle unpaired high surrogate (0xD83D) in tool results",
+			"claude-opus-4.5 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-sonnet-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **`list_all_sessions` RPC command** - List sessions across all projects for external frontends.
+- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
+
 - Thinking summaries are visible again on Opus 4.7+ (and any adaptive-thinking Claude model). Anthropic flipped the API default for `thinking.display` to `"omitted"`, so these models returned empty thinking blocks — dreb now sends `"summarized"` by default. Added a model-keyed `modelSettings` setting with a `thinkingDisplay` override (`"summarized" | "omitted"`), exposed in `/settings` → **Show thinking summaries** (shown only for adaptive models). Because the setting is keyed by model ID and resolved at the shared session-creation chokepoint, it is honored uniformly across the TUI, headless, JSON, RPC, and Telegram clients — and inherited automatically by subagents using the same model. ([#250](https://github.com/aebrer/dreb/issues/250))
 
 - Secret scrubbing and sensitive file access guards — two layers of defense against accidental credential leaks through the tool pipeline. Output scrubbing detects and redacts known secret patterns (AWS, GitHub, OpenAI, Anthropic, Slack, Stripe, PEM/SSH keys, URL credentials) in tool output before it enters the LLM conversation. Sensitive file guard blocks read access to credential files (`~/.ssh/id_*`, `~/.aws/credentials`, `~/.dreb/secrets/`, etc.) via both the `read` tool and bash commands. Both layers configurable via `sensitiveFilePaths` and `secretOutputPatterns` settings. ([#171](https://github.com/aebrer/dreb/issues/171))

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **`list_all_sessions` RPC command** - List sessions across all projects for external frontends.
-- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Refuses paths outside the sessions directory and canonicalizes the path before every guard so a non-canonical spelling cannot bypass protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
+- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Refuses paths outside the sessions directory and canonicalizes the path with `realpathSync` before every guard — dereferencing symlinked path components as well as `.`/`..` segments — so a non-canonical spelling cannot bypass protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
 
 - Thinking summaries are visible again on Opus 4.7+ (and any adaptive-thinking Claude model). Anthropic flipped the API default for `thinking.display` to `"omitted"`, so these models returned empty thinking blocks — dreb now sends `"summarized"` by default. Added a model-keyed `modelSettings` setting with a `thinkingDisplay` override (`"summarized" | "omitted"`), exposed in `/settings` → **Show thinking summaries** (shown only for adaptive models). Because the setting is keyed by model ID and resolved at the shared session-creation chokepoint, it is honored uniformly across the TUI, headless, JSON, RPC, and Telegram clients — and inherited automatically by subagents using the same model. ([#250](https://github.com/aebrer/dreb/issues/250))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **`list_all_sessions` RPC command** - List sessions across all projects for external frontends.
-- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
+- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Refuses paths outside the sessions directory and canonicalizes the path before every guard so a non-canonical spelling cannot bypass protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
 
 - Thinking summaries are visible again on Opus 4.7+ (and any adaptive-thinking Claude model). Anthropic flipped the API default for `thinking.display` to `"omitted"`, so these models returned empty thinking blocks — dreb now sends `"summarized"` by default. Added a model-keyed `modelSettings` setting with a `thinkingDisplay` override (`"summarized" | "omitted"`), exposed in `/settings` → **Show thinking summaries** (shown only for adaptive models). Because the setting is keyed by model ID and resolved at the shared session-creation chokepoint, it is honored uniformly across the TUI, headless, JSON, RPC, and Telegram clients — and inherited automatically by subagents using the same model. ([#250](https://github.com/aebrer/dreb/issues/250))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- **`list_all_sessions` RPC command** - List sessions across all projects for external frontends.
-- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Refuses paths outside the sessions directory and canonicalizes the path with `realpathSync` before every guard — dereferencing symlinked path components as well as `.`/`..` segments — so a non-canonical spelling cannot bypass protection. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
+- **`list_all_sessions` RPC command** - List sessions across all projects for external frontends. If the underlying listing fails (I/O error reading the sessions store), the command responds `success: false` instead of a silently-empty list, so clients can tell "no sessions" apart from "listing failed."
+- **`delete_session` RPC command** - Delete a session file (trash-first) with active-session protection. Uses the same unrestricted, cross-project path addressing as `switch_session` (no sessions-directory containment guard — this is a trusted local channel, and a frontend exposing it owns its own authorization); the path is `resolve()`d before the active-session compare and deletion. Refuses the active session, non-`.jsonl` paths, and nonexistent files. Session deletion logic moved from the TUI into `SessionManager.deleteSession`.
 
 - Thinking summaries are visible again on Opus 4.7+ (and any adaptive-thinking Claude model). Anthropic flipped the API default for `thinking.display` to `"omitted"`, so these models returned empty thinking blocks — dreb now sends `"summarized"` by default. Added a model-keyed `modelSettings` setting with a `thinkingDisplay` override (`"summarized" | "omitted"`), exposed in `/settings` → **Show thinking summaries** (shown only for adaptive models). Because the setting is keyed by model ID and resolved at the shared session-creation chokepoint, it is honored uniformly across the TUI, headless, JSON, RPC, and Telegram clients — and inherited automatically by subagents using the same model. ([#250](https://github.com/aebrer/dreb/issues/250))
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -644,7 +644,7 @@ If attempting to delete the currently active session:
 }
 ```
 
-The path is canonicalized before every check, and deletion is refused for paths outside the sessions directory (the global sessions directory, or the active session's own directory for custom `--session-dir` setups), non-`.jsonl` paths, and nonexistent files:
+The path is canonicalized with `realpathSync` before every check — dereferencing symlinked path components as well as `.`/`..` segments — and deletion is refused for paths outside the sessions directory (the global sessions directory, or the active session's own directory for custom `--session-dir` setups), non-`.jsonl` paths, and nonexistent files:
 ```json
 {
   "type": "response",

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -644,13 +644,13 @@ If attempting to delete the currently active session:
 }
 ```
 
-The path is canonicalized with `realpathSync` before every check — dereferencing symlinked path components as well as `.`/`..` segments — and deletion is refused for paths outside the sessions directory (the global sessions directory, or the active session's own directory for custom `--session-dir` setups), non-`.jsonl` paths, and nonexistent files:
+The path uses the same unrestricted, cross-project addressing as [`switch_session`](#switch_session): it is `resolve()`d (collapsing `.`/`..`/relative segments) and then checked against the active session. There is **no** sessions-directory containment guard — this is a trusted local channel, and any frontend exposing it (e.g. the web dashboard) is expected to enforce its own authorization. Deletion is refused only for the currently active session, non-`.jsonl` paths, and nonexistent files:
 ```json
 {
   "type": "response",
   "command": "delete_session",
   "success": false,
-  "error": "Refusing to delete a path outside the sessions directory: /tmp/evil.jsonl"
+  "error": "Not a session file (expected .jsonl): /tmp/evil.txt"
 }
 ```
 
@@ -830,7 +830,7 @@ Each session has:
 
 #### list_all_sessions
 
-List sessions across all projects. Returns sessions sorted by most recently modified first. May be slow with many sessions.
+List sessions across all projects. Returns sessions sorted by most recently modified first. May be slow with many sessions. If the underlying listing fails (an I/O error reading the sessions store), the command responds `success: false` rather than a silently-empty list — so a client can distinguish "no sessions" from "listing failed."
 
 ```json
 {"type": "list_all_sessions"}

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -621,6 +621,29 @@ If an extension cancelled the switch:
 {"type": "response", "command": "switch_session", "success": true, "data": {"cancelled": true}}
 ```
 
+#### delete_session
+
+Delete a session file. Deletion tries trash first and falls back to unlink. The currently active session cannot be deleted.
+
+```json
+{"type": "delete_session", "sessionPath": "/path/to/session.jsonl"}
+```
+
+Response:
+```json
+{"type": "response", "command": "delete_session", "success": true, "data": {"method": "trash"}}
+```
+
+If attempting to delete the currently active session:
+```json
+{
+  "type": "response",
+  "command": "delete_session",
+  "success": false,
+  "error": "Cannot delete the currently active session"
+}
+```
+
 #### fork
 
 Create a new fork from a previous user message. Can be cancelled by a `session_before_fork` extension event handler. Returns the text of the message being forked from.
@@ -794,6 +817,39 @@ Each session has:
 - `modified`: ISO timestamp of last modification
 - `messageCount`: Number of messages in the session
 - `firstMessage`: First user message text (for preview)
+
+#### list_all_sessions
+
+List sessions across all projects. Returns sessions sorted by most recently modified first. May be slow with many sessions.
+
+```json
+{"type": "list_all_sessions"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "list_all_sessions",
+  "success": true,
+  "data": {
+    "sessions": [
+      {
+        "path": "/home/user/.dreb/agent/sessions/--home-user-project--/2024-01-15T10-30-00_abc123.jsonl",
+        "id": "abc123-def456-...",
+        "cwd": "/home/user/project",
+        "name": "feature-work",
+        "created": "2024-01-15T10:30:00.000Z",
+        "modified": "2024-01-15T11:45:00.000Z",
+        "messageCount": 12,
+        "firstMessage": "Help me refactor the auth module"
+      }
+    ]
+  }
+}
+```
+
+Each session has the same fields as `list_sessions`.
 
 ### Version
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -644,6 +644,16 @@ If attempting to delete the currently active session:
 }
 ```
 
+The path is canonicalized before every check, and deletion is refused for paths outside the sessions directory (the global sessions directory, or the active session's own directory for custom `--session-dir` setups), non-`.jsonl` paths, and nonexistent files:
+```json
+{
+  "type": "response",
+  "command": "delete_session",
+  "success": false,
+  "error": "Refusing to delete a path outside the sessions directory: /tmp/evil.jsonl"
+}
+```
+
 #### fork
 
 Create a new fork from a previous user message. Can be cancelled by a `session_before_fork` extension event handler. Returns the text of the message being forked from.

--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -32,7 +32,7 @@ if (process.env.MY_ANTHROPIC_KEY) {
 // Model registry with no custom models.json
 const modelRegistry = new ModelRegistry(authStorage);
 
-const model = getModel("anthropic", "claude-sonnet-4-20250514");
+const model = getModel("anthropic", "claude-sonnet-5");
 if (!model) throw new Error("Model not found");
 
 // In-memory settings with overrides

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -15,7 +15,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "fs";
-import { join, resolve } from "path";
+import { join, resolve, sep } from "path";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import {
 	type BashExecutionMessage,
@@ -1380,21 +1380,52 @@ export class SessionManager {
 
 	/**
 	 * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
-	 * Refuses to delete non-session files or missing files.
+	 * Refuses to delete non-session files, missing files, paths outside the sessions
+	 * directory, or the currently active session.
+	 *
+	 * The path is canonicalized before every check and before deletion, so a non-canonical
+	 * spelling (relative segments, `..`, symlinked components) cannot bypass the containment
+	 * or active-session guards.
+	 *
+	 * @param sessionPath Path to the session file to delete.
+	 * @param opts.allowedDirs Additional directories (beyond the global sessions directory)
+	 *   whose contents may be deleted — e.g. a custom `--session-dir`.
+	 * @param opts.activeSessionPath If provided, refuses to delete this session (defense-in-depth
+	 *   for the active-session guard; callers should still guard at their own layer).
 	 */
 	static async deleteSession(
 		sessionPath: string,
+		opts: { allowedDirs?: string[]; activeSessionPath?: string } = {},
 	): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
-		if (!sessionPath.endsWith(".jsonl")) {
+		// Canonicalize once so no guard below can be bypassed by a non-canonical spelling.
+		const resolvedPath = resolve(sessionPath);
+
+		if (!resolvedPath.endsWith(".jsonl")) {
 			return { ok: false, method: "unlink", error: `Not a session file (expected .jsonl): ${sessionPath}` };
 		}
 
-		if (!existsSync(sessionPath)) {
+		if (opts.activeSessionPath && resolvedPath === resolve(opts.activeSessionPath)) {
+			return { ok: false, method: "unlink", error: "Cannot delete the currently active session" };
+		}
+
+		// Containment guard: the resolved path must live inside the global sessions directory
+		// or one of the explicitly allowed directories (e.g. a custom --session-dir).
+		const allowedRoots = [getSessionsDir(), ...(opts.allowedDirs ?? [])].map((dir) => resolve(dir));
+		const isContained = allowedRoots.some((root) => resolvedPath.startsWith(root + sep));
+		if (!isContained) {
+			return {
+				ok: false,
+				method: "unlink",
+				error: `Refusing to delete a path outside the sessions directory: ${sessionPath}`,
+			};
+		}
+
+		if (!existsSync(resolvedPath)) {
 			return { ok: false, method: "unlink", error: `Session file does not exist: ${sessionPath}` };
 		}
 
 		// Try `trash` first (if installed)
-		const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
+		const trashArgs = resolvedPath.startsWith("-") ? ["--", resolvedPath] : [resolvedPath];
 		const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
 
 		const getTrashErrorHint = (): string | null => {
@@ -1411,13 +1442,13 @@ export class SessionManager {
 		};
 
 		// If trash reports success, or the file is gone afterwards, treat it as successful
-		if (trashResult.status === 0 || !existsSync(sessionPath)) {
+		if (trashResult.status === 0 || !existsSync(resolvedPath)) {
 			return { ok: true, method: "trash" };
 		}
 
 		// Fallback to permanent deletion
 		try {
-			await unlink(sessionPath);
+			await unlink(resolvedPath);
 			return { ok: true, method: "unlink" };
 		} catch (err) {
 			const unlinkError = err instanceof Error ? err.message : String(err);

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -12,10 +12,11 @@ import {
 	readdirSync,
 	readFileSync,
 	readSync,
+	realpathSync,
 	statSync,
 	writeFileSync,
 } from "fs";
-import { join, resolve, sep } from "path";
+import { basename, dirname, join, resolve, sep } from "path";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import {
 	type BashExecutionMessage,
@@ -544,6 +545,42 @@ function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, sta
 	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
 }
 
+/**
+ * Resolve a session's creation date from its header timestamp, falling back to the file's
+ * mtime when the header timestamp is missing or malformed. Without this guard a bad header
+ * yields an Invalid Date, which later throws `RangeError: Invalid time value` when serialized
+ * via `.toISOString()` — and because listings map over every session, one bad file would
+ * take down the entire `list_all_sessions` response instead of degrading a single entry.
+ */
+function getSessionCreatedDate(header: SessionHeader, statsMtime: Date): Date {
+	const headerTime = typeof header.timestamp === "string" ? new Date(header.timestamp).getTime() : NaN;
+	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
+}
+
+/**
+ * Canonicalize a directory path, dereferencing symlinks via realpathSync. Falls back to the
+ * purely-lexical resolve() when the directory does not exist yet (realpath throws ENOENT).
+ */
+function canonicalizeDir(dir: string): string {
+	const lexical = resolve(dir);
+	try {
+		return realpathSync(lexical);
+	} catch {
+		return lexical;
+	}
+}
+
+/**
+ * Canonicalize a file path for the deletion guards. The containing directory is resolved
+ * through realpathSync so a symlinked parent component cannot smuggle the target outside the
+ * sessions tree; the basename is preserved (not dereferenced) so a session file that is itself
+ * a symlink is addressed and deleted directly rather than followed to another name.
+ */
+function canonicalizeForDeletion(filePath: string): string {
+	const lexical = resolve(filePath);
+	return join(canonicalizeDir(dirname(lexical)), basename(lexical));
+}
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	try {
 		const content = await readFile(filePath, "utf8");
@@ -596,6 +633,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 		const parentSessionPath = (header as SessionHeader).parentSession;
 
 		const modified = getSessionModifiedDate(entries, header as SessionHeader, stats.mtime);
+		const created = getSessionCreatedDate(header as SessionHeader, stats.mtime);
 
 		return {
 			path: filePath,
@@ -603,7 +641,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			cwd,
 			name,
 			parentSessionPath,
-			created: new Date((header as SessionHeader).timestamp),
+			created,
 			modified,
 			messageCount,
 			firstMessage: firstMessage || "(no messages)",
@@ -1383,8 +1421,10 @@ export class SessionManager {
 	 * Refuses to delete non-session files, missing files, paths outside the sessions
 	 * directory, or the currently active session.
 	 *
-	 * The path is canonicalized before every check and before deletion, so a non-canonical
-	 * spelling (relative segments, `..`, symlinked components) cannot bypass the containment
+	 * The path is canonicalized with `realpathSync` (which dereferences symlinked path
+	 * components, unlike the purely-lexical `resolve()`) before every check and before
+	 * deletion, so a non-canonical spelling — relative segments, `..`, or a symlinked
+	 * parent directory pointing outside the sessions tree — cannot bypass the containment
 	 * or active-session guards.
 	 *
 	 * @param sessionPath Path to the session file to delete.
@@ -1397,20 +1437,22 @@ export class SessionManager {
 		sessionPath: string,
 		opts: { allowedDirs?: string[]; activeSessionPath?: string } = {},
 	): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
-		// Canonicalize once so no guard below can be bypassed by a non-canonical spelling.
-		const resolvedPath = resolve(sessionPath);
+		// Canonicalize once so no guard below can be bypassed by a non-canonical spelling
+		// (relative segments, `..`, or a symlinked parent directory).
+		const resolvedPath = canonicalizeForDeletion(sessionPath);
 
 		if (!resolvedPath.endsWith(".jsonl")) {
 			return { ok: false, method: "unlink", error: `Not a session file (expected .jsonl): ${sessionPath}` };
 		}
 
-		if (opts.activeSessionPath && resolvedPath === resolve(opts.activeSessionPath)) {
+		if (opts.activeSessionPath && resolvedPath === canonicalizeForDeletion(opts.activeSessionPath)) {
 			return { ok: false, method: "unlink", error: "Cannot delete the currently active session" };
 		}
 
 		// Containment guard: the resolved path must live inside the global sessions directory
-		// or one of the explicitly allowed directories (e.g. a custom --session-dir).
-		const allowedRoots = [getSessionsDir(), ...(opts.allowedDirs ?? [])].map((dir) => resolve(dir));
+		// or one of the explicitly allowed directories (e.g. a custom --session-dir). Roots are
+		// canonicalized the same way so symlinked roots (e.g. macOS /tmp -> /private/tmp) match.
+		const allowedRoots = [getSessionsDir(), ...(opts.allowedDirs ?? [])].map((dir) => canonicalizeDir(dir));
 		const isContained = allowedRoots.some((root) => resolvedPath.startsWith(root + sep));
 		if (!isContained) {
 			return {
@@ -1424,9 +1466,11 @@ export class SessionManager {
 			return { ok: false, method: "unlink", error: `Session file does not exist: ${sessionPath}` };
 		}
 
-		// Try `trash` first (if installed)
-		const trashArgs = resolvedPath.startsWith("-") ? ["--", resolvedPath] : [resolvedPath];
-		const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+		// Try `trash` first (if installed). The path is absolute after canonicalization, so it
+		// can never be mistaken for a flag — no `--` guard needed. A timeout prevents a hung
+		// `trash` (e.g. a stuck network/FUSE trash location) from freezing the caller, since
+		// spawnSync blocks synchronously; on timeout we fall through to unlink.
+		const trashResult = spawnSync("trash", [resolvedPath], { encoding: "utf-8", timeout: 10_000 });
 
 		const getTrashErrorHint = (): string | null => {
 			const parts: string[] = [];

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+import { readdir, readFile, stat, unlink } from "node:fs/promises";
 import type { AgentMessage } from "@dreb/agent-core";
 import type { ImageContent, Message, TextContent } from "@dreb/ai";
 import { randomUUID } from "crypto";
@@ -13,7 +15,6 @@ import {
 	statSync,
 	writeFileSync,
 } from "fs";
-import { readdir, readFile, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import {
@@ -1375,6 +1376,55 @@ export class SessionManager {
 		}
 
 		return new SessionManager(targetCwd, dir, newSessionFile, true);
+	}
+
+	/**
+	 * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
+	 * Refuses to delete non-session files or missing files.
+	 */
+	static async deleteSession(
+		sessionPath: string,
+	): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
+		if (!sessionPath.endsWith(".jsonl")) {
+			return { ok: false, method: "unlink", error: `Not a session file (expected .jsonl): ${sessionPath}` };
+		}
+
+		if (!existsSync(sessionPath)) {
+			return { ok: false, method: "unlink", error: `Session file does not exist: ${sessionPath}` };
+		}
+
+		// Try `trash` first (if installed)
+		const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
+		const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+
+		const getTrashErrorHint = (): string | null => {
+			const parts: string[] = [];
+			if (trashResult.error) {
+				parts.push(trashResult.error.message);
+			}
+			const stderr = trashResult.stderr?.trim();
+			if (stderr) {
+				parts.push(stderr.split("\n")[0] ?? stderr);
+			}
+			if (parts.length === 0) return null;
+			return `trash: ${parts.join(" · ").slice(0, 200)}`;
+		};
+
+		// If trash reports success, or the file is gone afterwards, treat it as successful
+		if (trashResult.status === 0 || !existsSync(sessionPath)) {
+			return { ok: true, method: "trash" };
+		}
+
+		// Fallback to permanent deletion
+		try {
+			await unlink(sessionPath);
+			return { ok: true, method: "unlink" };
+		} catch (err) {
+			const unlinkError = err instanceof Error ? err.message : String(err);
+			const trashErrorHint = getTrashErrorHint();
+			const error = trashErrorHint ? `${unlinkError} (${trashErrorHint})` : unlinkError;
+			return { ok: false, method: "unlink", error };
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -12,11 +12,10 @@ import {
 	readdirSync,
 	readFileSync,
 	readSync,
-	realpathSync,
 	statSync,
 	writeFileSync,
 } from "fs";
-import { basename, dirname, join, resolve, sep } from "path";
+import { join, resolve } from "path";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import {
 	type BashExecutionMessage,
@@ -558,27 +557,13 @@ function getSessionCreatedDate(header: SessionHeader, statsMtime: Date): Date {
 }
 
 /**
- * Canonicalize a directory path, dereferencing symlinks via realpathSync. Falls back to the
- * purely-lexical resolve() when the directory does not exist yet (realpath throws ENOENT).
+ * Canonicalize a session path for the deletion guards. Collapses `.`/`..` and relative
+ * segments and absolutizes via the purely-lexical `resolve()`. This is a trusted local
+ * channel with the same path-based addressing as `switch_session`, so no symlink-escape
+ * or sessions-directory containment defense is applied here (see PR #315 discussion).
  */
-function canonicalizeDir(dir: string): string {
-	const lexical = resolve(dir);
-	try {
-		return realpathSync(lexical);
-	} catch {
-		return lexical;
-	}
-}
-
-/**
- * Canonicalize a file path for the deletion guards. The containing directory is resolved
- * through realpathSync so a symlinked parent component cannot smuggle the target outside the
- * sessions tree; the basename is preserved (not dereferenced) so a session file that is itself
- * a symlink is addressed and deleted directly rather than followed to another name.
- */
-function canonicalizeForDeletion(filePath: string): string {
-	const lexical = resolve(filePath);
-	return join(canonicalizeDir(dirname(lexical)), basename(lexical));
+function resolveForDeletion(filePath: string): string {
+	return resolve(filePath);
 }
 
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
@@ -1418,55 +1403,39 @@ export class SessionManager {
 
 	/**
 	 * Delete a session file, trying the `trash` CLI first, then falling back to unlink.
-	 * Refuses to delete non-session files, missing files, paths outside the sessions
-	 * directory, or the currently active session.
+	 * Refuses to delete non-session files, missing files, or the currently active session.
 	 *
-	 * The path is canonicalized with `realpathSync` (which dereferences symlinked path
-	 * components, unlike the purely-lexical `resolve()`) before every check and before
-	 * deletion, so a non-canonical spelling — relative segments, `..`, or a symlinked
-	 * parent directory pointing outside the sessions tree — cannot bypass the containment
-	 * or active-session guards.
+	 * Uses the same path-based addressing as `switch_session`: the path is `resolve()`d
+	 * (collapsing `.`/`..`/relative segments) before the active-session compare and before
+	 * deletion. This is a trusted local channel, so there is no sessions-directory containment
+	 * guard — see the PR #315 discussion for the rationale (the sibling `switch_session`
+	 * command is likewise unrestricted, and the dashboard owns its own authorization layer).
 	 *
 	 * @param sessionPath Path to the session file to delete.
-	 * @param opts.allowedDirs Additional directories (beyond the global sessions directory)
-	 *   whose contents may be deleted — e.g. a custom `--session-dir`.
-	 * @param opts.activeSessionPath If provided, refuses to delete this session (defense-in-depth
-	 *   for the active-session guard; callers should still guard at their own layer).
+	 * @param opts.activeSessionPath If provided, refuses to delete this session (the active-session
+	 *   guard; callers may also guard at their own layer).
 	 */
 	static async deleteSession(
 		sessionPath: string,
-		opts: { allowedDirs?: string[]; activeSessionPath?: string } = {},
+		opts: { activeSessionPath?: string } = {},
 	): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
-		// Canonicalize once so no guard below can be bypassed by a non-canonical spelling
-		// (relative segments, `..`, or a symlinked parent directory).
-		const resolvedPath = canonicalizeForDeletion(sessionPath);
+		// Resolve once so the active-session compare below can't be bypassed by a non-canonical
+		// spelling (relative segments or `..`).
+		const resolvedPath = resolveForDeletion(sessionPath);
 
 		if (!resolvedPath.endsWith(".jsonl")) {
 			return { ok: false, method: "unlink", error: `Not a session file (expected .jsonl): ${sessionPath}` };
 		}
 
-		if (opts.activeSessionPath && resolvedPath === canonicalizeForDeletion(opts.activeSessionPath)) {
+		if (opts.activeSessionPath && resolvedPath === resolveForDeletion(opts.activeSessionPath)) {
 			return { ok: false, method: "unlink", error: "Cannot delete the currently active session" };
-		}
-
-		// Containment guard: the resolved path must live inside the global sessions directory
-		// or one of the explicitly allowed directories (e.g. a custom --session-dir). Roots are
-		// canonicalized the same way so symlinked roots (e.g. macOS /tmp -> /private/tmp) match.
-		const allowedRoots = [getSessionsDir(), ...(opts.allowedDirs ?? [])].map((dir) => canonicalizeDir(dir));
-		const isContained = allowedRoots.some((root) => resolvedPath.startsWith(root + sep));
-		if (!isContained) {
-			return {
-				ok: false,
-				method: "unlink",
-				error: `Refusing to delete a path outside the sessions directory: ${sessionPath}`,
-			};
 		}
 
 		if (!existsSync(resolvedPath)) {
 			return { ok: false, method: "unlink", error: `Session file does not exist: ${sessionPath}` };
 		}
 
-		// Try `trash` first (if installed). The path is absolute after canonicalization, so it
+		// Try `trash` first (if installed). The path is absolute after resolve(), so it
 		// can never be mistaken for a flag — no `--` guard needed. A timeout prevents a hung
 		// `trash` (e.g. a stuck network/FUSE trash location) from freezing the caller, since
 		// spawnSync blocks synchronously; on timeout we fall through to unlink.
@@ -1522,52 +1491,46 @@ export class SessionManager {
 	static async listAll(onProgress?: SessionListProgress): Promise<SessionInfo[]> {
 		const sessionsDir = getSessionsDir();
 
-		try {
-			if (!existsSync(sessionsDir)) {
-				return [];
-			}
-			const entries = await readdir(sessionsDir, { withFileTypes: true });
-			const dirs = entries.filter((e) => e.isDirectory()).map((e) => join(sessionsDir, e.name));
-
-			// Count total files first for accurate progress
-			let totalFiles = 0;
-			const dirFiles: string[][] = [];
-			for (const dir of dirs) {
-				try {
-					const files = (await readdir(dir)).filter((f) => f.endsWith(".jsonl"));
-					dirFiles.push(files.map((f) => join(dir, f)));
-					totalFiles += files.length;
-				} catch {
-					/* Directory unreadable — skip */
-					dirFiles.push([]);
-				}
-			}
-
-			// Process all files with progress tracking
-			let loaded = 0;
-			const sessions: SessionInfo[] = [];
-			const allFiles = dirFiles.flat();
-
-			const results = await Promise.all(
-				allFiles.map(async (file) => {
-					const info = await buildSessionInfo(file);
-					loaded++;
-					onProgress?.(loaded, totalFiles);
-					return info;
-				}),
-			);
-
-			for (const info of results) {
-				if (info) {
-					sessions.push(info);
-				}
-			}
-
-			sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
-			return sessions;
-		} catch {
-			/* Session listing failed — return empty list */
+		// A missing sessions directory is a legitimate empty state (fresh install), not a
+		// failure — return []. Any actual I/O failure below propagates loudly so callers can
+		// distinguish "no sessions" from "listing failed" (RPC responds success:false; the TUI
+		// selector surfaces "Failed to load sessions"). No silent catch-and-return-[].
+		if (!existsSync(sessionsDir)) {
 			return [];
 		}
+		const entries = await readdir(sessionsDir, { withFileTypes: true });
+		const dirs = entries.filter((e) => e.isDirectory()).map((e) => join(sessionsDir, e.name));
+
+		// Count total files first for accurate progress
+		let totalFiles = 0;
+		const dirFiles: string[][] = [];
+		for (const dir of dirs) {
+			const files = (await readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+			dirFiles.push(files.map((f) => join(dir, f)));
+			totalFiles += files.length;
+		}
+
+		// Process all files with progress tracking
+		let loaded = 0;
+		const sessions: SessionInfo[] = [];
+		const allFiles = dirFiles.flat();
+
+		const results = await Promise.all(
+			allFiles.map(async (file) => {
+				const info = await buildSessionInfo(file);
+				loaded++;
+				onProgress?.(loaded, totalFiles);
+				return info;
+			}),
+		);
+
+		for (const info of results) {
+			if (info) {
+				sessions.push(info);
+			}
+		}
+
+		sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+		return sessions;
 	}
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -26,7 +26,7 @@ import { restoreStdout, takeOverStdout } from "./core/output-guard.js";
 import { DefaultPackageManager } from "./core/package-manager.js";
 import { DefaultResourceLoader } from "./core/resource-loader.js";
 import { type CreateAgentSessionOptions, createAgentSession } from "./core/sdk.js";
-import { SessionManager } from "./core/session-manager.js";
+import { type SessionInfo, SessionManager } from "./core/session-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { allTools } from "./core/tools/index.js";
@@ -357,8 +357,17 @@ async function resolveSessionPath(sessionArg: string, cwd: string, sessionDir?: 
 		return { type: "local", path: localMatches[0].path };
 	}
 
-	// Try global search across all projects
-	const allSessions = await SessionManager.listAll();
+	// Try global search across all projects. listAll fails loud on real I/O errors —
+	// convert a rejection into a clean, actionable exit instead of a raw stack dump,
+	// matching the RPC (success:false) and TUI ("Failed to load sessions") consumers.
+	let allSessions: SessionInfo[];
+	try {
+		allSessions = await SessionManager.listAll();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		log.error(chalk.red(`Failed to list sessions while resolving '${sessionArg}': ${message}`));
+		process.exit(1);
+	}
 	const globalMatches = allSessions.filter((s) => s.id.startsWith(sessionArg));
 
 	if (globalMatches.length >= 1) {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,4 +1,5 @@
 import * as os from "node:os";
+import { dirname } from "node:path";
 import {
 	type Component,
 	Container,
@@ -762,7 +763,13 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
-			const result = await SessionManager.deleteSession(sessionPath);
+			// Allow deletion of sessions in the active session's own directory too, so a custom
+			// `--session-dir` (which may live outside the global sessions directory) still works.
+			const allowedDirs = currentSessionFilePath ? [dirname(currentSessionFilePath)] : [];
+			const result = await SessionManager.deleteSession(sessionPath, {
+				allowedDirs,
+				activeSessionPath: currentSessionFilePath,
+			});
 
 			if (result.ok) {
 				if (this.currentSessions) {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,6 +1,3 @@
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { unlink } from "node:fs/promises";
 import * as os from "node:os";
 import {
 	type Component,
@@ -14,7 +11,7 @@ import {
 	visibleWidth,
 } from "@dreb/tui";
 import { KeybindingsManager } from "../../../core/keybindings.js";
-import type { SessionInfo, SessionListProgress } from "../../../core/session-manager.js";
+import { type SessionInfo, type SessionListProgress, SessionManager } from "../../../core/session-manager.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
@@ -613,46 +610,6 @@ class SessionList implements Component, Focusable {
 type SessionsLoader = (onProgress?: SessionListProgress) => Promise<SessionInfo[]>;
 
 /**
- * Delete a session file, trying the `trash` CLI first, then falling back to unlink
- */
-async function deleteSessionFile(
-	sessionPath: string,
-): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
-	// Try `trash` first (if installed)
-	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
-	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
-
-	const getTrashErrorHint = (): string | null => {
-		const parts: string[] = [];
-		if (trashResult.error) {
-			parts.push(trashResult.error.message);
-		}
-		const stderr = trashResult.stderr?.trim();
-		if (stderr) {
-			parts.push(stderr.split("\n")[0] ?? stderr);
-		}
-		if (parts.length === 0) return null;
-		return `trash: ${parts.join(" · ").slice(0, 200)}`;
-	};
-
-	// If trash reports success, or the file is gone afterwards, treat it as successful
-	if (trashResult.status === 0 || !existsSync(sessionPath)) {
-		return { ok: true, method: "trash" };
-	}
-
-	// Fallback to permanent deletion
-	try {
-		await unlink(sessionPath);
-		return { ok: true, method: "unlink" };
-	} catch (err) {
-		const unlinkError = err instanceof Error ? err.message : String(err);
-		const trashErrorHint = getTrashErrorHint();
-		const error = trashErrorHint ? `${unlinkError} (${trashErrorHint})` : unlinkError;
-		return { ok: false, method: "unlink", error };
-	}
-}
-
-/**
  * Component that renders a session selector
  */
 export class SessionSelectorComponent extends Container implements Focusable {
@@ -805,7 +762,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
-			const result = await deleteSessionFile(sessionPath);
+			const result = await SessionManager.deleteSession(sessionPath);
 
 			if (result.ok) {
 				if (this.currentSessions) {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,5 +1,4 @@
 import * as os from "node:os";
-import { dirname } from "node:path";
 import {
 	type Component,
 	Container,
@@ -763,11 +762,7 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
-			// Allow deletion of sessions in the active session's own directory too, so a custom
-			// `--session-dir` (which may live outside the global sessions directory) still works.
-			const allowedDirs = currentSessionFilePath ? [dirname(currentSessionFilePath)] : [];
 			const result = await SessionManager.deleteSession(sessionPath, {
-				allowedDirs,
 				activeSessionPath: currentSessionFilePath,
 			});
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -454,6 +454,15 @@ export class RpcClient {
 	}
 
 	/**
+	 * Delete a session file, trying trash first and falling back to unlink.
+	 * Throws on failure, including when attempting to delete the active session.
+	 */
+	async deleteSession(sessionPath: string): Promise<{ method: "trash" | "unlink" }> {
+		const response = await this.send({ type: "delete_session", sessionPath });
+		return this.getData(response);
+	}
+
+	/**
 	 * Fork from a specific message.
 	 * @returns Object with `text` (the message text) and `cancelled` (if extension cancelled)
 	 */
@@ -507,6 +516,15 @@ export class RpcClient {
 	 */
 	async listSessions(): Promise<RpcSessionInfo[]> {
 		const response = await this.send({ type: "list_sessions" });
+		return this.getData<{ sessions: RpcSessionInfo[] }>(response).sessions;
+	}
+
+	/**
+	 * List sessions across all projects.
+	 * Returns sessions sorted by most recently modified first. May be slow with many sessions.
+	 */
+	async listAllSessions(): Promise<RpcSessionInfo[]> {
+		const response = await this.send({ type: "list_all_sessions" });
 		return this.getData<{ sessions: RpcSessionInfo[] }>(response).sessions;
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -12,7 +12,6 @@
  */
 
 import * as crypto from "node:crypto";
-import { resolve } from "node:path";
 import { VERSION } from "../../config.js";
 import type { AgentSession } from "../../core/agent-session.js";
 import type {
@@ -67,6 +66,35 @@ export function getPerformanceStatsData(session: Pick<AgentSession, "getPerforma
 } {
 	const tracker = session.getPerformanceTracker();
 	return { models: tracker.getAllRollingAverages() };
+}
+
+/**
+ * Handle the `delete_session` RPC command: wires the active session and its directory into
+ * the core {@link SessionManager.deleteSession} guards and maps the result to a discriminated
+ * union the handler serializes. Extracted (like {@link getPerformanceStatsData}) so the guard
+ * wiring is unit-testable without a live RPC session. Note: the authoritative active-session
+ * and containment/canonicalization guards live in core — this passes the active path and the
+ * session directory through; it does not re-implement them.
+ */
+export async function deleteSessionForRpc(
+	sessionManager: Pick<SessionManager, "getSessionFile" | "getSessionDir">,
+	sessionPath: string,
+): Promise<{ ok: true; method: "trash" | "unlink" } | { ok: false; error: string }> {
+	const activePath = sessionManager.getSessionFile();
+	const result = await SessionManager.deleteSession(sessionPath, {
+		allowedDirs: [sessionManager.getSessionDir()],
+		activeSessionPath: activePath,
+	});
+	if (!result.ok) {
+		return { ok: false, error: result.error ?? "Unknown deletion error" };
+	}
+	return { ok: true, method: result.method };
+}
+
+/** Handle the `list_all_sessions` RPC command: list every project's sessions as RPC DTOs. */
+export async function listAllSessionsForRpc(): Promise<RpcSessionInfo[]> {
+	const sessions = await SessionManager.listAll();
+	return sessions.map(toRpcSessionInfo);
 }
 
 /**
@@ -590,16 +618,9 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			}
 
 			case "delete_session": {
-				const activePath = session.sessionManager.getSessionFile();
-				if (activePath && resolve(command.sessionPath) === resolve(activePath)) {
-					return error(id, "delete_session", "Cannot delete the currently active session");
-				}
-				const result = await SessionManager.deleteSession(command.sessionPath, {
-					allowedDirs: [session.sessionManager.getSessionDir()],
-					activeSessionPath: activePath,
-				});
+				const result = await deleteSessionForRpc(session.sessionManager, command.sessionPath);
 				if (!result.ok) {
-					return error(id, "delete_session", result.error ?? "Unknown deletion error");
+					return error(id, "delete_session", result.error);
 				}
 				return success(id, "delete_session", { method: result.method });
 			}
@@ -652,8 +673,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			}
 
 			case "list_all_sessions": {
-				const sessions = await SessionManager.listAll();
-				return success(id, "list_all_sessions", { sessions: sessions.map(toRpcSessionInfo) });
+				return success(id, "list_all_sessions", { sessions: await listAllSessionsForRpc() });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -12,6 +12,7 @@
  */
 
 import * as crypto from "node:crypto";
+import { resolve } from "node:path";
 import { VERSION } from "../../config.js";
 import type { AgentSession } from "../../core/agent-session.js";
 import type {
@@ -21,6 +22,7 @@ import type {
 } from "../../core/extensions/index.js";
 import { parseModelPattern } from "../../core/model-resolver.js";
 import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
+import type { SessionInfo } from "../../core/session-manager.js";
 import { SessionManager } from "../../core/session-manager.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
@@ -42,6 +44,23 @@ export type {
 	RpcResponse,
 	RpcSessionState,
 } from "./rpc-types.js";
+
+/**
+ * Map a core {@link SessionInfo} to the RPC DTO, converting Date fields to ISO strings.
+ * Shared by the `list_sessions` and `list_all_sessions` handlers so their shapes cannot drift.
+ */
+export function toRpcSessionInfo(s: SessionInfo): RpcSessionInfo {
+	return {
+		path: s.path,
+		id: s.id,
+		cwd: s.cwd,
+		name: s.name,
+		created: s.created.toISOString(),
+		modified: s.modified.toISOString(),
+		messageCount: s.messageCount,
+		firstMessage: s.firstMessage,
+	};
+}
 
 export function getPerformanceStatsData(session: Pick<AgentSession, "getPerformanceTracker">): {
 	models: Array<{ provider: string; modelId: string; median: number; mean: number; count: number }>;
@@ -572,10 +591,13 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 
 			case "delete_session": {
 				const activePath = session.sessionManager.getSessionFile();
-				if (activePath && command.sessionPath === activePath) {
+				if (activePath && resolve(command.sessionPath) === resolve(activePath)) {
 					return error(id, "delete_session", "Cannot delete the currently active session");
 				}
-				const result = await SessionManager.deleteSession(command.sessionPath);
+				const result = await SessionManager.deleteSession(command.sessionPath, {
+					allowedDirs: [session.sessionManager.getSessionDir()],
+					activeSessionPath: activePath,
+				});
 				if (!result.ok) {
 					return error(id, "delete_session", result.error ?? "Unknown deletion error");
 				}
@@ -626,32 +648,12 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				const cwd = session.sessionManager.getCwd();
 				const sessionDir = session.sessionManager.getSessionDir();
 				const sessions = await SessionManager.list(cwd, sessionDir);
-				const data: RpcSessionInfo[] = sessions.map((s) => ({
-					path: s.path,
-					id: s.id,
-					cwd: s.cwd,
-					name: s.name,
-					created: s.created.toISOString(),
-					modified: s.modified.toISOString(),
-					messageCount: s.messageCount,
-					firstMessage: s.firstMessage,
-				}));
-				return success(id, "list_sessions", { sessions: data });
+				return success(id, "list_sessions", { sessions: sessions.map(toRpcSessionInfo) });
 			}
 
 			case "list_all_sessions": {
 				const sessions = await SessionManager.listAll();
-				const data: RpcSessionInfo[] = sessions.map((s) => ({
-					path: s.path,
-					id: s.id,
-					cwd: s.cwd,
-					name: s.name,
-					created: s.created.toISOString(),
-					modified: s.modified.toISOString(),
-					messageCount: s.messageCount,
-					firstMessage: s.firstMessage,
-				}));
-				return success(id, "list_all_sessions", { sessions: data });
+				return success(id, "list_all_sessions", { sessions: sessions.map(toRpcSessionInfo) });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -69,20 +69,20 @@ export function getPerformanceStatsData(session: Pick<AgentSession, "getPerforma
 }
 
 /**
- * Handle the `delete_session` RPC command: wires the active session and its directory into
- * the core {@link SessionManager.deleteSession} guards and maps the result to a discriminated
+ * Handle the `delete_session` RPC command: wires the active session into the core
+ * {@link SessionManager.deleteSession} guard and maps the result to a discriminated
  * union the handler serializes. Extracted (like {@link getPerformanceStatsData}) so the guard
  * wiring is unit-testable without a live RPC session. Note: the authoritative active-session
- * and containment/canonicalization guards live in core — this passes the active path and the
- * session directory through; it does not re-implement them.
+ * guard lives in core — this passes the active path through; it does not re-implement it.
+ * Uses the same unrestricted path-based addressing as `switch_session` (no containment guard —
+ * see PR #315 discussion).
  */
 export async function deleteSessionForRpc(
-	sessionManager: Pick<SessionManager, "getSessionFile" | "getSessionDir">,
+	sessionManager: Pick<SessionManager, "getSessionFile">,
 	sessionPath: string,
 ): Promise<{ ok: true; method: "trash" | "unlink" } | { ok: false; error: string }> {
 	const activePath = sessionManager.getSessionFile();
 	const result = await SessionManager.deleteSession(sessionPath, {
-		allowedDirs: [sessionManager.getSessionDir()],
 		activeSessionPath: activePath,
 	});
 	if (!result.ok) {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -570,6 +570,18 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				return success(id, "switch_session", { cancelled });
 			}
 
+			case "delete_session": {
+				const activePath = session.sessionManager.getSessionFile();
+				if (activePath && command.sessionPath === activePath) {
+					return error(id, "delete_session", "Cannot delete the currently active session");
+				}
+				const result = await SessionManager.deleteSession(command.sessionPath);
+				if (!result.ok) {
+					return error(id, "delete_session", result.error ?? "Unknown deletion error");
+				}
+				return success(id, "delete_session", { method: result.method });
+			}
+
 			case "fork": {
 				const result = await session.fork(command.entryId);
 				return success(id, "fork", { text: result.selectedText, cancelled: result.cancelled });
@@ -625,6 +637,21 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 					firstMessage: s.firstMessage,
 				}));
 				return success(id, "list_sessions", { sessions: data });
+			}
+
+			case "list_all_sessions": {
+				const sessions = await SessionManager.listAll();
+				const data: RpcSessionInfo[] = sessions.map((s) => ({
+					path: s.path,
+					id: s.id,
+					cwd: s.cwd,
+					name: s.name,
+					created: s.created.toISOString(),
+					modified: s.modified.toISOString(),
+					messageCount: s.messageCount,
+					firstMessage: s.firstMessage,
+				}));
+				return success(id, "list_all_sessions", { sessions: data });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -62,6 +62,7 @@ export type RpcCommand =
 	| { id?: string; type: "get_performance_stats" }
 	| { id?: string; type: "export_html"; outputPath?: string }
 	| { id?: string; type: "switch_session"; sessionPath: string }
+	| { id?: string; type: "delete_session"; sessionPath: string }
 	| { id?: string; type: "fork"; entryId: string }
 	| { id?: string; type: "get_fork_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
@@ -75,6 +76,7 @@ export type RpcCommand =
 
 	// Session listing
 	| { id?: string; type: "list_sessions" }
+	| { id?: string; type: "list_all_sessions" }
 
 	// Version
 	| { id?: string; type: "get_version" };
@@ -216,6 +218,7 @@ export type RpcResponse =
 	  }
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }
+	| { id?: string; type: "response"; command: "delete_session"; success: true; data: { method: "trash" | "unlink" } }
 	| { id?: string; type: "response"; command: "fork"; success: true; data: { text: string; cancelled: boolean } }
 	| {
 			id?: string;
@@ -250,6 +253,13 @@ export type RpcResponse =
 			id?: string;
 			type: "response";
 			command: "list_sessions";
+			success: true;
+			data: { sessions: RpcSessionInfo[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_all_sessions";
 			success: true;
 			data: { sessions: RpcSessionInfo[] };
 	  }

--- a/packages/coding-agent/test/rpc-session-commands.test.ts
+++ b/packages/coding-agent/test/rpc-session-commands.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../src/core/session-manager.js";
 import { RpcClient } from "../src/modes/rpc/rpc-client.js";
+import { toRpcSessionInfo } from "../src/modes/rpc/rpc-mode.js";
 import type { RpcSessionInfo } from "../src/modes/rpc/rpc-types.js";
+
+describe("toRpcSessionInfo", () => {
+	it("maps a SessionInfo to the RPC DTO, converting Date fields to ISO strings", () => {
+		const info: SessionInfo = {
+			path: "/home/user/.dreb/agent/sessions/project/session.jsonl",
+			id: "abc123",
+			cwd: "/home/user/project",
+			name: "feature-work",
+			created: new Date("2024-01-15T10:30:00.000Z"),
+			modified: new Date("2024-01-15T11:45:00.000Z"),
+			messageCount: 12,
+			firstMessage: "Help me refactor the auth module",
+			allMessagesText: "Help me refactor the auth module",
+		};
+
+		const dto = toRpcSessionInfo(info);
+
+		expect(dto).toEqual({
+			path: "/home/user/.dreb/agent/sessions/project/session.jsonl",
+			id: "abc123",
+			cwd: "/home/user/project",
+			name: "feature-work",
+			created: "2024-01-15T10:30:00.000Z",
+			modified: "2024-01-15T11:45:00.000Z",
+			messageCount: 12,
+			firstMessage: "Help me refactor the auth module",
+		});
+		// Dates must be serialized to strings, not left as Date objects.
+		expect(typeof dto.created).toBe("string");
+		expect(typeof dto.modified).toBe("string");
+	});
+});
 
 describe("RPC session commands", () => {
 	it("RpcClient.listAllSessions sends the list_all_sessions command and unwraps sessions", async () => {

--- a/packages/coding-agent/test/rpc-session-commands.test.ts
+++ b/packages/coding-agent/test/rpc-session-commands.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { RpcClient } from "../src/modes/rpc/rpc-client.js";
+import type { RpcSessionInfo } from "../src/modes/rpc/rpc-types.js";
+
+describe("RPC session commands", () => {
+	it("RpcClient.listAllSessions sends the list_all_sessions command and unwraps sessions", async () => {
+		const client = new RpcClient() as any;
+		const sessions: RpcSessionInfo[] = [
+			{
+				path: "/home/user/.dreb/agent/sessions/project/session.jsonl",
+				id: "abc123",
+				cwd: "/home/user/project",
+				name: "feature-work",
+				created: "2024-01-15T10:30:00.000Z",
+				modified: "2024-01-15T11:45:00.000Z",
+				messageCount: 12,
+				firstMessage: "Help me refactor the auth module",
+			},
+		];
+		client.send = vi.fn().mockResolvedValue({
+			type: "response",
+			command: "list_all_sessions",
+			success: true,
+			data: { sessions },
+		});
+
+		await expect(client.listAllSessions()).resolves.toEqual(sessions);
+		expect(client.send).toHaveBeenCalledWith({ type: "list_all_sessions" });
+	});
+
+	it("RpcClient.deleteSession sends the delete_session command and returns deletion data", async () => {
+		const client = new RpcClient() as any;
+		const sessionPath = "/home/user/.dreb/agent/sessions/project/session.jsonl";
+		const data = { method: "trash" as const };
+		client.send = vi.fn().mockResolvedValue({
+			type: "response",
+			command: "delete_session",
+			success: true,
+			data,
+		});
+
+		await expect(client.deleteSession(sessionPath)).resolves.toEqual(data);
+		expect(client.send).toHaveBeenCalledWith({ type: "delete_session", sessionPath });
+	});
+
+	it("RpcClient.deleteSession rejects with the RPC error message on failure", async () => {
+		const client = new RpcClient() as any;
+		client.send = vi.fn().mockResolvedValue({
+			type: "response",
+			command: "delete_session",
+			success: false,
+			error: "Cannot delete the currently active session",
+		});
+
+		await expect(client.deleteSession("/tmp/current.jsonl")).rejects.toThrow(
+			"Cannot delete the currently active session",
+		);
+	});
+
+	it("RpcClient.listAllSessions rejects with the RPC error message on failure", async () => {
+		const client = new RpcClient() as any;
+		client.send = vi.fn().mockResolvedValue({
+			type: "response",
+			command: "list_all_sessions",
+			success: false,
+			error: "Unable to list sessions",
+		});
+
+		await expect(client.listAllSessions()).rejects.toThrow("Unable to list sessions");
+	});
+});

--- a/packages/coding-agent/test/rpc-session-commands.test.ts
+++ b/packages/coding-agent/test/rpc-session-commands.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, it, vi } from "vitest";
+import { existsSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionInfo } from "../src/core/session-manager.js";
+import { SessionManager } from "../src/core/session-manager.js";
 import { RpcClient } from "../src/modes/rpc/rpc-client.js";
-import { toRpcSessionInfo } from "../src/modes/rpc/rpc-mode.js";
+import { deleteSessionForRpc, listAllSessionsForRpc, toRpcSessionInfo } from "../src/modes/rpc/rpc-mode.js";
 import type { RpcSessionInfo } from "../src/modes/rpc/rpc-types.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "dreb-rpc-session-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
 
 describe("toRpcSessionInfo", () => {
 	it("maps a SessionInfo to the RPC DTO, converting Date fields to ISO strings", () => {
@@ -101,5 +119,87 @@ describe("RPC session commands", () => {
 		});
 
 		await expect(client.listAllSessions()).rejects.toThrow("Unable to list sessions");
+	});
+});
+
+describe("deleteSessionForRpc (server-side handler wiring)", () => {
+	function stubSessionManager(sessionDir: string, activeFile?: string) {
+		return {
+			getSessionDir: () => sessionDir,
+			getSessionFile: () => activeFile,
+		} satisfies Pick<SessionManager, "getSessionDir" | "getSessionFile">;
+	}
+
+	it("refuses to delete the active session without touching the filesystem", async () => {
+		const dir = await createTempDir();
+		const activePath = join(dir, "active.jsonl");
+		writeFileSync(activePath, "{}\n", "utf8");
+
+		const result = await deleteSessionForRpc(stubSessionManager(dir, activePath), activePath);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error).toContain("Cannot delete the currently active session");
+		// The active-session guard fires before any deletion — the file must survive.
+		expect(existsSync(activePath)).toBe(true);
+	});
+
+	it("deletes a valid session under the active session directory and reports the method", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "session.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		// No active session; the file lives under the (allowed) active session directory.
+		const result = await deleteSessionForRpc(stubSessionManager(dir), sessionPath);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+		expect(["trash", "unlink"]).toContain(result.method);
+		expect(existsSync(sessionPath)).toBe(false);
+	});
+
+	it("surfaces the core error for a nonexistent session path", async () => {
+		const dir = await createTempDir();
+		const result = await deleteSessionForRpc(stubSessionManager(dir), join(dir, "missing.jsonl"));
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error).toContain("does not exist");
+	});
+
+	it("surfaces the containment error for a path outside the sessions directory", async () => {
+		const allowedDir = await createTempDir();
+		const outsideDir = await createTempDir();
+		const outside = join(outsideDir, "outside.jsonl");
+		writeFileSync(outside, "{}\n", "utf8");
+
+		const result = await deleteSessionForRpc(stubSessionManager(allowedDir), outside);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error).toContain("outside the sessions directory");
+		expect(existsSync(outside)).toBe(true);
+	});
+});
+
+describe("listAllSessionsForRpc (server-side handler wiring)", () => {
+	it("maps every SessionManager.listAll() result through toRpcSessionInfo (Date -> ISO)", async () => {
+		const info: SessionInfo = {
+			path: "/home/user/.dreb/agent/sessions/project/session.jsonl",
+			id: "abc123",
+			cwd: "/home/user/project",
+			name: "feature-work",
+			created: new Date("2024-01-15T10:30:00.000Z"),
+			modified: new Date("2024-01-15T11:45:00.000Z"),
+			messageCount: 3,
+			firstMessage: "hi",
+			allMessagesText: "hi",
+		};
+		vi.spyOn(SessionManager, "listAll").mockResolvedValue([info]);
+
+		const dtos = await listAllSessionsForRpc();
+
+		expect(dtos).toEqual([toRpcSessionInfo(info)]);
+		expect(typeof dtos[0]?.created).toBe("string");
 	});
 });

--- a/packages/coding-agent/test/rpc-session-commands.test.ts
+++ b/packages/coding-agent/test/rpc-session-commands.test.ts
@@ -123,11 +123,10 @@ describe("RPC session commands", () => {
 });
 
 describe("deleteSessionForRpc (server-side handler wiring)", () => {
-	function stubSessionManager(sessionDir: string, activeFile?: string) {
+	function stubSessionManager(activeFile?: string) {
 		return {
-			getSessionDir: () => sessionDir,
 			getSessionFile: () => activeFile,
-		} satisfies Pick<SessionManager, "getSessionDir" | "getSessionFile">;
+		} satisfies Pick<SessionManager, "getSessionFile">;
 	}
 
 	it("refuses to delete the active session without touching the filesystem", async () => {
@@ -135,7 +134,7 @@ describe("deleteSessionForRpc (server-side handler wiring)", () => {
 		const activePath = join(dir, "active.jsonl");
 		writeFileSync(activePath, "{}\n", "utf8");
 
-		const result = await deleteSessionForRpc(stubSessionManager(dir, activePath), activePath);
+		const result = await deleteSessionForRpc(stubSessionManager(activePath), activePath);
 
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("unreachable");
@@ -144,13 +143,13 @@ describe("deleteSessionForRpc (server-side handler wiring)", () => {
 		expect(existsSync(activePath)).toBe(true);
 	});
 
-	it("deletes a valid session under the active session directory and reports the method", async () => {
+	it("deletes a valid session and reports the method", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "session.jsonl");
 		writeFileSync(sessionPath, "{}\n", "utf8");
 
-		// No active session; the file lives under the (allowed) active session directory.
-		const result = await deleteSessionForRpc(stubSessionManager(dir), sessionPath);
+		// No active session; same unrestricted path addressing as switch_session (no containment).
+		const result = await deleteSessionForRpc(stubSessionManager(), sessionPath);
 
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error("unreachable");
@@ -160,25 +159,24 @@ describe("deleteSessionForRpc (server-side handler wiring)", () => {
 
 	it("surfaces the core error for a nonexistent session path", async () => {
 		const dir = await createTempDir();
-		const result = await deleteSessionForRpc(stubSessionManager(dir), join(dir, "missing.jsonl"));
+		const result = await deleteSessionForRpc(stubSessionManager(), join(dir, "missing.jsonl"));
 
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("unreachable");
 		expect(result.error).toContain("does not exist");
 	});
 
-	it("surfaces the containment error for a path outside the sessions directory", async () => {
-		const allowedDir = await createTempDir();
-		const outsideDir = await createTempDir();
-		const outside = join(outsideDir, "outside.jsonl");
-		writeFileSync(outside, "{}\n", "utf8");
+	it("surfaces the core error for a non-.jsonl path without deleting it", async () => {
+		const dir = await createTempDir();
+		const filePath = join(dir, "not-a-session.txt");
+		writeFileSync(filePath, "keep me\n", "utf8");
 
-		const result = await deleteSessionForRpc(stubSessionManager(allowedDir), outside);
+		const result = await deleteSessionForRpc(stubSessionManager(), filePath);
 
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("unreachable");
-		expect(result.error).toContain("outside the sessions directory");
-		expect(existsSync(outside)).toBe(true);
+		expect(result.error).toContain("Not a session file");
+		expect(existsSync(filePath)).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/session-info-created-timestamp.test.ts
+++ b/packages/coding-agent/test/session-info-created-timestamp.test.ts
@@ -1,0 +1,70 @@
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+import { toRpcSessionInfo } from "../src/modes/rpc/rpc-mode.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "dreb-session-created-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Write a session file whose header has the given (possibly invalid) timestamp value. */
+function writeSessionWithTimestamp(path: string, timestamp: unknown): void {
+	const header: Record<string, unknown> = {
+		type: "session",
+		id: "test-session",
+		version: 3,
+		cwd: "/tmp",
+	};
+	if (timestamp !== undefined) header.timestamp = timestamp;
+	writeFileSync(path, `${JSON.stringify(header)}\n`, "utf8");
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("SessionInfo.created guard", () => {
+	it("falls back to a valid Date when the header timestamp is missing", async () => {
+		const dir = await createTempDir();
+		writeSessionWithTimestamp(join(dir, "no-timestamp.jsonl"), undefined);
+
+		const sessions = await SessionManager.list("/tmp", dir);
+
+		expect(sessions).toHaveLength(1);
+		// A missing header timestamp must NOT yield an Invalid Date.
+		expect(Number.isNaN(sessions[0]?.created.getTime())).toBe(false);
+	});
+
+	it("falls back to a valid Date when the header timestamp is malformed", async () => {
+		const dir = await createTempDir();
+		writeSessionWithTimestamp(join(dir, "bad-timestamp.jsonl"), "not-a-real-date");
+
+		const sessions = await SessionManager.list("/tmp", dir);
+
+		expect(sessions).toHaveLength(1);
+		expect(Number.isNaN(sessions[0]?.created.getTime())).toBe(false);
+	});
+
+	it("does not throw when a session with a bad timestamp is serialized to the RPC DTO", async () => {
+		// Regression: an Invalid Date reaches toRpcSessionInfo's created.toISOString(), which
+		// throws RangeError — and because listings map over every session, one bad file would
+		// take down the entire list_all_sessions response.
+		const dir = await createTempDir();
+		writeSessionWithTimestamp(join(dir, "bad-timestamp.jsonl"), "garbage");
+
+		const sessions = await SessionManager.list("/tmp", dir);
+		expect(sessions).toHaveLength(1);
+
+		const info = sessions[0];
+		if (!info) throw new Error("expected a session");
+		expect(() => toRpcSessionInfo(info)).not.toThrow();
+		expect(typeof toRpcSessionInfo(info).created).toBe("string");
+	});
+});

--- a/packages/coding-agent/test/session-manager-delete.test.ts
+++ b/packages/coding-agent/test/session-manager-delete.test.ts
@@ -40,12 +40,16 @@ afterEach(async () => {
 });
 
 describe("SessionManager.deleteSession", () => {
+	// deleteSession uses the same unrestricted path-based addressing as switch_session:
+	// there is no sessions-directory containment guard, so a .jsonl file anywhere the process
+	// can write (here, a temp dir outside the global sessions directory) is deletable. See the
+	// PR #315 discussion for the rationale.
 	it("deletes an existing .jsonl file via unlink and reports the method", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "session.jsonl");
 		writeFileSync(sessionPath, "{}\n", "utf8");
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(true);
 		expect(result.method).toBe("unlink");
@@ -66,7 +70,7 @@ describe("SessionManager.deleteSession", () => {
 			stderr: "",
 		} as unknown as ReturnType<typeof spawnSync>);
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(true);
 		expect(result.method).toBe("trash");
@@ -92,7 +96,7 @@ describe("SessionManager.deleteSession", () => {
 			} as unknown as ReturnType<typeof spawnSync>;
 		}) as unknown as typeof spawnSync);
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(true);
 		expect(result.method).toBe("trash");
@@ -113,7 +117,7 @@ describe("SessionManager.deleteSession", () => {
 			stderr: "trash: permission denied\nsecond line ignored",
 		} as unknown as ReturnType<typeof spawnSync>);
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("trash: ");
@@ -137,7 +141,7 @@ describe("SessionManager.deleteSession", () => {
 			error: new Error("spawn trash EACCES"),
 		} as unknown as ReturnType<typeof spawnSync>);
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(false);
 		// Both the spawn error message and the first stderr line are composed into the hint.
@@ -150,7 +154,7 @@ describe("SessionManager.deleteSession", () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "missing.jsonl");
 
-		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(sessionPath);
 
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("does not exist");
@@ -161,81 +165,21 @@ describe("SessionManager.deleteSession", () => {
 		const filePath = join(dir, "not-a-session.txt");
 		writeFileSync(filePath, "do not delete\n", "utf8");
 
-		const result = await SessionManager.deleteSession(filePath, { allowedDirs: [dir] });
+		const result = await SessionManager.deleteSession(filePath);
 
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("Not a session file");
 		expect(existsSync(filePath)).toBe(true);
 	});
 
-	it("refuses to delete a path outside the sessions directory", async () => {
-		const dir = await createTempDir();
-		const sessionPath = join(dir, "outside.jsonl");
-		writeFileSync(sessionPath, "{}\n", "utf8");
-
-		// No allowedDirs: the temp dir is outside the global sessions directory.
-		const result = await SessionManager.deleteSession(sessionPath);
-
-		expect(result.ok).toBe(false);
-		expect(result.error).toContain("outside the sessions directory");
-		expect(existsSync(sessionPath)).toBe(true);
-	});
-
-	it("refuses to delete the active session even via a non-canonical path (guard cannot be bypassed)", async () => {
+	it("refuses to delete the active session even via a non-canonical (./..) path", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "active.jsonl");
 		writeFileSync(sessionPath, "{}\n", "utf8");
 
-		// A non-canonical spelling of the same file must still be refused.
-		const nonCanonical = join(dir, ".", "active.jsonl");
+		// A non-canonical spelling of the same file must still be refused after resolve().
+		const nonCanonical = join(dir, "sub", "..", ".", "active.jsonl");
 		const result = await SessionManager.deleteSession(nonCanonical, {
-			allowedDirs: [dir],
-			activeSessionPath: sessionPath,
-		});
-
-		expect(result.ok).toBe(false);
-		expect(result.error).toContain("Cannot delete the currently active session");
-		expect(existsSync(sessionPath)).toBe(true);
-	});
-
-	it("refuses a path whose symlinked parent directory points outside the allowed roots", async () => {
-		// The containment guard must dereference symlinks (realpathSync), not just resolve()
-		// lexically — otherwise a symlinked directory inside an allowed root smuggles the real
-		// deletion target outside the sessions tree.
-		const { symlinkSync } = await import("node:fs");
-		const outsideDir = await createTempDir(); // the real (forbidden) deletion target
-		const sessionsRoot = await createTempDir(); // an allowed root
-		const victim = join(outsideDir, "victim.jsonl");
-		writeFileSync(victim, "{}\n", "utf8");
-
-		// sessionsRoot/link -> outsideDir. Lexically, sessionsRoot/link/victim.jsonl looks
-		// contained; only realpath reveals it resolves to outsideDir/victim.jsonl.
-		const link = join(sessionsRoot, "link");
-		symlinkSync(outsideDir, link, "dir");
-
-		const result = await SessionManager.deleteSession(join(link, "victim.jsonl"), {
-			allowedDirs: [sessionsRoot],
-		});
-
-		expect(result.ok).toBe(false);
-		expect(result.error).toContain("outside the sessions directory");
-		expect(existsSync(victim)).toBe(true);
-	});
-
-	it("refuses the active session addressed through a symlinked parent directory", async () => {
-		// The active-session guard must also survive symlink spellings, not just `.`/`..`.
-		const { symlinkSync } = await import("node:fs");
-		const dir = await createTempDir();
-		const realDir = join(dir, "real");
-		mkdirSync(realDir);
-		const sessionPath = join(realDir, "active.jsonl");
-		writeFileSync(sessionPath, "{}\n", "utf8");
-
-		const linkedDir = join(dir, "link");
-		symlinkSync(realDir, linkedDir, "dir");
-
-		const result = await SessionManager.deleteSession(join(linkedDir, "active.jsonl"), {
-			allowedDirs: [dir],
 			activeSessionPath: sessionPath,
 		});
 

--- a/packages/coding-agent/test/session-manager-delete.test.ts
+++ b/packages/coding-agent/test/session-manager-delete.test.ts
@@ -1,0 +1,53 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../src/core/session-manager.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "dreb-session-delete-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("SessionManager.deleteSession", () => {
+	it("deletes an existing .jsonl file", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "session.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		const result = await SessionManager.deleteSession(sessionPath);
+
+		expect(result.ok).toBe(true);
+		expect(existsSync(sessionPath)).toBe(false);
+	});
+
+	it("fails for a nonexistent session path", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "missing.jsonl");
+
+		const result = await SessionManager.deleteSession(sessionPath);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("does not exist");
+	});
+
+	it("rejects non-.jsonl paths without deleting the file", async () => {
+		const dir = await createTempDir();
+		const filePath = join(dir, "not-a-session.txt");
+		writeFileSync(filePath, "do not delete\n", "utf8");
+
+		const result = await SessionManager.deleteSession(filePath);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Not a session file");
+		expect(existsSync(filePath)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/session-manager-delete.test.ts
+++ b/packages/coding-agent/test/session-manager-delete.test.ts
@@ -122,6 +122,30 @@ describe("SessionManager.deleteSession", () => {
 		expect(result.error).not.toContain("second line ignored");
 	});
 
+	it("includes both the spawn error and stderr in the hint when trash errored and unlink failed", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "stubborn.jsonl");
+		mkdirSync(sessionPath); // unlink() throws on a directory
+
+		mockSpawnSync.mockReturnValue({
+			status: null,
+			signal: null,
+			output: [],
+			pid: 0,
+			stdout: "",
+			stderr: "trash: cannot access",
+			error: new Error("spawn trash EACCES"),
+		} as unknown as ReturnType<typeof spawnSync>);
+
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+
+		expect(result.ok).toBe(false);
+		// Both the spawn error message and the first stderr line are composed into the hint.
+		expect(result.error).toContain("spawn trash EACCES");
+		expect(result.error).toContain(" · ");
+		expect(result.error).toContain("trash: cannot access");
+	});
+
 	it("fails for a nonexistent session path", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "missing.jsonl");
@@ -165,6 +189,52 @@ describe("SessionManager.deleteSession", () => {
 		// A non-canonical spelling of the same file must still be refused.
 		const nonCanonical = join(dir, ".", "active.jsonl");
 		const result = await SessionManager.deleteSession(nonCanonical, {
+			allowedDirs: [dir],
+			activeSessionPath: sessionPath,
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Cannot delete the currently active session");
+		expect(existsSync(sessionPath)).toBe(true);
+	});
+
+	it("refuses a path whose symlinked parent directory points outside the allowed roots", async () => {
+		// The containment guard must dereference symlinks (realpathSync), not just resolve()
+		// lexically — otherwise a symlinked directory inside an allowed root smuggles the real
+		// deletion target outside the sessions tree.
+		const { symlinkSync } = await import("node:fs");
+		const outsideDir = await createTempDir(); // the real (forbidden) deletion target
+		const sessionsRoot = await createTempDir(); // an allowed root
+		const victim = join(outsideDir, "victim.jsonl");
+		writeFileSync(victim, "{}\n", "utf8");
+
+		// sessionsRoot/link -> outsideDir. Lexically, sessionsRoot/link/victim.jsonl looks
+		// contained; only realpath reveals it resolves to outsideDir/victim.jsonl.
+		const link = join(sessionsRoot, "link");
+		symlinkSync(outsideDir, link, "dir");
+
+		const result = await SessionManager.deleteSession(join(link, "victim.jsonl"), {
+			allowedDirs: [sessionsRoot],
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("outside the sessions directory");
+		expect(existsSync(victim)).toBe(true);
+	});
+
+	it("refuses the active session addressed through a symlinked parent directory", async () => {
+		// The active-session guard must also survive symlink spellings, not just `.`/`..`.
+		const { symlinkSync } = await import("node:fs");
+		const dir = await createTempDir();
+		const realDir = join(dir, "real");
+		mkdirSync(realDir);
+		const sessionPath = join(realDir, "active.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		const linkedDir = join(dir, "link");
+		symlinkSync(realDir, linkedDir, "dir");
+
+		const result = await SessionManager.deleteSession(join(linkedDir, "active.jsonl"), {
 			allowedDirs: [dir],
 			activeSessionPath: sessionPath,
 		});

--- a/packages/coding-agent/test/session-manager-delete.test.ts
+++ b/packages/coding-agent/test/session-manager-delete.test.ts
@@ -1,9 +1,18 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the `trash` CLI so branch selection is deterministic regardless of whether
+// `trash` is installed on the machine running the tests. The default return simulates
+// `trash` being absent (ENOENT), so deletion falls through to the unlink path.
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
+
+import { spawnSync } from "node:child_process";
 import { SessionManager } from "../src/core/session-manager.js";
+
+const mockSpawnSync = vi.mocked(spawnSync);
 
 const tempDirs: string[] = [];
 
@@ -13,27 +22,111 @@ async function createTempDir(): Promise<string> {
 	return dir;
 }
 
+beforeEach(() => {
+	mockSpawnSync.mockReturnValue({
+		status: null,
+		signal: null,
+		output: [],
+		pid: 0,
+		stdout: "",
+		stderr: "",
+		error: new Error("spawn trash ENOENT"),
+	} as unknown as ReturnType<typeof spawnSync>);
+});
+
 afterEach(async () => {
+	vi.clearAllMocks();
 	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
 describe("SessionManager.deleteSession", () => {
-	it("deletes an existing .jsonl file", async () => {
+	it("deletes an existing .jsonl file via unlink and reports the method", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "session.jsonl");
 		writeFileSync(sessionPath, "{}\n", "utf8");
 
-		const result = await SessionManager.deleteSession(sessionPath);
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
 
 		expect(result.ok).toBe(true);
+		expect(result.method).toBe("unlink");
 		expect(existsSync(sessionPath)).toBe(false);
+	});
+
+	it("reports method 'trash' when the trash CLI succeeds", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "session.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		mockSpawnSync.mockReturnValue({
+			status: 0,
+			signal: null,
+			output: [],
+			pid: 0,
+			stdout: "",
+			stderr: "",
+		} as unknown as ReturnType<typeof spawnSync>);
+
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+
+		expect(result.ok).toBe(true);
+		expect(result.method).toBe("trash");
+	});
+
+	it("treats the file being gone after a nonzero trash exit as trash success", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "session.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		const { unlinkSync } = await import("node:fs");
+		// Simulate `trash` moving the file away but returning a nonzero status: the file
+		// still exists when the existence guard runs, then is gone after spawnSync.
+		mockSpawnSync.mockImplementation((() => {
+			unlinkSync(sessionPath);
+			return {
+				status: 1,
+				signal: null,
+				output: [],
+				pid: 0,
+				stdout: "",
+				stderr: "",
+			} as unknown as ReturnType<typeof spawnSync>;
+		}) as unknown as typeof spawnSync);
+
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+
+		expect(result.ok).toBe(true);
+		expect(result.method).toBe("trash");
+	});
+
+	it("composes a trash error hint when unlink also fails", async () => {
+		const dir = await createTempDir();
+		// A directory named like a session file: exists, ends in .jsonl, but unlink() throws.
+		const sessionPath = join(dir, "stubborn.jsonl");
+		mkdirSync(sessionPath);
+
+		mockSpawnSync.mockReturnValue({
+			status: 1,
+			signal: null,
+			output: [],
+			pid: 0,
+			stdout: "",
+			stderr: "trash: permission denied\nsecond line ignored",
+		} as unknown as ReturnType<typeof spawnSync>);
+
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("trash: ");
+		expect(result.error).toContain("permission denied");
+		// Only the first stderr line is included in the hint.
+		expect(result.error).not.toContain("second line ignored");
 	});
 
 	it("fails for a nonexistent session path", async () => {
 		const dir = await createTempDir();
 		const sessionPath = join(dir, "missing.jsonl");
 
-		const result = await SessionManager.deleteSession(sessionPath);
+		const result = await SessionManager.deleteSession(sessionPath, { allowedDirs: [dir] });
 
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("does not exist");
@@ -44,10 +137,40 @@ describe("SessionManager.deleteSession", () => {
 		const filePath = join(dir, "not-a-session.txt");
 		writeFileSync(filePath, "do not delete\n", "utf8");
 
-		const result = await SessionManager.deleteSession(filePath);
+		const result = await SessionManager.deleteSession(filePath, { allowedDirs: [dir] });
 
 		expect(result.ok).toBe(false);
 		expect(result.error).toContain("Not a session file");
 		expect(existsSync(filePath)).toBe(true);
+	});
+
+	it("refuses to delete a path outside the sessions directory", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "outside.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		// No allowedDirs: the temp dir is outside the global sessions directory.
+		const result = await SessionManager.deleteSession(sessionPath);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("outside the sessions directory");
+		expect(existsSync(sessionPath)).toBe(true);
+	});
+
+	it("refuses to delete the active session even via a non-canonical path (guard cannot be bypassed)", async () => {
+		const dir = await createTempDir();
+		const sessionPath = join(dir, "active.jsonl");
+		writeFileSync(sessionPath, "{}\n", "utf8");
+
+		// A non-canonical spelling of the same file must still be refused.
+		const nonCanonical = join(dir, ".", "active.jsonl");
+		const result = await SessionManager.deleteSession(nonCanonical, {
+			allowedDirs: [dir],
+			activeSessionPath: sessionPath,
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("Cannot delete the currently active session");
+		expect(existsSync(sessionPath)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/session-manager-listall.test.ts
+++ b/packages/coding-agent/test/session-manager-listall.test.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.js";
+import { SessionManager } from "../src/core/session-manager.js";
+
+// listAll() scans getSessionsDir() = <agentDir>/sessions. We point the agent dir at a temp
+// directory via the ENV_AGENT_DIR override so these tests never touch the real store.
+
+const tempDirs: string[] = [];
+const savedEnv = process.env[ENV_AGENT_DIR];
+
+async function createAgentDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "dreb-listall-"));
+	tempDirs.push(dir);
+	process.env[ENV_AGENT_DIR] = dir;
+	return dir;
+}
+
+function writeSession(path: string): void {
+	const header = { type: "session", id: "s", version: 3, cwd: "/tmp", timestamp: new Date().toISOString() };
+	writeFileSync(path, `${JSON.stringify(header)}\n`, "utf8");
+}
+
+afterEach(async () => {
+	if (savedEnv === undefined) delete process.env[ENV_AGENT_DIR];
+	else process.env[ENV_AGENT_DIR] = savedEnv;
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("SessionManager.listAll", () => {
+	it("lists sessions across project directories", async () => {
+		const agentDir = await createAgentDir();
+		const projectDir = join(agentDir, "sessions", "project-a");
+		mkdirSync(projectDir, { recursive: true });
+		writeSession(join(projectDir, "one.jsonl"));
+
+		const sessions = await SessionManager.listAll();
+
+		expect(sessions.map((s) => s.path)).toContain(join(projectDir, "one.jsonl"));
+	});
+
+	it("returns an empty list when the sessions directory does not exist yet (fresh install)", async () => {
+		await createAgentDir(); // agent dir exists, but no sessions/ subdirectory
+
+		await expect(SessionManager.listAll()).resolves.toEqual([]);
+	});
+
+	it("fails loudly instead of returning [] when the sessions listing errors", async () => {
+		// A missing directory is a legitimate empty state; an actual I/O failure is not. Here the
+		// sessions path exists but is a FILE, so readdir throws (ENOTDIR). The old outer
+		// catch { return [] } masked this as "no sessions" — regression guard for that behavior.
+		const agentDir = await createAgentDir();
+		writeFileSync(join(agentDir, "sessions"), "not a directory\n", "utf8");
+
+		await expect(SessionManager.listAll()).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
Closes #312

Adds `list_all_sessions` and `delete_session` RPC commands so external frontends (the planned web dashboard) can list sessions across all projects and delete sessions without importing SessionManager directly. Moves the trash-first deletion logic from the TUI session selector into core.

Implementation plan posted as a comment below.
