### PR TITLE
ci: fix publish workflow — npm 11.5.1 ci drops rollup native binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # Manual retry path: a failed publish run can be re-executed from master
+  # (publish steps skip versions that are already on npm, so retries are safe).
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -18,12 +21,19 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # Install and build with the stock npm bundled with Node 22 (npm 10.x) —
+      # the same toolchain the CI check/test jobs use and the one that generated
+      # package-lock.json. npm 11.5.1's `npm ci` silently skips platform-specific
+      # optional dependencies that the lockfile marks `optional: true, peer: true`
+      # (e.g. @rollup/rollup-linux-x64-gnu), which breaks the vite build.
+      - run: npm ci
+      - run: npm run build
+      # Trusted publishing (OIDC provenance) requires npm >= 11.5.1 — upgrade
+      # only for the publish steps, after install/build are done.
       - name: Upgrade npm for trusted publishing
         run: |
           npm install -g npm@11.5.1
           npm --version
-      - run: npm ci
-      - run: npm run build
 
       - name: Publish @dreb/tui
         working-directory: packages/tui

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ This builds all packages in dependency order: tui → ai → agent → semantic-
 
 - **Node:** `22.x` (enforced via `engines.node` in every workspace `package.json`, plus `.nvmrc` / `.node-version`). The Node 22 line bundles npm 10.x — that's what local dev and the CI `check`/`test` jobs run, and what generated the committed `package-lock.json`.
 - **`packageManager` pin:** the root `package.json` pins `packageManager: npm@11.5.1`. This deliberately matches the version the **publish** workflow (`.github/workflows/publish.yml`) upgrades to, because npm trusted publishing (OIDC provenance) requires npm ≥ 11.5.1. Keep these two in lockstep: if you bump one, bump the other.
-- **Why the npm 10 (dev) vs npm 11.5.1 (publish) split is safe:** the publish job installs with `npm ci`, which is **read-only** on `package-lock.json` — it installs exactly what is committed and never re-resolves the dependency graph. So building or publishing under npm 11.5.1 cannot mutate or re-churn a lockfile generated under npm 10.x. Lockfile changes only ever come from an intentional `npm install`.
+- **Publish workflow ordering matters:** the publish job runs `npm ci` + `npm run build` on the stock npm 10.x bundled with Node 22, and only *then* upgrades to npm 11.5.1 for the `npm publish` steps. Running `npm ci` under npm 11.5.1 silently skips platform-specific optional dependencies that the lockfile marks `optional: true, peer: true` (e.g. `@rollup/rollup-linux-x64-gnu`, needed by vite/rollup for the dashboard build), which breaks the build. Do not move the npm upgrade above install/build.
+- **Why the npm 10 (dev/install) vs npm 11.5.1 (publish-only) split is safe:** `npm publish` does not touch `package-lock.json`, and installs always run under npm 10.x — the same toolchain that generated the committed lockfile. Lockfile changes only ever come from an intentional `npm install`.
 
 ## Monorepo Structure
 


### PR DESCRIPTION
The v2.35.0 publish run failed in `npm run build`: the dashboard's vite build could not load `@rollup/rollup-linux-x64-gnu`.

Root cause, reproduced locally against the exact merge commit:

- The publish workflow upgraded to npm 11.5.1 **before** `npm ci`.
- npm 11.5.1's `npm ci` silently skips platform-specific optional dependencies that the lockfile marks `optional: true, peer: true` — which is exactly how rollup's native binaries appear in a lockfile generated by npm 10 (vite pulls rollup as a peer/optional graph). Result: `node_modules/@rollup/rollup-linux-x64-gnu` missing, vite build dead.
- Reproduction: `npm ci` with npm 11.5.1 → native rollup binary MISSING; same tree with npm 10.9.3 → PRESENT. This never bit before because v2.35.0 is the first release including `@dreb/dashboard` (the only vite build in the workspace).

Fix:

- Publish workflow now runs `npm ci` + `npm run build` on the stock npm 10.x bundled with Node 22 (the same toolchain as CI and local dev, and the one that generated the lockfile), and upgrades to npm 11.5.1 **after** the build, only for the `npm publish` steps (trusted publishing needs ≥ 11.5.1). Verified locally that publish-under-11.5.1 semantics are unaffected: `npm publish` doesn't touch the lockfile or node_modules.
- Added `workflow_dispatch` to the publish workflow so the failed v2.35.0 publish can be retried from master once this lands (all publish steps skip versions already on npm, so the retry is idempotent).
- AGENTS.md toolchain notes updated to document the ordering constraint.

After merge: re-run the publish workflow via `gh workflow run publish.yml`.
