### PR TITLE
Document WSL2 mirrored-networking dashboard access gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ systemctl --user enable --now dreb-dashboard
 
 macOS users can run the same command under a launchd user agent; a full plist is deferred.
 
+**WSL2 users:** if you reach the dashboard from a Windows browser and hit an intermittent access-denied / pairing screen on `http://127.0.0.1` after the WSL VM has been idle, see the [WSL2 gotcha](packages/coding-agent/docs/dashboard.md#wsl2-gotcha) for the cause and keep-alive workarounds.
+
 Full docs: [dashboard.md](packages/coding-agent/docs/dashboard.md).
 
 ## Design philosophy

--- a/packages/coding-agent/docs/dashboard.md
+++ b/packages/coding-agent/docs/dashboard.md
@@ -74,6 +74,47 @@ agents, running commands through them, browsing the whole host filesystem
 pairing screen states this before the PIN is entered. Every file operation is
 logged server-side.
 
+## WSL2 gotcha — intermittent "access denied" / pairing screen on localhost
+
+<a id="wsl2-gotcha"></a>
+
+If you run the dashboard inside **WSL2** and reach it from a Windows browser at
+`http://127.0.0.1:5343`, you may intermittently get an **access-denied /
+pairing screen even in local mode** — typically right after the WSL VM has been
+idle, clearing once WSL is "warm" again (e.g. after you open a WSL terminal,
+which is itself slow to start because the VM is resuming).
+
+**Cause.** With WSL's `networkingMode=mirrored`, host→guest loopback traffic can
+reach the server with a source address of `10.255.255.254` — the mirrored
+host-loopback address WSL assigns to `lo` — instead of `127.0.0.1`, during the
+window after a cold boot / resume before the loopback relay settles. Local-mode
+auth only treats `127.x.x.x`/`::1` as loopback, so those requests fail the
+loopback check and are denied; the client renders that denial as the
+access-denied / pairing screen. No actual Tailscale/pairing is involved.
+
+**Why it correlates with WSL idling.** WSL tears the VM down when idle, and a
+dashboard running as a background service does **not** keep it alive: WSL's
+instance watchdog only counts processes it launches directly (interactive
+`wsl.exe` sessions or `wsl --exec`), and a `systemd`-managed service lives under
+PID 1 where the watchdog never sees it. So an always-on dashboard still lets the
+VM idle out, and the first request after resume can land in the transitional
+networking window above.
+
+**Workarounds** (host-side — no dreb changes needed):
+
+- **Keep a WSL terminal open.** Simplest and most reliable: an attached
+  interactive session is exactly the signal WSL uses to keep the VM alive, which
+  also avoids the post-resume networking window entirely.
+- **Headless keep-alive.** Run `wsl --exec dbus-launch true` (e.g. as a logon
+  Scheduled Task): it leaves a lingering background daemon that holds the VM open
+  with no terminal window. Re-run after each Windows reboot — it does not
+  persist. See [microsoft/WSL#10138](https://github.com/microsoft/WSL/issues/10138).
+  A `sleep infinity` session via Task Scheduler works too. (`vmIdleTimeout=-1`
+  in `.wslconfig` is Windows-11-only and reported unreliable for keeping the
+  *instance* — not just the VM — alive.)
+- **Access via the WSL VM's own IP** instead of localhost, if that path is
+  loopback-clean for your setup.
+
 ## Screens
 
 | Screen | What it does |

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -87,6 +87,16 @@ upload/download. Every file operation is logged server-side. Browser
 notifications are opt-in per device from settings; the tab-title attention
 badge works without permission.
 
+## WSL2 gotcha — intermittent "access denied" / pairing screen on localhost
+
+Running the dashboard inside **WSL2** and reaching it from a Windows browser can
+intermittently show an access-denied / pairing screen on `http://127.0.0.1`
+right after the WSL VM has been idle. It's a WSL mirrored-networking quirk (the
+loopback source address is transiently `10.255.255.254`, which fails local-mode
+auth's `127.x`/`::1` check), not a dreb bug. Keeping a WSL terminal open — or a
+headless keep-alive — avoids it. Full explanation and workarounds:
+[WSL2 gotcha](../coding-agent/docs/dashboard.md#wsl2-gotcha).
+
 ## Options
 
 | Flag | Description |


### PR DESCRIPTION
## What

Documents a WSL2-specific dashboard access gotcha and consolidates the docs to a single source of truth.

**The gotcha.** Running the dashboard inside WSL2 and reaching it from a Windows browser can intermittently show an **access-denied / pairing screen on `http://127.0.0.1` in local mode**, right after the WSL VM has been idle. Root cause: with `networkingMode=mirrored`, host→guest loopback traffic can arrive with a source address of `10.255.255.254` (the mirrored host-loopback address on `lo`) instead of `127.0.0.1` during the post-boot/resume window, which fails local-mode auth's `127.x`/`::1` loopback check. Reproduced directly:

```
curl --interface 10.255.255.254 http://127.0.0.1:5343/api/auth
{"error":"Remote dashboard access is disabled","needsPairing":false}  # 403
```

The doc also explains why a background dashboard service does **not** keep the VM alive (WSL's instance watchdog only counts processes it launches directly; a systemd-managed service under PID 1 is invisible to it) and lists host-side keep-alive workarounds.

## Docs structure (single source of truth)

- **Canonical:** full section added to `packages/coding-agent/docs/dashboard.md` (`#wsl2-gotcha`).
- **Package README** (`packages/dashboard/README.md`): short summary + link to canonical (no duplicated body).
- **Root README:** one-line WSL pointer → canonical anchor.

No code changes — this is a host-environment quirk, not a dreb bug, so it's documented rather than patched.

## Verification

- All three relative links / anchors resolve.
- `http://` retained throughout (localhost is a secure context over plain HTTP; local mode serves no TLS).
- Pre-commit: biome clean, full suite 4485 passed / 0 failed.
