### PR TITLE
Feature: 'Local Only Mode' — toggle to prepend best local model to all agent fallback lists

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -136,6 +136,9 @@ export interface Settings {
 		archivePath?: string; // Custom archive location for dream backups (default: ~/.dreb/memory-archive/)
 	};
 	tabTitle?: TabTitleSettings;
+	localOnlyMode?: boolean; // default: false — when true, prepend local model to all agent fallback lists
+	localOnlyModel?: string; // provider/model ID of the local model to inject
+	finalFallbackToLocalModel?: boolean; // default: false — when true, append local model as last fallback
 }
 
 export interface TabTitleSettings {
@@ -1126,6 +1129,40 @@ export class SettingsManager {
 		}
 		this.globalSettings.modelSettings[modelId].thinkingDisplay = value;
 		this.markModified("modelSettings", modelId);
+		this.save();
+	}
+
+	getLocalOnlyMode(): boolean {
+		return this.settings.localOnlyMode ?? false;
+	}
+
+	getLocalOnlyModel(): string | undefined {
+		return this.settings.localOnlyModel;
+	}
+
+	getFinalFallbackToLocalModel(): boolean {
+		return this.settings.finalFallbackToLocalModel ?? false;
+	}
+
+	setLocalOnlyMode(enabled: boolean): void {
+		this.globalSettings.localOnlyMode = enabled;
+		this.markModified("localOnlyMode");
+		this.save();
+	}
+
+	setLocalOnlyModel(modelId: string | undefined): void {
+		if (modelId === undefined) {
+			delete this.globalSettings.localOnlyModel;
+		} else {
+			this.globalSettings.localOnlyModel = modelId;
+		}
+		this.markModified("localOnlyModel");
+		this.save();
+	}
+
+	setFinalFallbackToLocalModel(enabled: boolean): void {
+		this.globalSettings.finalFallbackToLocalModel = enabled;
+		this.markModified("finalFallbackToLocalModel");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -687,6 +687,14 @@ export function resolveModelStringSingle(
 	return { ok: true, modelId: resolved.model.id, provider: resolved.model.provider };
 }
 
+/** Configuration for Local Only Mode — injects a local model into the fallback list. */
+export interface LocalOnlyConfig {
+	enabled: boolean;
+	modelId: string;
+	/** When true, append local model as last fallback; when false, prepend as first. */
+	finalFallback: boolean;
+}
+
 export interface ProbeModelAvailabilityOptions {
 	/** Parent/tool abort signal. A model availability probe timeout is layered on top. */
 	signal?: AbortSignal;
@@ -820,6 +828,7 @@ export async function resolveModelForSubagentSpawn(
 	signal?: AbortSignal,
 	/** Optional log prefix for warning messages (defaults to "[subagent]") */
 	logPrefix = "[subagent]",
+	localOnlyConfig?: LocalOnlyConfig,
 ): Promise<SubagentModelResolution> {
 	if (signal?.aborted) return { ok: false, error: "Aborted before spawn", skippedModels: [] };
 
@@ -831,10 +840,31 @@ export async function resolveModelForSubagentSpawn(
 		return { ...resolved, skippedModels: [] };
 	}
 
+	// Inject local-only model if enabled
+	const effectiveModels: string[] = [...models];
+	if (localOnlyConfig?.enabled && localOnlyConfig.modelId) {
+		const localModel = localOnlyConfig.modelId;
+		const alreadyPresent = effectiveModels.includes(localModel);
+
+		if (localOnlyConfig.finalFallback) {
+			// Final fallback: append local model at end (skip if already present)
+			if (!alreadyPresent) {
+				effectiveModels.push(localModel);
+				log.debug(`${logPrefix} Appending local model "${localModel}" as final fallback.`);
+			}
+		} else {
+			// Prepend: add as first model (skip if already present)
+			if (!alreadyPresent) {
+				effectiveModels.unshift(localModel);
+				log.debug(`${logPrefix} Prepending local model "${localModel}" to fallback list.`);
+			}
+		}
+	}
+
 	const skippedModels: SkippedFallbackModel[] = [];
 	let lastError = "";
 
-	for (const modelStr of models) {
+	for (const modelStr of effectiveModels) {
 		if (signal?.aborted) return { ok: false, error: "Aborted before spawn", skippedModels };
 
 		const resolved = resolveModelStringSingle(modelStr, parentProvider, registry);
@@ -970,6 +1000,8 @@ export async function executeSingle(
 	agentModels?: string[],
 	parentSessionFile?: string,
 	onChildEvent?: (event: Record<string, unknown>) => void,
+	localOnlyConfig?: LocalOnlyConfig,
+	_logPrefix?: string,
 ): Promise<SubagentResult> {
 	const name = agentName || DEFAULT_AGENT;
 	const config = agents.get(name);
@@ -1009,7 +1041,15 @@ export async function executeSingle(
 	// an additional best-effort 1-token probe before spawn so runtime-unavailable
 	// models are skipped before committing to a child process.
 	if (modelSpec) {
-		const resolved = await resolveModelForSubagentSpawn(modelSpec, parentProvider, registry, parentModel, signal);
+		const resolved = await resolveModelForSubagentSpawn(
+			modelSpec,
+			parentProvider,
+			registry,
+			parentModel,
+			signal,
+			"[subagent]",
+			localOnlyConfig,
+		);
 		skippedModels = resolved.skippedModels;
 		if (!resolved.ok) {
 			const skippedDetails = formatSkippedModelFailureDetails(skippedModels);
@@ -1064,6 +1104,7 @@ async function executeChain(
 	getAgentModelsForAgentFn?: (name: string) => string[] | undefined,
 	parentSessionFile?: string,
 	onChildEvent?: (event: Record<string, unknown>) => void,
+	localOnlyConfig?: LocalOnlyConfig,
 ): Promise<SubagentResult[]> {
 	const results: SubagentResult[] = [];
 	let previousOutput = "";
@@ -1119,6 +1160,7 @@ async function executeChain(
 			stepMach6Models,
 			parentSessionFile,
 			onChildEvent,
+			localOnlyConfig,
 		);
 		results.push(result);
 
@@ -1483,6 +1525,8 @@ export interface SubagentToolOptions {
 	modelRegistry?: ModelRegistry;
 	/** Settings-based model override getter for mach6.models. */
 	getAgentModelsForAgent?: (agentName: string) => string[] | undefined;
+	/** Local Only Mode configuration — injects a local model into every agent's fallback list. */
+	localOnlyConfig?: LocalOnlyConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -1653,6 +1697,7 @@ export function createSubagentToolDefinition(
 	const getParentSessionFile = options?.parentSessionFile ?? (() => undefined);
 	const modelRegistry = options?.modelRegistry;
 	const getAgentModelsForAgent = options?.getAgentModelsForAgent;
+	const localOnlyConfig = options?.localOnlyConfig;
 
 	// Discover agents at definition time to build the prompt guidelines.
 	// This is cheap (reads .md files) and the same call happens on every execute().
@@ -1872,6 +1917,7 @@ export function createSubagentToolDefinition(
 							agentModels,
 							getParentSessionFile(),
 							onChildEvent,
+							localOnlyConfig,
 						),
 					);
 				};
@@ -1970,6 +2016,7 @@ export function createSubagentToolDefinition(
 								getAgentModelsForAgent,
 								getParentSessionFile(),
 								onChildEvent,
+								localOnlyConfig,
 							);
 							const resultText = results
 								.map((r, i) => `### Step ${i + 1}\n${formatSingleResult(r)}`)

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -65,6 +65,14 @@ export interface SettingsConfig {
 	agentNames: string[];
 	/** Available model IDs for selection in the ranked list */
 	availableModelIds: string[];
+	/** Local Only Mode toggle state */
+	localOnlyMode: boolean;
+	/** Currently selected local model ID (provider/model) */
+	localOnlyModel: string;
+	/** When true, append local model as last fallback (final fallback to local model). */
+	finalFallbackToLocalModel: boolean;
+	/** List of available model IDs for the local model dropdown (ALL models). */
+	localModelAvailableModels: string[];
 }
 
 export interface SettingsCallbacks {
@@ -89,6 +97,9 @@ export interface SettingsCallbacks {
 	onQuietStartupChange: (enabled: boolean) => void;
 	onAutoLoadNestedContextChange: (enabled: boolean) => void;
 	onAgentModelsChange: (agentName: string, models: string[]) => void;
+	onLocalOnlyModeChange: (enabled: boolean) => void;
+	onLocalOnlyModelChange: (modelId: string) => void;
+	onFinalFallbackToLocalModelChange: (enabled: boolean) => void;
 	onCancel: () => void;
 }
 
@@ -550,6 +561,47 @@ export class SettingsSelectorComponent extends Container {
 			});
 		}
 
+		// Local Only Mode section
+		items.push({
+			id: "local-only-mode",
+			label: "Local only mode",
+			description: "Prepend a local model to all agent fallback lists",
+			currentValue: config.localOnlyMode ? "true" : "false",
+			values: ["true", "false"],
+		});
+
+		if (config.localModelAvailableModels.length > 0) {
+			items.push({
+				id: "local-only-model",
+				label: "Local model",
+				description: "Local model to prepend to agent fallback lists",
+				currentValue: config.localOnlyModel || config.localModelAvailableModels[0],
+				submenu: (_currentValue, done) =>
+					new SelectSubmenu(
+						"Local Model",
+						"Select a local model for agent fallback lists",
+						config.localModelAvailableModels.map((modelId) => ({
+							value: modelId,
+							label: modelId,
+						})),
+						config.localOnlyModel || config.localModelAvailableModels[0],
+						(modelId) => {
+							callbacks.onLocalOnlyModelChange(modelId);
+							done(modelId);
+						},
+						() => done(),
+					),
+			});
+		}
+
+		items.push({
+			id: "local-only-append-mode",
+			label: "Final fallback to local model",
+			description: "Append local model as last fallback instead of first",
+			currentValue: config.finalFallbackToLocalModel ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Only show image toggle if terminal supports it
 		if (supportsImages) {
 			// Insert after autocompact
@@ -682,6 +734,12 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "autocomplete-max-visible":
 						callbacks.onAutocompleteMaxVisibleChange(parseInt(newValue, 10));
+						break;
+					case "local-only-mode":
+						callbacks.onLocalOnlyModeChange(newValue === "true");
+						break;
+					case "local-only-append-mode":
+						callbacks.onFinalFallbackToLocalModelChange(newValue === "true");
 						break;
 				}
 			},

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3706,6 +3706,8 @@ export class InteractiveMode {
 			const agentNames = Array.from(agentTypes.keys()).sort();
 			const availableModels = this.session.modelRegistry.getAvailable();
 			const availableModelIds = availableModels.map((m) => `${m.provider}/${m.id}`);
+			// Local model dropdown shows ALL available models (same source as Agent Models picker)
+			const localModelAvailableModels = availableModelIds;
 
 			const currentModel = this.session.model;
 			const thinkingDisplaySupported = currentModel ? supportsAdaptiveThinking(currentModel) : false;
@@ -3741,6 +3743,10 @@ export class InteractiveMode {
 					agentModels: this.settingsManager.getAgentModels(),
 					agentNames: agentNames,
 					availableModelIds,
+					localOnlyMode: this.settingsManager.getLocalOnlyMode(),
+					localOnlyModel: this.settingsManager.getLocalOnlyModel() ?? "",
+					finalFallbackToLocalModel: this.settingsManager.getFinalFallbackToLocalModel(),
+					localModelAvailableModels,
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3875,6 +3881,15 @@ export class InteractiveMode {
 									"Edit the project settings file to change it.",
 							);
 						}
+					},
+					onLocalOnlyModeChange: (enabled) => {
+						this.settingsManager.setLocalOnlyMode(enabled);
+					},
+					onLocalOnlyModelChange: (modelId) => {
+						this.settingsManager.setLocalOnlyModel(modelId || undefined);
+					},
+					onFinalFallbackToLocalModelChange: (enabled: boolean) => {
+						this.settingsManager.setFinalFallbackToLocalModel(enabled);
 					},
 					onCancel: () => {
 						done();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -158,6 +158,8 @@ export function getStateForRpc(session: AgentSession, modelFallbackMessage?: str
 		pendingMessageCount: session.pendingMessageCount,
 		contextUsage: session.getContextUsage(),
 		modelFallbackMessage,
+		localOnlyMode: session.settingsManager.getLocalOnlyMode(),
+		localOnlyModel: session.settingsManager.getLocalOnlyModel(),
 	};
 }
 
@@ -231,6 +233,9 @@ type SettingsReader = Pick<
 	| "getTransport"
 	| "getHideThinkingBlock"
 	| "getAgentModels"
+	| "getLocalOnlyMode"
+	| "getLocalOnlyModel"
+	| "getFinalFallbackToLocalModel"
 >;
 
 type SettingsWriter = SettingsReader &
@@ -250,6 +255,9 @@ type SettingsWriter = SettingsReader &
 		| "setHideThinkingBlock"
 		| "setAgentModelsForAgent"
 		| "removeAgentModelsForAgent"
+		| "setLocalOnlyMode"
+		| "setLocalOnlyModel"
+		| "setFinalFallbackToLocalModel"
 		| "hasProjectAgentModelOverride"
 		| "hasGlobalSettingsLoadError"
 		| "flush"
@@ -279,6 +287,9 @@ export function getSettingsForRpc(settingsManager: SettingsReader): RpcSettingsS
 		transport: settingsManager.getTransport(),
 		hideThinkingBlock: settingsManager.getHideThinkingBlock(),
 		agentModels: settingsManager.getAgentModels(),
+		localOnlyMode: settingsManager.getLocalOnlyMode(),
+		localOnlyModel: settingsManager.getLocalOnlyModel(),
+		finalFallbackToLocalModel: settingsManager.getFinalFallbackToLocalModel(),
 	};
 }
 
@@ -297,6 +308,9 @@ const SETTINGS_UPDATE_KEYS = [
 	"transport",
 	"hideThinkingBlock",
 	"agentModels",
+	"localOnlyMode",
+	"localOnlyModel",
+	"finalFallbackToLocalModel",
 ] as const;
 
 const QUEUE_MODES = ["all", "one-at-a-time"] as const;
@@ -533,6 +547,15 @@ export async function setSettingsForRpc(
 		}
 		if (update.hideThinkingBlock !== undefined) {
 			settingsManager.setHideThinkingBlock(update.hideThinkingBlock);
+		}
+		if (update.localOnlyMode !== undefined) {
+			settingsManager.setLocalOnlyMode(update.localOnlyMode);
+		}
+		if (update.localOnlyModel !== undefined) {
+			settingsManager.setLocalOnlyModel(update.localOnlyModel);
+		}
+		if (update.finalFallbackToLocalModel !== undefined) {
+			settingsManager.setFinalFallbackToLocalModel(update.finalFallbackToLocalModel);
 		}
 
 		const warnings: string[] = [];

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -162,6 +162,10 @@ export interface RpcPendingMessages {
 export interface RpcSessionState {
 	model?: Model<any>;
 	scopedModels: RpcScopedModel[];
+	/** Whether local/self-hosted model injection is enabled for agent fallback lists */
+	localOnlyMode?: boolean;
+	/** The local model ID to inject (provider/model format) */
+	localOnlyModel?: string;
 	usingSubscription: boolean;
 	thinkingLevel: ThinkingLevel;
 	isStreaming: boolean;
@@ -493,6 +497,12 @@ export interface RpcSettingsSnapshot {
 	hideThinkingBlock?: boolean;
 	/** Per-agent model fallback lists, merged global + project with project entries winning */
 	agentModels?: Record<string, string[]>;
+	/** Whether local/self-hosted model injection is enabled for agent fallback lists */
+	localOnlyMode?: boolean;
+	/** The local model ID to inject (provider/model format) */
+	localOnlyModel?: string;
+	/** When true, final fallback to local model (appended at end of fallback list) */
+	finalFallbackToLocalModel?: boolean;
 }
 
 /** Settings snapshot returned by `set_settings`; warnings are present for loud shadowing notices. */
@@ -518,6 +528,9 @@ export interface RpcSettingsUpdate {
 	transport?: Transport;
 	hideThinkingBlock?: boolean;
 	agentModels?: Record<string, string[]>;
+	localOnlyMode?: boolean;
+	localOnlyModel?: string;
+	finalFallbackToLocalModel?: boolean;
 }
 
 // ============================================================================

--- a/packages/coding-agent/test/rpc-settings-commands.test.ts
+++ b/packages/coding-agent/test/rpc-settings-commands.test.ts
@@ -51,6 +51,9 @@ describe("getSettingsForRpc", () => {
 			transport: "sse",
 			hideThinkingBlock: false,
 			agentModels: {},
+			localOnlyMode: false,
+			localOnlyModel: undefined,
+			finalFallbackToLocalModel: false,
 		});
 	});
 
@@ -69,6 +72,9 @@ describe("getSettingsForRpc", () => {
 			transport: "websocket",
 			hideThinkingBlock: true,
 			agentModels: { models: { Explore: ["anthropic/sonnet", "openai/gpt-5"] } },
+			localOnlyMode: true,
+			localOnlyModel: "ollama/llama3",
+			finalFallbackToLocalModel: true,
 		});
 
 		expect(getSettingsForRpc(manager)).toEqual({
@@ -86,6 +92,9 @@ describe("getSettingsForRpc", () => {
 			transport: "websocket",
 			hideThinkingBlock: true,
 			agentModels: { Explore: ["anthropic/sonnet", "openai/gpt-5"] },
+			localOnlyMode: true,
+			localOnlyModel: "ollama/llama3",
+			finalFallbackToLocalModel: true,
 		});
 	});
 });
@@ -268,6 +277,9 @@ describe("setSettingsForRpc writes", () => {
 			transport: "auto",
 			hideThinkingBlock: true,
 			agentModels: { Explore: ["anthropic/sonnet", "openai/gpt-5"] },
+			localOnlyMode: true,
+			localOnlyModel: "ollama/llama3",
+			finalFallbackToLocalModel: true,
 		});
 
 		expect(result.ok).toBe(true);
@@ -287,6 +299,9 @@ describe("setSettingsForRpc writes", () => {
 			transport: "auto",
 			hideThinkingBlock: true,
 			agentModels: { Explore: ["anthropic/sonnet", "openai/gpt-5"] },
+			localOnlyMode: true,
+			localOnlyModel: "ollama/llama3",
+			finalFallbackToLocalModel: true,
 		});
 		// Reflected in subsequent reads.
 		expect(getSettingsForRpc(manager)).toEqual(result.settings);
@@ -342,6 +357,36 @@ describe("setSettingsForRpc writes", () => {
 		const rawGlobal = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8"));
 		expect(rawGlobal.agentModels.models.Explore).toEqual(["global/model"]);
 		expect(rawGlobal.agentModels.models["Code Reviewer"]).toEqual(["global/reviewer"]);
+	});
+
+	it("persists localOnlyMode: true via set_settings", async () => {
+		const manager = SettingsManager.inMemory();
+		const result = await setSettingsForRpc(manager, stubRegistry([]), { localOnlyMode: true });
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+		expect(result.settings.localOnlyMode).toBe(true);
+		expect(getSettingsForRpc(manager).localOnlyMode).toBe(true);
+	});
+
+	it("persists localOnlyModel via set_settings", async () => {
+		const manager = SettingsManager.inMemory();
+		const result = await setSettingsForRpc(manager, stubRegistry([]), { localOnlyModel: "ollama/llama3" });
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+		expect(result.settings.localOnlyModel).toBe("ollama/llama3");
+		expect(getSettingsForRpc(manager).localOnlyModel).toBe("ollama/llama3");
+	});
+
+	it("persists finalFallbackToLocalModel: true via set_settings", async () => {
+		const manager = SettingsManager.inMemory();
+		const result = await setSettingsForRpc(manager, stubRegistry([]), { finalFallbackToLocalModel: true });
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+		expect(result.settings.finalFallbackToLocalModel).toBe(true);
+		expect(getSettingsForRpc(manager).finalFallbackToLocalModel).toBe(true);
 	});
 
 	it("persists to disk and is visible to a fresh SettingsManager (fresh-runtime simulation)", async () => {
@@ -547,6 +592,9 @@ describe("RpcClient settings methods", () => {
 		transport: "sse",
 		hideThinkingBlock: false,
 		agentModels: {},
+		localOnlyMode: false,
+		localOnlyModel: undefined,
+		finalFallbackToLocalModel: false,
 	};
 
 	it("getSettings sends the get_settings command and unwraps the snapshot", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -584,4 +584,53 @@ describe("SettingsManager", () => {
 			expect(manager.getBackgroundAgentGuardrailEnabled()).toBe(false);
 		});
 	});
+
+	describe("local-only mode settings", () => {
+		it("getLocalOnlyMode() returns false by default, true after set", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getLocalOnlyMode()).toBe(false);
+
+			manager.setLocalOnlyMode(true);
+			await manager.flush();
+
+			expect(manager.getLocalOnlyMode()).toBe(true);
+		});
+
+		it("getLocalOnlyModel() returns undefined by default, returns value after set, undefined after clearing", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getLocalOnlyModel()).toBeUndefined();
+
+			manager.setLocalOnlyModel("ollama/qwen3.5");
+			await manager.flush();
+			expect(manager.getLocalOnlyModel()).toBe("ollama/qwen3.5");
+
+			manager.setLocalOnlyModel(undefined);
+			await manager.flush();
+			expect(manager.getLocalOnlyModel()).toBeUndefined();
+		});
+
+		it("getFinalFallbackToLocalModel() returns false by default, true after set", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getFinalFallbackToLocalModel()).toBe(false);
+
+			manager.setFinalFallbackToLocalModel(true);
+			await manager.flush();
+
+			expect(manager.getFinalFallbackToLocalModel()).toBe(true);
+		});
+
+		it("setters call save() — verified via flush persistence", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			manager.setLocalOnlyMode(true);
+			manager.setLocalOnlyModel("ollama/qwen3.5");
+			manager.setFinalFallbackToLocalModel(true);
+			await manager.flush();
+
+			const saved = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
+			expect(saved.localOnlyMode).toBe(true);
+			expect(saved.localOnlyModel).toBe("ollama/qwen3.5");
+			expect(saved.finalFallbackToLocalModel).toBe(true);
+		});
+	});
 });

--- a/packages/coding-agent/test/settings-selector-local-only.test.ts
+++ b/packages/coding-agent/test/settings-selector-local-only.test.ts
@@ -1,0 +1,231 @@
+import { setKeybindings } from "@dreb/tui";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import {
+	type SettingsCallbacks,
+	type SettingsConfig,
+	SettingsSelectorComponent,
+} from "../src/modes/interactive/components/settings-selector.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+beforeEach(() => {
+	// Keybindings are a global singleton — reset for test isolation.
+	setKeybindings(new KeybindingsManager());
+});
+
+const ENTER = "\r";
+
+function makeConfig(overrides: Partial<SettingsConfig> = {}): SettingsConfig {
+	return {
+		autoCompact: true,
+		showImages: false,
+		autoResizeImages: false,
+		blockImages: false,
+		enableSkillCommands: false,
+		steeringMode: "all",
+		followUpMode: "all",
+		transport: "auto",
+		thinkingLevel: "high",
+		availableThinkingLevels: ["off", "low", "medium", "high"],
+		currentTheme: "dark",
+		availableThemes: ["dark", "light"],
+		hideThinkingBlock: false,
+		thinkingDisplaySupported: false,
+		thinkingDisplay: "summarized",
+		doubleEscapeAction: "tree",
+		treeFilterMode: "default",
+		showHardwareCursor: false,
+		editorPaddingX: 1,
+		autocompleteMaxVisible: 7,
+		quietStartup: false,
+		autoLoadNestedContext: true,
+		agentModels: {},
+		agentNames: [],
+		availableModelIds: [],
+		localOnlyMode: false,
+		localOnlyModel: "",
+		finalFallbackToLocalModel: false,
+		localModelAvailableModels: ["ollama/qwen3:latest", "ollama/llama3.1:8b"],
+		...overrides,
+	};
+}
+
+function makeCallbacks(): SettingsCallbacks {
+	return {
+		onAutoCompactChange: vi.fn(),
+		onAutoLoadNestedContextChange: vi.fn(),
+		onShowImagesChange: vi.fn(),
+		onAutoResizeImagesChange: vi.fn(),
+		onBlockImagesChange: vi.fn(),
+		onEnableSkillCommandsChange: vi.fn(),
+		onSteeringModeChange: vi.fn(),
+		onFollowUpModeChange: vi.fn(),
+		onTransportChange: vi.fn(),
+		onThinkingLevelChange: vi.fn(),
+		onThemeChange: vi.fn(),
+		onHideThinkingBlockChange: vi.fn(),
+		onThinkingDisplayChange: vi.fn(),
+		onDoubleEscapeActionChange: vi.fn(),
+		onTreeFilterModeChange: vi.fn(),
+		onShowHardwareCursorChange: vi.fn(),
+		onEditorPaddingXChange: vi.fn(),
+		onAutocompleteMaxVisibleChange: vi.fn(),
+		onQuietStartupChange: vi.fn(),
+		onAgentModelsChange: vi.fn(),
+		onLocalOnlyModeChange: vi.fn(),
+		onLocalOnlyModelChange: vi.fn(),
+		onFinalFallbackToLocalModelChange: vi.fn(),
+		onCancel: vi.fn(),
+	};
+}
+
+/**
+ * Filter the list down to the local-only-mode item using the built-in search.
+ * Note: spaces in search trigger the "confirm" action in SettingsList,
+ * so search terms must not contain spaces.
+ */
+function focusLocalOnlyMode(component: SettingsSelectorComponent): void {
+	const list = component.getSettingsList();
+	// "only" uniquely matches the "Local only mode" label.
+	for (const ch of "only") {
+		list.handleInput(ch);
+	}
+}
+
+function focusLocalModelAppend(component: SettingsSelectorComponent): void {
+	const list = component.getSettingsList();
+	// "final" uniquely matches "Final fallback to local model".
+	for (const ch of "final") {
+		list.handleInput(ch);
+	}
+}
+
+function focusLocalModel(component: SettingsSelectorComponent): void {
+	const list = component.getSettingsList();
+	// "localmode" uniquely matches "Local model" (space in label is removed).
+	for (const ch of "localmode") {
+		list.handleInput(ch);
+	}
+}
+
+describe("SettingsSelectorComponent — Local Only Mode", () => {
+	test("renders localOnlyMode toggle with correct state (false)", () => {
+		const component = new SettingsSelectorComponent(makeConfig({ localOnlyMode: false }), makeCallbacks());
+		focusLocalOnlyMode(component);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		expect(output).toContain("Local only mode");
+		expect(output).toContain("false");
+	});
+
+	test("renders localOnlyMode toggle with correct state (true)", () => {
+		const component = new SettingsSelectorComponent(makeConfig({ localOnlyMode: true }), makeCallbacks());
+		focusLocalOnlyMode(component);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		expect(output).toContain("Local only mode");
+		expect(output).toContain("true");
+	});
+
+	test("toggling localOnlyMode from false to true fires onLocalOnlyModeChange", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(makeConfig({ localOnlyMode: false }), callbacks);
+		focusLocalOnlyMode(component);
+
+		component.getSettingsList().handleInput(ENTER);
+
+		expect(callbacks.onLocalOnlyModeChange).toHaveBeenCalledWith(true);
+	});
+
+	test("toggling localOnlyMode from true to false fires onLocalOnlyModeChange", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(makeConfig({ localOnlyMode: true }), callbacks);
+		focusLocalOnlyMode(component);
+
+		component.getSettingsList().handleInput(ENTER);
+
+		expect(callbacks.onLocalOnlyModeChange).toHaveBeenCalledWith(false);
+	});
+
+	test("renders finalFallbackToLocalModel toggle with correct state", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(makeConfig({ finalFallbackToLocalModel: true }), callbacks);
+		focusLocalModelAppend(component);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		expect(output).toContain("Final fallback to local model");
+		expect(output).toContain("Append local model as last fallback");
+		expect(output).toContain("true");
+	});
+
+	test("toggling finalFallbackToLocalModel fires onFinalFallbackToLocalModelChange", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(makeConfig({ finalFallbackToLocalModel: false }), callbacks);
+		focusLocalModelAppend(component);
+
+		component.getSettingsList().handleInput(ENTER);
+
+		expect(callbacks.onFinalFallbackToLocalModelChange).toHaveBeenCalledWith(true);
+	});
+
+	test("localOnlyModel dropdown populates from available models", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(
+			makeConfig({
+				localModelAvailableModels: ["ollama/qwen3:latest", "ollama/llama3.1:8b"],
+			}),
+			callbacks,
+		);
+		focusLocalModel(component);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		expect(output).toContain("Local model");
+
+		// Open the submenu
+		component.getSettingsList().handleInput(ENTER);
+
+		const submenuOutput = component.getSettingsList().render(80).join("\n");
+		expect(submenuOutput).toContain("Local Model");
+		expect(submenuOutput).toContain("ollama/qwen3:latest");
+		expect(submenuOutput).toContain("ollama/llama3.1:8b");
+	});
+
+	test("when no local models available, localOnlyModel entry is hidden", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(
+			makeConfig({
+				localOnlyMode: false,
+				localModelAvailableModels: [],
+			}),
+			callbacks,
+		);
+		focusLocalOnlyMode(component);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		expect(output).toContain("Local only mode");
+		expect(output).not.toContain("Local model");
+	});
+
+	test("localOnlyModel entry uses selected model as default when set", () => {
+		const callbacks = makeCallbacks();
+		const component = new SettingsSelectorComponent(
+			makeConfig({
+				localOnlyModel: "ollama/llama3.1:8b",
+				localModelAvailableModels: ["ollama/qwen3:latest", "ollama/llama3.1:8b"],
+			}),
+			callbacks,
+		);
+		focusLocalModel(component);
+
+		// Open the submenu
+		component.getSettingsList().handleInput(ENTER);
+
+		const output = component.getSettingsList().render(80).join("\n");
+		// The selected model should appear in the submenu list
+		expect(output).toContain("ollama/llama3.1:8b");
+	});
+});

--- a/packages/coding-agent/test/settings-selector-thinking-display.test.ts
+++ b/packages/coding-agent/test/settings-selector-thinking-display.test.ts
@@ -46,6 +46,10 @@ function makeConfig(overrides: Partial<SettingsConfig> = {}): SettingsConfig {
 		agentModels: {},
 		agentNames: [],
 		availableModelIds: [],
+		localOnlyMode: false,
+		localOnlyModel: "",
+		finalFallbackToLocalModel: false,
+		localModelAvailableModels: [],
 		...overrides,
 	};
 }
@@ -73,6 +77,9 @@ function makeCallbacks(): SettingsCallbacks {
 		onAutocompleteMaxVisibleChange: vi.fn(),
 		onQuietStartupChange: vi.fn(),
 		onAgentModelsChange: vi.fn(),
+		onLocalOnlyModeChange: vi.fn(),
+		onLocalOnlyModelChange: vi.fn(),
+		onFinalFallbackToLocalModelChange: vi.fn(),
 		onCancel: vi.fn(),
 	};
 }

--- a/packages/coding-agent/test/subagent-model-fallback.test.ts
+++ b/packages/coding-agent/test/subagent-model-fallback.test.ts
@@ -1786,3 +1786,374 @@ describe("parentSessionFile threading", () => {
 		expect(spawnArgs).not.toContain("--parent-session");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Local Only Mode — subagent resolution injection
+// ---------------------------------------------------------------------------
+
+describe("Local Only Mode — resolveModelForSubagentSpawn injection", () => {
+	const localConfigPrepend = {
+		enabled: true,
+		modelId: "ollama/qwen3.6:latest",
+		finalFallback: false,
+	};
+
+	const localConfigAppend = {
+		enabled: true,
+		modelId: "ollama/qwen3.6:latest",
+		finalFallback: true,
+	};
+
+	function hasLocalInjectionMessage(_prefix = "[subagent]"): boolean {
+		const calls = vi.mocked(log.debug).mock.calls;
+		return calls.some(
+			(c) =>
+				typeof c[0] === "string" &&
+				(c[0].includes("Prepending local model") || c[0].includes("Appending local model")),
+		);
+	}
+
+	test("prepend: local model is added as first fallback when enabled and not already present", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localConfigPrepend,
+		);
+
+		// ollama/qwen3.6:latest is NOT in the mock registry → fails at resolve time,
+		// falls through to primary-model which succeeds.
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+			expect(result.skippedModels).toContainEqual({
+				model: "ollama/qwen3.6:latest",
+				reason: expect.any(String),
+			});
+		}
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(true);
+		expect(hasLocalInjectionMessage()).toBe(true);
+	});
+
+	test("finalFallback: local model is added as last fallback when finalFallback is true", async () => {
+		// primary-model probes first — fail it; fallback-model probes second — succeed;
+		// ollama should be last and never reached.
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(assistantResult("error", "primary down"))
+			.mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localConfigAppend,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("fallback-model");
+		}
+		// 2 probes (primary + fallback), ollama never reached
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+		expect(log.warn).toHaveBeenCalledWith(
+			'[subagent] Model "primary-model" failed probe (primary down). Trying next fallback...',
+		);
+	});
+
+	test("deduplication: local model not added when already in the list", async () => {
+		// primary-model is already first — it's also our local model via a separate config
+		const dedupConfig = {
+			enabled: true,
+			modelId: "primary-model", // already first in the array
+			finalFallback: false,
+		};
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			dedupConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		// Only 1 probe — local model already first, no duplicate prepended
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("no injection when enabled is false", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const disabledConfig = { ...localConfigPrepend, enabled: false };
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			disabledConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("no injection when config is undefined", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			undefined,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("no injection when enabled but modelId is empty", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const emptyModelIdConfig = { ...localConfigPrepend, modelId: "" };
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			emptyModelIdConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("no injection when non-array model (registry-less path)", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			"primary-model",
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localConfigPrepend,
+		);
+
+		// Single string → resolveModelWithFallbacks path, no injection
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		expect(completeSimple).not.toHaveBeenCalled();
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("no injection when no registry (registry-less path)", async () => {
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			undefined, // no registry
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localConfigPrepend,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		expect(completeSimple).not.toHaveBeenCalled();
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+
+	test("local model probe fails, falls through to first real fallback", async () => {
+		// parent-model IS in the registry and NOT in the models array,
+		// so it gets prepended and passes resolveModelStringSingle.
+		// Then its probe fails, and we fall through to primary-model.
+		const localProbeConfig = {
+			enabled: true,
+			modelId: "parent-model",
+			finalFallback: false,
+		};
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(assistantResult("error", "local model down"))
+			.mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localProbeConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		// 2 probes: local (parent-model) fails, primary succeeds
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+		expect(log.warn).toHaveBeenCalledWith(
+			'[subagent] Model "parent-model" failed probe (local model down). Trying next fallback...',
+		);
+	});
+
+	test("local model probe fails, all fallbacks fail, parent succeeds", async () => {
+		const localProbeConfig = {
+			enabled: true,
+			modelId: "parent-model",
+			finalFallback: false,
+		};
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(assistantResult("error", "local down"))
+			.mockResolvedValueOnce(assistantResult("error", "primary down"))
+			.mockRejectedValueOnce(new Error("fallback auth revoked"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localProbeConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("parent-model");
+			expect(result.warning).toContain('Falling back to parent model "parent-model"');
+		}
+		// 3 probes: local (parent-model) fails, primary fails, fallback fails, then parent succeeds
+		expect(completeSimple).toHaveBeenCalledTimes(3);
+	});
+
+	test("append mode: local model is tried last after all real fallbacks", async () => {
+		// parent-model is in the registry, append mode → added at end.
+		// primary-model probe succeeds → parent-model never reached.
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const appendLocalConfig = {
+			enabled: true,
+			modelId: "parent-model",
+			finalFallback: true,
+		};
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			appendLocalConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		// Only 1 probe — primary-model succeeds, parent-model (appended) never reached
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(true);
+	});
+
+	test("local model probe fails, primary succeeds, fallback never reached", async () => {
+		const localProbeConfig = {
+			enabled: true,
+			modelId: "parent-model",
+			finalFallback: false,
+		};
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(assistantResult("error", "local down"))
+			.mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			localProbeConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		// 2 probes: local fails, primary succeeds (fallback never probed)
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+		expect(result.skippedModels).toContainEqual({
+			model: "parent-model",
+			reason: "local down",
+		});
+	});
+
+	test("local model deduplication when already present via append mode", async () => {
+		// primary-model is in the list; append mode with primary-model as local
+		const dedupAppendConfig = {
+			enabled: true,
+			modelId: "primary-model",
+			finalFallback: true,
+		};
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			dedupAppendConfig,
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.modelId).toBe("primary-model");
+		}
+		// Only 1 probe — no duplicate added
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(hasLocalInjectionMessage()).toBe(false);
+	});
+});

--- a/packages/dashboard/src/client/screens/session.tsx
+++ b/packages/dashboard/src/client/screens/session.tsx
@@ -1047,6 +1047,28 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 									{ctx()!.percent === null ? "?" : `${ctx()!.percent!.toFixed(0)}%`}
 								</output>
 							</Show>
+							<button
+								type="button"
+								class="switcher optional"
+								title={runtime()?.state.localOnlyMode ? "local mode on" : "local mode off — click to toggle"}
+								onClick={async () => {
+									try {
+										const newState = !(runtime()?.state.localOnlyMode ?? false);
+										await api.saveSettings({ localOnlyMode: newState });
+										await props.store.refreshFleet();
+									} catch (err) {
+										setActionError(err instanceof Error ? err.message : String(err));
+									}
+								}}
+							>
+								<span class="label">local</span>{" "}
+								<span
+									class="value"
+									style={{ color: runtime()?.state.localOnlyMode ? "var(--accent)" : undefined }}
+								>
+									{runtime()?.state.localOnlyMode ? "on" : "off"}
+								</span>
+							</button>
 							<button type="button" class="switcher" onClick={() => setShowOverflow(!showOverflow())}>
 								⋯
 							</button>

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -21,7 +21,7 @@ const QUEUE_MODES = ["all", "one-at-a-time"] as const;
 const TRANSPORTS = ["sse", "websocket", "auto"] as const;
 
 type ModelChoice = Pick<ModelInfoDto, "provider" | "id"> & Partial<Pick<ModelInfoDto, "name" | "reasoning">>;
-type ModelPickerTarget = { kind: "default" } | { kind: "agent"; agentName: string };
+type ModelPickerTarget = { kind: "default" } | { kind: "agent"; agentName: string } | { kind: "localModel" };
 
 function modelKey(model: Pick<ModelInfoDto, "provider" | "id">): string {
 	return `${model.provider}/${model.id}`;
@@ -396,6 +396,53 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 												{(transport) => <option value={transport}>{transport}</option>}
 											</For>
 										</select>
+									</span>
+								</div>
+							</section>
+
+							<section class="settings-section">
+								<h2>local model</h2>
+								<div class="setting-row">
+									<span class="setting-label">
+										<span class="name">local model</span>
+										<span class="hint">selected model for local-only mode — pick any available model</span>
+									</span>
+									<span class="setting-control">
+										<button
+											type="button"
+											class="btn btn-small model-picker-button"
+											onClick={() => setModelPickerTarget({ kind: "localModel" })}
+										>
+											{current().localOnlyModel ?? "choose model…"}
+										</button>
+									</span>
+								</div>
+								<div class="setting-row">
+									<span class="setting-label">
+										<span class="name">local mode</span>
+										<span class="hint">
+											when on, the local model becomes the default and is prepended to agent fallback lists
+										</span>
+									</span>
+									<span class="setting-control">
+										<OnOffSelect
+											value={current().localOnlyMode !== false}
+											onChange={(value) => save({ localOnlyMode: value })}
+										/>
+									</span>
+								</div>
+								<div class="setting-row">
+									<span class="setting-label">
+										<span class="name">final fallback to local model</span>
+										<span class="hint">
+											when on, the local model is appended to all subagent fallback lists as a last resort
+										</span>
+									</span>
+									<span class="setting-control">
+										<OnOffSelect
+											value={current().finalFallbackToLocalModel !== false}
+											onChange={(value) => save({ finalFallbackToLocalModel: value })}
+										/>
 									</span>
 								</div>
 							</section>
@@ -862,7 +909,9 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 				{(target) => {
 					const pickerTitle = () => {
 						const active = target();
-						return active.kind === "default" ? "select default model" : `add model for ${active.agentName}`;
+						if (active.kind === "default") return "select default model";
+						if (active.kind === "localModel") return "select local model";
+						return `add model for ${active.agentName}`;
 					};
 					const selectedKeys = () => {
 						const active = target();
@@ -870,6 +919,9 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 							return settings()?.defaultProvider && settings()?.defaultModel
 								? [`${settings()!.defaultProvider}/${settings()!.defaultModel}`]
 								: [];
+						}
+						if (active.kind === "localModel") {
+							return settings()?.localOnlyModel ? [settings()!.localOnlyModel] : [];
 						}
 						return currentAgentModels(active.agentName);
 					};
@@ -884,6 +936,10 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 								setModelPickerTarget(undefined);
 								if (active.kind === "default") {
 									void save({ defaultProvider: model.provider, defaultModel: model.id });
+									return;
+								}
+								if (active.kind === "localModel") {
+									void save({ localOnlyModel: modelKey(model) });
 									return;
 								}
 								const entry = modelKey(model);

--- a/packages/dashboard/src/shared/protocol.ts
+++ b/packages/dashboard/src/shared/protocol.ts
@@ -147,6 +147,8 @@ export interface SessionStateDto {
 	pendingMessageCount: number;
 	contextUsage?: ContextUsageDto;
 	modelFallbackMessage?: string;
+	localOnlyMode?: boolean;
+	localOnlyModel?: string;
 }
 
 /** A live runtime managed by the dashboard server's pool. */
@@ -244,6 +246,9 @@ export interface SettingsDto {
 	transport?: "sse" | "websocket" | "auto";
 	hideThinkingBlock?: boolean;
 	agentModels?: Record<string, string[]>;
+	localOnlyMode?: boolean;
+	localOnlyModel?: string;
+	finalFallbackToLocalModel?: boolean;
 }
 
 export type SettingsSaveResultDto = SettingsDto & { warnings?: string[] };


### PR DESCRIPTION
Closes #354

Implementation plan posted as a comment below.
