### PR TITLE
Isolate auto-title context to the current session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10908,7 +10908,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10937,7 +10937,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -10993,7 +10993,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11122,7 +11122,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11351,7 +11351,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11433,7 +11433,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.36.1",
+			"version": "2.37.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -258,9 +258,9 @@ Compaction is lossy. The full history remains in the JSONL file; use `/tree` to 
 
 ### Tab Title
 
-After a few tool calls, dreb auto-generates a short terminal tab title describing the session's task. Useful when multiple tabs are open. Fires once per session via a background LLM call; failures are silent.
+After a few tool calls, dreb auto-generates a terminal tab title describing the session's task — based primarily on your actual request and current-session actions, with branch/repo/cwd used only for disambiguation. Useful when multiple tabs are open. Fires once per session via a background LLM call, and never overwrites an already-named (e.g. resumed) session; failures are surfaced (shown in interactive mode, logged to stderr in RPC mode).
 
-Disable or adjust the trigger threshold in [settings](docs/settings.md):
+Disable, adjust the trigger threshold, or set a title length target in [settings](docs/settings.md):
 
 ```json
 { "tabTitle": { "enabled": false } }

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -98,14 +98,16 @@ current model supports adaptive thinking).
 |---------|------|---------|-------------|
 | `tabTitle.enabled` | boolean | `true` | Auto-generate terminal tab title from session task |
 | `tabTitle.triggerAfter` | number | `9` | Number of tool calls before generating title |
+| `tabTitle.maxTitleLength` | number | `60` | Soft target length hint for generated titles (clamped to a hard cap of 300) |
 
-After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a short (≤30 character) terminal tab title, then sets it via OSC 0. Only fires once per session. If the LLM call fails, the default title remains.
+After the configured number of tool calls, dreb fires a single background LLM call to summarize the session's task into a terminal tab title, then sets it via OSC 0. The title is based primarily on your actual request and current-session actions, with branch/repo/cwd metadata used only for disambiguation. `maxTitleLength` is a soft target communicated to the model (default 60); titles may run a little longer for clarity and are hard-capped at 300 characters. The TUI truncates long titles visually while the dashboard shows the full name. Only fires once per session, and never overwrites an already-named (e.g. resumed) session. If the LLM call fails, the default title remains and the failure is surfaced (shown in interactive mode, logged to stderr in RPC mode).
 
 ```json
 {
   "tabTitle": {
     "enabled": true,
-    "triggerAfter": 9
+    "triggerAfter": 9,
+    "maxTitleLength": 60
   }
 }
 ```

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/context-buffer.ts
+++ b/packages/coding-agent/src/core/context-buffer.ts
@@ -46,6 +46,34 @@ export class RollingContextBuffer {
 }
 
 /**
+ * Extract the plain-text content of a user message.
+ *
+ * Handles both string content and structured content arrays (text parts only —
+ * tool_result and other non-text parts are ignored). Returns the trimmed text,
+ * or undefined when the message is not a usable user message.
+ */
+export function extractUserText(message: { role: string; content?: unknown }): string | undefined {
+	if (message.role !== "user") return undefined;
+
+	const { content } = message;
+	if (typeof content === "string") {
+		const trimmed = content.trim();
+		return trimmed || undefined;
+	}
+
+	if (Array.isArray(content)) {
+		const text = content
+			.filter((c: any) => c?.type === "text" && typeof c.text === "string")
+			.map((c: any) => c.text)
+			.join("")
+			.trim();
+		return text || undefined;
+	}
+
+	return undefined;
+}
+
+/**
  * Label an assistant message_end event into 0-2 context entries.
  *
  * Returns labeled strings for text content and/or tool calls.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -143,6 +143,7 @@ export interface Settings {
 export interface TabTitleSettings {
 	enabled?: boolean; // default: true — auto-generate terminal tab title from session task
 	triggerAfter?: number; // default: 9 — number of tool calls before generating title
+	maxTitleLength?: number; // default: 60 — soft target length hint for generated titles (hard-capped at 300)
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/src/core/tab-title.ts
+++ b/packages/coding-agent/src/core/tab-title.ts
@@ -1,7 +1,9 @@
 /**
  * Auto-generates a terminal tab title from session context after a threshold
  * number of tool calls. Uses a lightweight single-shot LLM call to produce a
- * concise ≤30 character title, then sets it via the terminal's OSC 0 escape.
+ * concise title — the model aims for a configurable soft target (default 60
+ * characters, via TabTitleSettings.maxTitleLength) and the result is hard-capped
+ * at 300 characters — then sets it via the terminal's OSC 0 escape.
  *
  * Fires at most once per session. Final failures are reported through the
  * optional onError hook while preserving fire-and-forget behavior.

--- a/packages/coding-agent/src/core/tab-title.ts
+++ b/packages/coding-agent/src/core/tab-title.ts
@@ -13,33 +13,52 @@ import { join } from "node:path";
 import type { Api, Context, Model } from "@dreb/ai";
 import { completeSimple } from "@dreb/ai";
 import { CONFIG_DIR_NAME, getPackageDir } from "../config.js";
-import { labelMessageEnd, labelToolEnd, RollingContextBuffer } from "./context-buffer.js";
+import { extractUserText, labelMessageEnd, labelToolEnd, RollingContextBuffer } from "./context-buffer.js";
 import type { ModelRegistry } from "./model-registry.js";
 import type { TabTitleSettings } from "./settings-manager.js";
 import { parseAgentFrontmatter, resolveModelForSubagentSpawn } from "./tools/subagent.js";
 
 const DEFAULT_TRIGGER_AFTER = 9;
-const MAX_TITLE_LENGTH = 30;
+// Soft target communicated to the model — titles should aim for this length but
+// may run longer when clarity demands it. Configurable via TabTitleSettings.maxTitleLength.
+const DEFAULT_TITLE_SOFT_TARGET = 60;
+// Hidden hard cap — a safety limit that titles are truncated to regardless of the
+// soft target. The dashboard has room for long names; the TUI truncates visually.
+const TITLE_HARD_CAP = 300;
+// Cap on how much of a single user message we feed into the title context.
+const MAX_USER_TEXT_CHARS = 2000;
 const TITLE_GENERATION_TIMEOUT_MS = 60_000;
 
-const TITLE_PROMPT =
-	"You are a headless terminal-tab title generator. You are NOT the assistant in the session — " +
-	"you will never speak to the user. Your only job is to output a single short title string, nothing else. " +
-	"No quotes, no explanation, no preamble. " +
-	"The title disambiguates terminal windows for a human at a glance. " +
-	"Describe what is being DONE (e.g. 'Fix auth bug', 'Plan subagent refactor', 'Review modal'), " +
-	"not just label the invocation. " +
-	"If a branch name is present, abbreviate it to its semantic slug " +
-	"(e.g. feature/issue-217-copy-selector-modal → copy-selector) and combine with the action. " +
-	"Avoid reference-only formats like '#N' or 'mach6-X #N'. " +
-	"Do not include 'dreb' — the caller already adds it. " +
-	"Output ONLY the title text, ≤30 characters.";
+function buildTitlePrompt(softTarget: number): string {
+	return (
+		"You are a headless terminal-tab title generator. You are NOT the assistant in the session — " +
+		"you will never speak to the user. Your only job is to output a single short title string, nothing else. " +
+		"No quotes, no explanation, no preamble. " +
+		"The title disambiguates terminal windows for a human at a glance. " +
+		"Base the title PRIMARILY on the user's actual request and the concrete actions taken in THIS session. " +
+		"Describe what is being DONE (e.g. 'Fix auth bug', 'Plan subagent refactor', 'Review modal'), " +
+		"not just label the invocation. " +
+		"Branch, repo, and cwd metadata are SECONDARY — use them only to disambiguate when the user's " +
+		"request is otherwise ambiguous. Never let a branch name override the user's actual intent: " +
+		"if the branch is 'feature/dashboard-foundation' but the user asked to install a Playwright skill, " +
+		"the title is about the Playwright skill, not the dashboard. " +
+		"Avoid reference-only formats like '#N' or 'mach6-X #N'. " +
+		"Do not include 'dreb' — the caller already adds it. " +
+		`Output ONLY the title text. Aim for about ${softTarget} characters; a little longer is fine if needed for clarity.`
+	);
+}
 
 export interface TabTitleDeps {
 	/** Set the terminal tab title (OSC 0). */
 	setTitle: (title: string) => void;
 	/** Persist the generated title as the session name. Called with the raw title (without "dreb - " prefix). */
 	setSessionName?: (name: string) => void;
+	/**
+	 * Get the current session name, if the session is already named. When this returns a
+	 * non-empty string, title generation is skipped — auto-titling only names unnamed
+	 * sessions and must never overwrite an existing (e.g. resumed) session's name.
+	 */
+	getSessionName?: () => string | undefined;
 	/** Get the current session messages (for context). */
 	getMessages: () => Array<{ role: string; content?: unknown }>;
 	/** Get the current model (parent session model — used as fallback). */
@@ -67,6 +86,7 @@ export class TabTitleGenerator {
 	private toolCallCount = 0;
 	private fired = false;
 	private readonly threshold: number;
+	private readonly softTarget: number;
 	private readonly contextBuffer: RollingContextBuffer;
 
 	constructor(
@@ -74,6 +94,9 @@ export class TabTitleGenerator {
 		private readonly deps: TabTitleDeps,
 	) {
 		this.threshold = settings?.triggerAfter ?? DEFAULT_TRIGGER_AFTER;
+		// Soft target is configurable but always clamped to the hidden hard cap.
+		const configured = settings?.maxTitleLength ?? DEFAULT_TITLE_SOFT_TARGET;
+		this.softTarget = Math.max(1, Math.min(configured, TITLE_HARD_CAP));
 		this.contextBuffer = new RollingContextBuffer({ maxEntries: 30, maxChars: 6000 });
 	}
 
@@ -120,6 +143,10 @@ export class TabTitleGenerator {
 	}
 
 	private async generateTitle(): Promise<void> {
+		// Skip entirely if the session already has a name (e.g. resumed session).
+		// This guards the race where a name is set between generator construction and firing.
+		if (this.deps.getSessionName?.()) return;
+
 		// Single timeout bounds the entire pipeline (model probing + API key + LLM call)
 		const signal = AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS);
 
@@ -130,13 +157,15 @@ export class TabTitleGenerator {
 		if (!userContext) return;
 
 		const context: Context = {
-			systemPrompt: TITLE_PROMPT,
+			systemPrompt: buildTitlePrompt(this.softTarget),
 			messages: [{ role: "user", content: userContext, timestamp: Date.now() }],
 		};
 
 		const response = await this.completeWithParentFallback(model, context, signal);
 		const title = this.sanitizeTitle(response);
 		if (title) {
+			// Re-check: a name may have landed during the async LLM call.
+			if (this.deps.getSessionName?.()) return;
 			this.deps.setTitle(`dreb - ${title}`);
 			this.deps.setSessionName?.(title);
 		}
@@ -259,20 +288,61 @@ export class TabTitleGenerator {
 	private buildContext(): string | undefined {
 		const lines: string[] = [];
 
-		// Metadata block
+		// Primary signal: the user's actual request(s) from the current session.
+		// Pin the FIRST user message (session-defining intent) and append the LATEST
+		// user message when it differs, to catch mid-session pivots. Sourced from the
+		// live message list rather than the rolling buffer so early intent is never
+		// evicted by later tool activity.
+		const userIntent = this.collectUserIntent();
+		if (userIntent.length > 0) {
+			lines.push("User request(s):");
+			for (const req of userIntent) {
+				lines.push(`- ${req}`);
+			}
+		}
+
+		// Secondary signal: concrete current-session actions (assistant text + tools).
+		const bufferContent = this.contextBuffer.build();
+		if (bufferContent) {
+			lines.push("");
+			lines.push("Session activity:");
+			lines.push(bufferContent);
+		}
+
+		// Tertiary signal: metadata, for disambiguation only.
 		const branch = this.deps.getBranch?.();
 		const repo = this.deps.getRepo?.();
 		const cwd = this.deps.getCwd?.();
-		if (branch) lines.push(`Branch: ${branch}`);
-		if (repo) lines.push(`Repo: ${repo}`);
-		if (cwd) lines.push(`Cwd: ${cwd}`);
-
-		// Rolling buffer
-		const bufferContent = this.contextBuffer.build();
-		if (bufferContent) lines.push(bufferContent);
+		const metadata: string[] = [];
+		if (branch) metadata.push(`Branch: ${branch}`);
+		if (repo) metadata.push(`Repo: ${repo}`);
+		if (cwd) metadata.push(`Cwd: ${cwd}`);
+		if (metadata.length > 0) {
+			lines.push("");
+			lines.push("Context metadata (secondary — disambiguation only):");
+			lines.push(...metadata);
+		}
 
 		if (lines.length === 0) return undefined;
 		return lines.join("\n");
+	}
+
+	/**
+	 * Collect the user's intent-bearing requests from the current session's messages.
+	 * Returns the first user message, plus the latest user message when it differs.
+	 */
+	private collectUserIntent(): string[] {
+		const messages = this.deps.getMessages?.() ?? [];
+		const userTexts: string[] = [];
+		for (const message of messages) {
+			const text = extractUserText(message);
+			if (text) userTexts.push(text.slice(0, MAX_USER_TEXT_CHARS));
+		}
+		if (userTexts.length === 0) return [];
+
+		const first = userTexts[0];
+		const last = userTexts[userTexts.length - 1];
+		return first === last ? [first] : [first, last];
 	}
 
 	/** Clean up LLM response to a usable tab title. */
@@ -292,9 +362,9 @@ export class TabTitleGenerator {
 		}
 		// Remove newlines
 		title = title.replace(/[\r\n]+/g, " ").trim();
-		// Truncate to max length
-		if (title.length > MAX_TITLE_LENGTH) {
-			title = title.slice(0, MAX_TITLE_LENGTH);
+		// Truncate to the hidden hard cap (safety limit; the soft target is a prompt hint)
+		if (title.length > TITLE_HARD_CAP) {
+			title = title.slice(0, TITLE_HARD_CAP);
 		}
 		return title || undefined;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -710,11 +710,19 @@ export class InteractiveMode {
 		const settings = this.settingsManager.getTabTitleSettings();
 		if (settings?.enabled === false) return;
 
+		// Don't auto-title a session that already has a name (e.g. resumed sessions).
+		// Auto-titling exists to name unnamed sessions; overwriting a user's/prior name
+		// with fresh context would be the cross-session confusion this guards against.
+		if (this.sessionManager.getSessionName()) return;
+
 		this.tabTitleGenerator = new TabTitleGenerator(settings, {
 			setTitle: (title) => this.ui.terminal.setTitle(title),
 			setSessionName: (name) => {
+				// Re-check at fire time: a name may have been set between init and firing.
+				if (this.sessionManager.getSessionName()) return;
 				this.session.setSessionName(name);
 			},
+			getSessionName: () => this.sessionManager.getSessionName(),
 			getMessages: () => this.session.state.messages,
 			getModel: () => this.session.model,
 			getModelRegistry: () => this.session.modelRegistry,
@@ -723,6 +731,9 @@ export class InteractiveMode {
 			getBranch: () => this.footerDataProvider.getGitBranch(),
 			getRepo: () => path.basename(process.cwd()),
 			getCwd: () => process.cwd(),
+			onError: (err) => {
+				this.showError(`Tab title auto-generation failed: ${err instanceof Error ? err.message : String(err)}`);
+			},
 		});
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1015,6 +1015,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 							session.setSessionName(name);
 						}
 					},
+					getSessionName: () => session.sessionName,
 					getMessages: () => session.messages,
 					getModel: () => session.model,
 					getModelRegistry: () => session.modelRegistry,

--- a/packages/coding-agent/test/context-buffer.test.ts
+++ b/packages/coding-agent/test/context-buffer.test.ts
@@ -2,7 +2,7 @@
  * Tests for the shared rolling context buffer and event-labeling utilities.
  */
 import { describe, expect, it } from "vitest";
-import { labelMessageEnd, labelToolEnd, RollingContextBuffer } from "../src/core/context-buffer.js";
+import { extractUserText, labelMessageEnd, labelToolEnd, RollingContextBuffer } from "../src/core/context-buffer.js";
 
 describe("RollingContextBuffer", () => {
 	it("append adds entries", () => {
@@ -182,5 +182,45 @@ describe("labelToolEnd", () => {
 			result: { output: "command not found" },
 		});
 		expect(result).toBe("Tool bash failed: command not found");
+	});
+});
+
+describe("extractUserText", () => {
+	it("returns trimmed string content for a user message", () => {
+		expect(extractUserText({ role: "user", content: "  fix the bug  " })).toBe("fix the bug");
+	});
+
+	it("joins text parts of structured user content", () => {
+		expect(
+			extractUserText({
+				role: "user",
+				content: [
+					{ type: "text", text: "add " },
+					{ type: "text", text: "dark mode" },
+				],
+			}),
+		).toBe("add dark mode");
+	});
+
+	it("ignores non-text parts in structured content", () => {
+		expect(
+			extractUserText({
+				role: "user",
+				content: [
+					{ type: "toolResult", output: "ignored" },
+					{ type: "text", text: "real request" },
+				],
+			}),
+		).toBe("real request");
+	});
+
+	it("returns undefined for non-user messages", () => {
+		expect(extractUserText({ role: "assistant", content: "hello" })).toBeUndefined();
+	});
+
+	it("returns undefined for empty or whitespace-only content", () => {
+		expect(extractUserText({ role: "user", content: "   " })).toBeUndefined();
+		expect(extractUserText({ role: "user", content: [] })).toBeUndefined();
+		expect(extractUserText({ role: "user" })).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -928,6 +928,29 @@ describe("TabTitleGenerator", () => {
 			const content = (mockCompleteSimple.mock.calls[0][1] as any).messages[0].content as string;
 			expect(content).toContain("add dark mode toggle");
 		});
+
+		it("caps each user message at MAX_USER_TEXT_CHARS (2000) in the context", async () => {
+			// A giant pasted request must not bloat the title context. The head is kept,
+			// the tail beyond 2000 chars is dropped.
+			const head = "H".repeat(2000);
+			const tail = "TAIL_SENTINEL";
+			const deps = createMockDeps({
+				getMessages: () => [{ role: "user", content: head + tail }],
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const content = (mockCompleteSimple.mock.calls[0][1] as any).messages[0].content as string;
+			// The first 2000 chars survive; the tail beyond the cap is truncated away.
+			expect(content).toContain(head);
+			expect(content).not.toContain(tail);
+		});
 	});
 
 	describe("title length (soft target / hard cap)", () => {

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -342,8 +342,9 @@ describe("TabTitleGenerator", () => {
 			expect(content).toContain("Tool bash completed: ls output");
 		});
 
-		it("includes only metadata when no events have been sent", async () => {
+		it("includes only metadata when no events and no user messages", async () => {
 			const deps = createMockDeps({
+				getMessages: () => [],
 				getBranch: () => "main",
 				getRepo: () => "dreb",
 				getCwd: () => "/home/user/dreb",
@@ -366,9 +367,26 @@ describe("TabTitleGenerator", () => {
 	});
 
 	describe("title sanitization", () => {
-		it("truncates titles longer than 30 characters", async () => {
+		it("truncates titles longer than the hard cap (300)", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("A".repeat(400)) as any);
+
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+
+			const title = (deps.setTitle as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			const titleContent = title.replace("dreb - ", "");
+			expect(titleContent.length).toBe(300);
+		});
+
+		it("does not truncate titles under the hard cap (soft target is only a prompt hint)", async () => {
 			mockCompleteSimple.mockResolvedValue(
-				makeAssistantResponse("This is a very long title that exceeds the limit") as any,
+				makeAssistantResponse("This is a longer descriptive title well over thirty characters") as any,
 			);
 
 			const deps = createMockDeps();
@@ -381,9 +399,7 @@ describe("TabTitleGenerator", () => {
 			});
 
 			const title = (deps.setTitle as ReturnType<typeof vi.fn>).mock.calls[0][0];
-			// "dreb - " is 7 chars, title content should be ≤30
-			const titleContent = title.replace("dreb - ", "");
-			expect(titleContent.length).toBeLessThanOrEqual(30);
+			expect(title).toBe("dreb - This is a longer descriptive title well over thirty characters");
 		});
 
 		it("strips surrounding double quotes from LLM response", async () => {
@@ -462,8 +478,9 @@ describe("TabTitleGenerator", () => {
 			expect(context.messages[0].content).toContain("Assistant: Looking at the code now.");
 		});
 
-		it("onMessageEnd with user message → no entry (filtered out)", async () => {
+		it("onMessageEnd with user message → no rolling-buffer entry (filtered out)", async () => {
 			const deps = createMockDeps({
+				getMessages: () => [],
 				getBranch: () => "main",
 			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
@@ -567,8 +584,9 @@ describe("TabTitleGenerator", () => {
 		});
 
 		it("buildContext returns undefined when buffer is empty and no metadata", async () => {
-			// Explicitly nullify all metadata getters and send no events
+			// Explicitly nullify all metadata getters, empty messages, and send no events
 			const deps = createMockDeps({
+				getMessages: () => [],
 				getBranch: () => null,
 				getRepo: () => undefined,
 				getCwd: () => undefined,
@@ -802,6 +820,213 @@ describe("TabTitleGenerator", () => {
 
 			expect(deps.setTitle).not.toHaveBeenCalled();
 			expect(deps.setSessionName).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("user intent priority", () => {
+		it("titles from the user's request, not the branch slug", async () => {
+			// Regression for issue 324: a dashboard-foundation branch must not override
+			// an unrelated user request.
+			const deps = createMockDeps({
+				getMessages: () => [{ role: "user", content: "install the Playwright webapp-testing skill" }],
+				getBranch: () => "feature/issue-307-dashboard-foundation",
+				getRepo: () => "dreb",
+				getCwd: () => "/home/user/dreb",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			const content = context.messages[0].content as string;
+			// User request appears, and leads the context ahead of metadata.
+			expect(content).toContain("install the Playwright webapp-testing skill");
+			expect(content.indexOf("install the Playwright")).toBeLessThan(content.indexOf("Branch:"));
+			// Metadata is explicitly demoted to secondary.
+			expect(content).toContain("secondary");
+		});
+
+		it("pins the first user request even after many tool calls (no buffer eviction)", async () => {
+			const deps = createMockDeps({
+				getMessages: () => [
+					{ role: "user", content: "refactor the auth module to use JWT" },
+					{ role: "assistant", content: [{ type: "text", text: "on it" }] },
+				],
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 30 }, deps);
+
+			// Flood the rolling buffer with unrelated tool activity.
+			for (let i = 0; i < 30; i++) {
+				gen.onToolEnd({ toolName: "bash", isError: false, result: { output: `noise ${i}` } });
+			}
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.messages[0].content).toContain("refactor the auth module to use JWT");
+		});
+
+		it("includes both first and latest user request when they differ", async () => {
+			const deps = createMockDeps({
+				getMessages: () => [
+					{ role: "user", content: "start building the export feature" },
+					{ role: "assistant", content: [{ type: "text", text: "sure" }] },
+					{ role: "user", content: "actually make it a CSV export" },
+				],
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const content = (mockCompleteSimple.mock.calls[0][1] as any).messages[0].content as string;
+			expect(content).toContain("start building the export feature");
+			expect(content).toContain("actually make it a CSV export");
+		});
+
+		it("de-duplicates when first and only user request equals the latest", async () => {
+			const deps = createMockDeps({
+				getMessages: () => [{ role: "user", content: "fix the flaky test" }],
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const content = (mockCompleteSimple.mock.calls[0][1] as any).messages[0].content as string;
+			expect(content.split("fix the flaky test").length - 1).toBe(1);
+		});
+
+		it("extracts text from structured (array) user content", async () => {
+			const deps = createMockDeps({
+				getMessages: () => [{ role: "user", content: [{ type: "text", text: "add dark mode toggle" }] }],
+				getBranch: () => "main",
+			});
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const content = (mockCompleteSimple.mock.calls[0][1] as any).messages[0].content as string;
+			expect(content).toContain("add dark mode toggle");
+		});
+	});
+
+	describe("title length (soft target / hard cap)", () => {
+		it("mentions the default soft target (60) in the prompt", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.systemPrompt).toContain("60");
+		});
+
+		it("honors a custom maxTitleLength as the soft target hint", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1, maxTitleLength: 120 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.systemPrompt).toContain("120");
+		});
+
+		it("clamps an over-large maxTitleLength to the hard cap in the prompt", async () => {
+			const deps = createMockDeps();
+			const gen = new TabTitleGenerator({ triggerAfter: 1, maxTitleLength: 9999 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const context = mockCompleteSimple.mock.calls[0][1] as any;
+			expect(context.systemPrompt).toContain("300");
+			expect(context.systemPrompt).not.toContain("9999");
+		});
+	});
+
+	describe("resumed / already-named session guard", () => {
+		it("skips generation when the session already has a name", async () => {
+			const deps = createMockDeps({ getSessionName: () => "Existing session name" });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(gen.hasFired).toBe(true);
+			});
+
+			expect(mockCompleteSimple).not.toHaveBeenCalled();
+			expect(deps.setTitle).not.toHaveBeenCalled();
+			expect(deps.setSessionName).not.toHaveBeenCalled();
+		});
+
+		it("does not overwrite a name that appears during async generation", async () => {
+			// Unnamed at fire time, but a name lands before the LLM call resolves.
+			let name: string | undefined;
+			let resolveCompletion: (v: unknown) => void = () => {};
+			mockCompleteSimple.mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						resolveCompletion = resolve;
+					}) as any,
+			);
+
+			const deps = createMockDeps({ getSessionName: () => name });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+			await vi.waitFor(() => expect(mockCompleteSimple).toHaveBeenCalled());
+
+			// Name is set (e.g. user renamed) before completion resolves.
+			name = "User chosen name";
+			resolveCompletion(makeAssistantResponse("Auto title") as any);
+
+			await vi.waitFor(() => expect(gen.hasFired).toBe(true));
+			expect(deps.setTitle).not.toHaveBeenCalled();
+			expect(deps.setSessionName).not.toHaveBeenCalled();
+		});
+
+		it("generates normally when getSessionName returns empty", async () => {
+			const deps = createMockDeps({ getSessionName: () => undefined });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(deps.setTitle).toHaveBeenCalled();
+			});
+			expect(deps.setSessionName).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.36.1",
+  "version": "2.37.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.36.1",
+	"version": "2.37.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #324

Fix auto-generated session/tab titles that ignore the user's actual request and default to the branch slug (e.g. an OpenCode session titled "Build dashboard base"). Sources title context from the current-session user request, demotes git/repo/cwd metadata to secondary disambiguation, rewrites the title prompt, raises the length cap, and unifies resumed-named-session behavior across interactive and RPC.

Implementation plan posted as a comment below.
