### PR TITLE
Fix dashboard container width shrink-wrap causing fleet layout jitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10908,7 +10908,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10937,7 +10937,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -10993,7 +10993,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11122,7 +11122,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11351,7 +11351,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11433,7 +11433,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.36.0",
+			"version": "2.36.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/skills/mach6-implement/SKILL.md
+++ b/packages/coding-agent/skills/mach6-implement/SKILL.md
@@ -18,7 +18,7 @@ This skill has two modes:
 2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
 3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
-5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 ## Step 1: Parse input
 

--- a/packages/coding-agent/skills/mach6-issue/SKILL.md
+++ b/packages/coding-agent/skills/mach6-issue/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: "[issue-number | description]"
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
 5. **Task tracking** — Use the `tasks_update` tool to show progress through multi-step commands.
 6. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning or implementing.
-7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 ## Determine Mode
 
@@ -76,7 +76,8 @@ Present to the user:
 Post as an issue comment:
 
 ```bash
-cat > /tmp/gh-comment.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <!-- mach6-assessment -->
 ## Issue Assessment
 
@@ -85,7 +86,7 @@ cat > /tmp/gh-comment.md << 'MACH6_EOF'
 ---
 *Automated assessment by mach6*
 MACH6_EOF
-gh issue comment <number> --body-file /tmp/gh-comment.md
+gh issue comment <number> --body-file "$GH_BODY"
 ```
 
 Update task: post → completed.
@@ -127,10 +128,11 @@ Present the draft to the user for approval.
 ### Step 3: Create the issue
 
 ```bash
-cat > /tmp/gh-body.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-body.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <body>
 MACH6_EOF
-gh issue create --title "<title>" --body-file /tmp/gh-body.md [--label "<labels>"]
+gh issue create --title "<title>" --body-file "$GH_BODY" [--label "<labels>"]
 ```
 
 Report the issue number and URL. Suggest next step: `/skill:mach6-plan <number>`

--- a/packages/coding-agent/skills/mach6-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6-plan/SKILL.md
@@ -18,7 +18,7 @@ This command is strictly for **planning**. Do NOT implement any code changes —
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 5. **Task tracking** — Use the `tasks_update` tool to show progress through multi-step commands.
 6. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning.
-7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 ## Step 1: Set up task tracking
 
@@ -98,14 +98,15 @@ git commit --allow-empty -m "chore: open PR for issue <N>"
 git push -u origin feature/issue-<N>-<slug>
 
 # Open draft PR
-cat > /tmp/gh-body.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-body.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 Closes #<N>
 
 <brief description>
 
 Implementation plan posted as a comment below.
 MACH6_EOF
-gh pr create --draft --title "<title>" --body-file /tmp/gh-body.md
+gh pr create --draft --title "<title>" --body-file "$GH_BODY"
 ```
 
 Update task: branch → completed, post → in_progress.
@@ -113,7 +114,8 @@ Update task: branch → completed, post → in_progress.
 ## Step 7: Post plan to PR
 
 ```bash
-cat > /tmp/gh-comment.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <!-- mach6-plan -->
 ## Implementation Plan
 
@@ -122,7 +124,7 @@ cat > /tmp/gh-comment.md << 'MACH6_EOF'
 ---
 *Plan created by mach6*
 MACH6_EOF
-gh pr comment <pr-number> --body-file /tmp/gh-comment.md
+gh pr comment <pr-number> --body-file "$GH_BODY"
 ```
 
 Update task: post → completed.

--- a/packages/coding-agent/skills/mach6-publish/SKILL.md
+++ b/packages/coding-agent/skills/mach6-publish/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "<pr-number>"
 2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
 3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
-5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 ## Step 1: Set up task tracking
 
@@ -181,10 +181,11 @@ git push --tags
 
 3. Present draft to user for approval, then create:
    ```bash
-   cat > /tmp/gh-release-notes.md << 'MACH6_EOF'
+   GH_NOTES="$(mktemp /tmp/gh-release-notes.XXXXXX.md)"
+   cat > "$GH_NOTES" << 'MACH6_EOF'
    <release-notes>
    MACH6_EOF
-   gh release create v<version> --title "v<version>" --notes-file /tmp/gh-release-notes.md
+   gh release create v<version> --title "v<version>" --notes-file "$GH_NOTES"
    ```
 
 Update task: release → completed.

--- a/packages/coding-agent/skills/mach6-push/SKILL.md
+++ b/packages/coding-agent/skills/mach6-push/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "[commit message]"
 3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
 4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
 5. **Task tracking** — Use the `tasks_update` tool to show progress.
-6. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+6. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 ## Step 1: Set up task tracking
 
@@ -81,7 +81,8 @@ If session context points to an issue but a PR also exists on the current branch
 
 Post a progress comment:
 ```bash
-cat > /tmp/gh-comment.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <!-- mach6-progress -->
 ## Progress Update
 
@@ -92,7 +93,7 @@ cat > /tmp/gh-comment.md << 'MACH6_EOF'
 ---
 *Progress tracked by mach6*
 MACH6_EOF
-gh pr comment <number> --body-file /tmp/gh-comment.md
+gh pr comment <number> --body-file "$GH_BODY"
 ```
 
 Update task: comment → completed.

--- a/packages/coding-agent/skills/mach6-review/SKILL.md
+++ b/packages/coding-agent/skills/mach6-review/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "<pr-number> [code|errors|tests|completeness|simplify]"
 2. **HTML markers** — Use `<!-- mach6-review -->` and `<!-- mach6-assessment -->` as the first line of comment bodies.
 3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
-5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks. Write each body to a **unique per-invocation temp file** via `mktemp` (e.g. `GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"`) — never a fixed path like `/tmp/gh-comment.md`, which concurrent mach6 sessions on the same machine would clobber, cross-posting one session's body to another's PR/issue.
 
 **Important: Do NOT fix any issues in this session. Fixes happen via `/skill:mach6-implement`.**
 
@@ -96,7 +96,8 @@ Update task: review → completed, post-review → in_progress.
 Compile all findings from all agents into a single structured comment:
 
 ```bash
-cat > /tmp/gh-comment.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <!-- mach6-review -->
 ## Code Review
 
@@ -117,7 +118,7 @@ cat > /tmp/gh-comment.md << 'MACH6_EOF'
 ---
 *Reviewed by mach6*
 MACH6_EOF
-gh pr comment <pr-number> --body-file /tmp/gh-comment.md
+gh pr comment <pr-number> --body-file "$GH_BODY"
 ```
 
 Save the review comment URL:
@@ -156,7 +157,8 @@ Update task: assess → completed, post-assess → in_progress.
 ## Step 7: Post assessment
 
 ```bash
-cat > /tmp/gh-comment.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-comment.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <!-- mach6-assessment -->
 ## Review Assessment
 
@@ -175,7 +177,7 @@ cat > /tmp/gh-comment.md << 'MACH6_EOF'
 ---
 *Assessment by mach6*
 MACH6_EOF
-gh pr comment <pr-number> --body-file /tmp/gh-comment.md
+gh pr comment <pr-number> --body-file "$GH_BODY"
 ```
 
 Update task: post-assess → completed, summary → in_progress.
@@ -189,10 +191,11 @@ Present to the user:
 
 If any findings were classified as **deferred**, ask the user if they want to create issues for them:
 ```bash
-cat > /tmp/gh-body.md << 'MACH6_EOF'
+GH_BODY="$(mktemp /tmp/gh-body.XXXXXX.md)"
+cat > "$GH_BODY" << 'MACH6_EOF'
 <body referencing PR and finding>
 MACH6_EOF
-gh issue create --title "<title>" --body-file /tmp/gh-body.md
+gh issue create --title "<title>" --body-file "$GH_BODY"
 ```
 
 Update task: summary → completed.

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/client/styles/tokens.css
+++ b/packages/dashboard/src/client/styles/tokens.css
@@ -174,6 +174,11 @@ pre {
 /* ---------------------------------------------------------------- layout */
 
 .container {
+	/* width: 100% is required: as a flex item in the .screen-fill column,
+	   auto cross-axis margins disable align-items: stretch, so without an
+	   explicit width the container shrink-wraps to its content and the page
+	   width jitters as card/table text changes. */
+	width: 100%;
 	max-width: 1200px;
 	margin: 0 auto;
 	padding: var(--space-4) var(--space-5);

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.36.0",
+	"version": "2.36.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #341
Closes #343

**Primary fix (#341):** the dashboard `.container` shrink-wrap defect — as a flex item in the `.screen-fill` column, `margin: 0 auto` disables stretch and the container sizes to its content, so live card/table text changes resize the whole page (and flip the fleet grid between 1 and 2 columns). Add `width: 100%` to `.container` so it always fills available space up to its 1200px cap.

**Drive-by hotfix (#343):** the `mach6-*` skills wrote GitHub comment/PR bodies to hardcoded shared temp paths (`/tmp/gh-comment.md`, `/tmp/gh-body.md`, `/tmp/gh-release-notes.md`), so two concurrent sessions on one machine could clobber each other's files and cross-post one session's body to another's PR/issue. Every body write now uses a unique `mktemp` path, and the shared "Non-interactive gh" rule in all six skills documents this so it isn't reintroduced.

Implementation plan for the primary fix is posted as a comment.
