### PR TITLE
Sanitize NUL bytes from model-bound text

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -620,7 +620,7 @@ export function convertMessages(
 			if (nonEmptyThinkingBlocks.length > 0) {
 				if (compat.requiresThinkingAsText) {
 					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
-					const thinkingText = nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n\n");
+					const thinkingText = sanitizeSurrogates(nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n\n"));
 					const textContent = assistantMsg.content as Array<{ type: "text"; text: string }> | null;
 					if (textContent) {
 						textContent.unshift({ type: "text", text: thinkingText });
@@ -631,7 +631,9 @@ export function convertMessages(
 					// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
 					if (signature && signature.length > 0) {
-						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n");
+						(assistantMsg as any)[signature] = sanitizeSurrogates(
+							nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n"),
+						);
 					}
 				}
 			}

--- a/packages/ai/src/utils/sanitize-unicode.ts
+++ b/packages/ai/src/utils/sanitize-unicode.ts
@@ -1,6 +1,7 @@
 /**
- * Removes unpaired Unicode surrogate characters from a string.
+ * Removes NUL and unpaired Unicode surrogate characters from model-bound text.
  *
+ * NUL can corrupt local-model generation even when the provider accepts the JSON payload.
  * Unpaired surrogates (high surrogates 0xD800-0xDBFF without matching low surrogates 0xDC00-0xDFFF,
  * or vice versa) cause JSON serialization errors in many API providers.
  *
@@ -19,7 +20,6 @@
  * sanitizeSurrogates(`Text ${unpaired} here`) // => "Text  here"
  */
 export function sanitizeSurrogates(text: string): string {
-	// Replace unpaired high surrogates (0xD800-0xDBFF not followed by low surrogate)
-	// Replace unpaired low surrogates (0xDC00-0xDFFF not preceded by high surrogate)
-	return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
+	// Replace NUL, unpaired high surrogates, and unpaired low surrogates.
+	return text.replace(/\u0000|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
 }

--- a/packages/ai/test/openai-completions-nul-sanitization.test.ts
+++ b/packages/ai/test/openai-completions-nul-sanitization.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.js";
+import { convertMessages } from "../src/providers/openai-completions.js";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat: Required<OpenAICompletionsCompat> = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	reasoningEffortMap: {},
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	supportsStrictMode: true,
+};
+
+describe("openai-completions NUL sanitization", () => {
+	it("removes NUL from every model-bound text role", () => {
+		const model: Model<"openai-completions"> = {
+			...getModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+		};
+		const now = Date.now();
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "think\0ing", thinkingSignature: "reasoning_content" },
+				{ type: "text", text: "ans\0wer" },
+				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "file.txt" } },
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: "tool\0result" }],
+			isError: false,
+			timestamp: now + 1,
+		};
+		const context: Context = {
+			systemPrompt: "sys\0tem",
+			messages: [{ role: "user", content: "us\0er", timestamp: now - 1 }, assistant, toolResult],
+		};
+
+		const messages = convertMessages(model, context, compat);
+
+		expect(messages).toHaveLength(4);
+		expect(messages[0]).toMatchObject({ role: "system", content: "system" });
+		expect(messages[1]).toMatchObject({ role: "user", content: "user" });
+		expect(messages[2]).toMatchObject({
+			role: "assistant",
+			content: "answer",
+			reasoning_content: "thinking",
+		});
+		expect(messages[3]).toMatchObject({ role: "tool", content: "toolresult" });
+		expect(JSON.stringify(messages)).not.toContain("\\u0000");
+	});
+});


### PR DESCRIPTION
## Summary

- strip embedded NUL characters from model-bound text
- sanitize replayed OpenAI-compatible thinking content
- cover system, user, assistant, reasoning, and tool-result messages with a regression test

## Validation

- full test suite: 4,485 passed, 655 skipped
- monorepo build
- workspace-link verification
- replayed the original contaminated Qwen3.6 session successfully

Closes #352
