### PR TITLE
Fix stick-to-bottom follow drop-out in dashboard transcript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           ln -sf "$(which fdfind)" "$HOME/.local/bin/fd"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: npm ci
+      - name: Install Playwright Chromium (dashboard real-browser scroll tests)
+        run: npx playwright install --with-deps chromium
       - run: npm run build
       - run: bash test.sh
 
@@ -66,6 +68,8 @@ jobs:
           ln -sf "$(which fdfind)" "$HOME/.local/bin/fd"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: npm ci
+      - name: Install Playwright Chromium (dashboard real-browser scroll tests)
+        run: npx playwright install --with-deps chromium
       - run: npm run build
       - name: Generate coverage
         run: npm run coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -11182,6 +11182,7 @@
 				"@types/express": "^5.0.5",
 				"@types/node": "^24.3.0",
 				"dompurify": "^3.4.11",
+				"esbuild": "^0.27.4",
 				"highlight.js": "^11.11.1",
 				"jsdom": "^28.0.0",
 				"marked": "^15.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8523,6 +8523,53 @@
 			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
 			"license": "MIT"
 		},
+		"node_modules/playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.12",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -11138,6 +11185,7 @@
 				"highlight.js": "^11.11.1",
 				"jsdom": "^28.0.0",
 				"marked": "^15.0.12",
+				"playwright": "^1.61.1",
 				"solid-js": "^1.9.14",
 				"typescript": "^5.9.2",
 				"vite": "^8.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.39.0",
+			"version": "2.40.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,6 +37,7 @@
 		"@types/express": "^5.0.5",
 		"@types/node": "^24.3.0",
 		"dompurify": "^3.4.11",
+		"esbuild": "^0.27.4",
 		"highlight.js": "^11.11.1",
 		"jsdom": "^28.0.0",
 		"marked": "^15.0.12",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -40,6 +40,7 @@
 		"highlight.js": "^11.11.1",
 		"jsdom": "^28.0.0",
 		"marked": "^15.0.12",
+		"playwright": "^1.61.1",
 		"solid-js": "^1.9.14",
 		"typescript": "^5.9.2",
 		"vite": "^8.1.3",

--- a/packages/dashboard/src/client/components/transcript.tsx
+++ b/packages/dashboard/src/client/components/transcript.tsx
@@ -9,7 +9,7 @@ import DOMPurify from "dompurify";
 import hljs from "highlight.js/lib/common";
 import { marked } from "marked";
 import { createEffect, createMemo, createSignal, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js";
-import { createCoalescedBottomScroller } from "../scrolling.js";
+import { createStickToBottom } from "../scrolling.js";
 import { expandThinking, isToolAutoOpen } from "../state/preferences.js";
 import type { AgentResultEntry, AssistantEntry, ToolEntry, TranscriptEntry } from "../state/reducer.js";
 
@@ -133,56 +133,31 @@ function HighlightedPre(props: {
 	throttle?: boolean;
 }): JSX.Element {
 	let preRef: HTMLPreElement | undefined;
-	let stickToBottom = true;
-	let userScrolling = false;
-	let userScrollTimer: ReturnType<typeof setTimeout> | undefined;
 	const text = throttledString(
 		() => props.text,
 		() => props.throttle === true,
 	);
 	const html = createMemo(() => highlightedHtml(text(), props.language));
-	const atBottom = () => !preRef || preRef.scrollTop + preRef.clientHeight >= preRef.scrollHeight - 24;
-	const bottomScroller = createCoalescedBottomScroller({
-		element: () => preRef,
-		shouldScroll: () => stickToBottom && !userScrolling,
-	});
-	const releaseUserScrollSoon = () => {
-		if (userScrollTimer) clearTimeout(userScrollTimer);
-		userScrollTimer = setTimeout(() => {
-			userScrolling = false;
-			stickToBottom = atBottom();
-		}, 250);
-	};
+	const stickToBottom = createStickToBottom({ scroller: () => preRef, threshold: 24 });
 
 	createEffect(() => {
 		text();
 		props.language;
-		if (!props.autoScroll || !stickToBottom || userScrolling) return;
-		bottomScroller.request();
+		if (props.autoScroll) stickToBottom.notifyContentChanged();
 	});
-	onCleanup(() => {
-		if (userScrollTimer) clearTimeout(userScrollTimer);
-		bottomScroller.cancel();
-	});
+	onCleanup(() => stickToBottom.dispose());
 
 	return (
 		<pre
 			ref={preRef}
-			onWheel={() => {
-				if (!props.autoScroll) return;
-				userScrolling = true;
-				releaseUserScrollSoon();
-			}}
 			onTouchStart={() => {
-				if (props.autoScroll) userScrolling = true;
+				if (props.autoScroll) stickToBottom.handleTouchStart();
 			}}
 			onTouchEnd={() => {
-				if (!props.autoScroll) return;
-				userScrolling = false;
-				stickToBottom = atBottom();
+				if (props.autoScroll) stickToBottom.handleTouchEnd();
 			}}
 			onScroll={() => {
-				if (props.autoScroll) stickToBottom = atBottom();
+				if (props.autoScroll) stickToBottom.handleScroll();
 			}}
 		>
 			<Show when={html()} fallback={text()}>

--- a/packages/dashboard/src/client/components/transcript.tsx
+++ b/packages/dashboard/src/client/components/transcript.tsx
@@ -8,8 +8,20 @@
 import DOMPurify from "dompurify";
 import hljs from "highlight.js/lib/common";
 import { marked } from "marked";
-import { createEffect, createMemo, createSignal, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js";
-import { createStickToBottom } from "../scrolling.js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	type JSX,
+	Match,
+	onCleanup,
+	onMount,
+	Show,
+	Switch,
+	untrack,
+} from "solid-js";
+import { bindStickToBottom, createStickToBottom } from "../scrolling.js";
 import { expandThinking, isToolAutoOpen } from "../state/preferences.js";
 import type { AgentResultEntry, AssistantEntry, ToolEntry, TranscriptEntry } from "../state/reducer.js";
 
@@ -145,24 +157,19 @@ function HighlightedPre(props: {
 		props.language;
 		if (props.autoScroll) stickToBottom.notifyContentChanged();
 	});
+	onMount(() => {
+		if (preRef)
+			onCleanup(
+				bindStickToBottom(stickToBottom, preRef, { enabled: () => props.autoScroll === true, keyboard: "element" }),
+			);
+	});
 	onCleanup(() => stickToBottom.dispose());
 
 	return (
-		<pre
-			ref={preRef}
-			onTouchStart={() => {
-				if (props.autoScroll) stickToBottom.handleTouchStart();
-			}}
-			onTouchEnd={() => {
-				if (props.autoScroll) stickToBottom.handleTouchEnd();
-			}}
-			onTouchCancel={() => {
-				if (props.autoScroll) stickToBottom.handleTouchCancel();
-			}}
-			onScroll={() => {
-				if (props.autoScroll) stickToBottom.handleScroll();
-			}}
-		>
+		// tabindex makes the nested scroller keyboard-focusable so PageUp/ArrowUp
+		// can scroll it — and so the element-level keydown listener actually fires
+		// to arm upward intent on ITS controller (not the outer transcript's).
+		<pre ref={preRef} tabindex="0">
 			<Show when={html()} fallback={text()}>
 				{(safeHtml) => <code class="hljs" innerHTML={safeHtml()} />}
 			</Show>
@@ -584,7 +591,14 @@ function AssistantBlockView(props: { entry: AssistantEntry; who: string }): JSX.
 }
 
 export type TranscriptRenderItem =
-	| { kind: "assistant-turn"; entries: Array<AssistantEntry | ToolEntry> }
+	| {
+			kind: "assistant-turn";
+			/** Stable identity — the turn's leading assistant entry. */
+			lead: AssistantEntry;
+			/** Reactive: appending a tool updates this WITHOUT replacing the item. */
+			entries: () => Array<AssistantEntry | ToolEntry>;
+			setEntries: (entries: Array<AssistantEntry | ToolEntry>) => void;
+	  }
 	| { kind: "entry"; entry: TranscriptEntry };
 
 function canReuseEntryItem(
@@ -594,15 +608,9 @@ function canReuseEntryItem(
 	return item?.kind === "entry" && item.entry === entry;
 }
 
-function canReuseAssistantTurn(
-	item: TranscriptRenderItem | undefined,
-	entries: Array<AssistantEntry | ToolEntry>,
-): item is TranscriptRenderItem {
-	return (
-		item?.kind === "assistant-turn" &&
-		item.entries.length === entries.length &&
-		item.entries.every((entry, index) => entry === entries[index])
-	);
+function makeAssistantTurnItem(entries: Array<AssistantEntry | ToolEntry>): TranscriptRenderItem {
+	const [entriesSignal, setEntries] = createSignal(entries);
+	return { kind: "assistant-turn", lead: entries[0] as AssistantEntry, entries: entriesSignal, setEntries };
 }
 
 export function transcriptRenderItems(
@@ -621,11 +629,21 @@ export function transcriptRenderItems(
 				index += 1;
 			}
 			const previousItem = previous[items.length];
-			items.push(
-				canReuseAssistantTurn(previousItem, turnEntries)
-					? previousItem
-					: { kind: "assistant-turn", entries: turnEntries },
-			);
+			if (previousItem?.kind === "assistant-turn" && previousItem.lead === entry) {
+				// Same turn (same leading assistant entry): keep the item — and thus
+				// the rendered wrapper DOM — stable, and only update its entry list.
+				// Appending a tool result must NOT destroy and recreate the whole
+				// assistant-turn subtree (the markdown re-render + wrapper swap is a
+				// reflow that lowers scrollTop and jolts the reading position).
+				const prevEntries = untrack(previousItem.entries);
+				const changed =
+					prevEntries.length !== turnEntries.length ||
+					turnEntries.some((turnEntry, turnIndex) => turnEntry !== prevEntries[turnIndex]);
+				if (changed) previousItem.setEntries(turnEntries);
+				items.push(previousItem);
+			} else {
+				items.push(makeAssistantTurnItem(turnEntries));
+			}
 			continue;
 		}
 		if (entry) {
@@ -750,11 +768,7 @@ export function Transcript(props: {
 					<Switch>
 						<Match when={item.kind === "assistant-turn"}>
 							<div class="assistant-turn" data-testid="assistant-turn">
-								<For
-									each={
-										(item as { kind: "assistant-turn"; entries: Array<AssistantEntry | ToolEntry> }).entries
-									}
-								>
+								<For each={(item as Extract<TranscriptRenderItem, { kind: "assistant-turn" }>).entries()}>
 									{(entry) => <EntryView entry={entry} who={who()} userLabel={userLabel()} />}
 								</For>
 							</div>

--- a/packages/dashboard/src/client/components/transcript.tsx
+++ b/packages/dashboard/src/client/components/transcript.tsx
@@ -156,6 +156,9 @@ function HighlightedPre(props: {
 			onTouchEnd={() => {
 				if (props.autoScroll) stickToBottom.handleTouchEnd();
 			}}
+			onTouchCancel={() => {
+				if (props.autoScroll) stickToBottom.handleTouchCancel();
+			}}
 			onScroll={() => {
 				if (props.autoScroll) stickToBottom.handleScroll();
 			}}

--- a/packages/dashboard/src/client/screens/session.tsx
+++ b/packages/dashboard/src/client/screens/session.tsx
@@ -22,7 +22,7 @@ import { api } from "../api.js";
 import { Modal } from "../components/common.js";
 import { Transcript } from "../components/transcript.js";
 import { isAbortError } from "../errors.js";
-import { createCoalescedBottomScroller } from "../scrolling.js";
+import { createStickToBottom } from "../scrolling.js";
 import {
 	addComposerHistoryEntry,
 	getComposerDraft,
@@ -399,13 +399,11 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	const [statsPopoverError, setStatsPopoverError] = createSignal<string>();
 
 	let chatRef: HTMLDivElement | undefined;
+	let chatInnerRef: HTMLDivElement | undefined;
 	let composerRef: HTMLTextAreaElement | undefined;
 	let genericFileInputRef: HTMLInputElement | undefined;
 	let imageFileInputRef: HTMLInputElement | undefined;
 	let statsPopoverRef: HTMLDivElement | undefined;
-	let autoScroll = true;
-	let userScrollingTranscript = false;
-	let userScrollTimer: ReturnType<typeof setTimeout> | undefined;
 	let disposed = false;
 
 	const streaming = () => session()?.streaming ?? false;
@@ -417,21 +415,7 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	// halts all of these; the dashboard stop button must reach the same states
 	// (a mid-turn refresh or a paused-on-subagents parent must not hide it).
 	const showStopControls = () => streaming() || compacting() || parentPaused() || anyLiveAgent();
-	const chatAtBottom = () => !chatRef || chatRef.scrollTop + chatRef.clientHeight >= chatRef.scrollHeight - 40;
-	const bottomScroller = createCoalescedBottomScroller({
-		element: () => chatRef,
-		shouldScroll: () => autoScroll && !userScrollingTranscript,
-	});
-	function releaseTranscriptScrollSoon(): void {
-		if (userScrollTimer) clearTimeout(userScrollTimer);
-		userScrollTimer = setTimeout(() => {
-			userScrollingTranscript = false;
-			autoScroll = chatAtBottom();
-		}, 250);
-	}
-	function scrollChatToBottomAfterLayout(): void {
-		bottomScroller.request();
-	}
+	const stickToBottom = createStickToBottom({ scroller: () => chatRef });
 
 	async function refreshRuntimeDetails(includeDailyCost = false) {
 		const [statsResult, performanceResult, branchResult] = await Promise.allSettled([
@@ -752,8 +736,7 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	}, 1000);
 	onCleanup(() => {
 		clearInterval(timer);
-		if (userScrollTimer) clearTimeout(userScrollTimer);
-		bottomScroller.cancel();
+		stickToBottom.dispose();
 		clearImageAttachments();
 	});
 
@@ -774,8 +757,12 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	createEffect(() => {
 		props.store.revisions[props.sessionKey];
 		session()?.entries.length;
-		if (autoScroll && !userScrollingTranscript) scrollChatToBottomAfterLayout();
+		stickToBottom.notifyContentChanged();
 	});
+
+	// Re-pin when transcript content grows asynchronously (e.g. late syntax
+	// highlighting of a long tool output) without a new envelope.
+	onMount(() => stickToBottom.observeContent(chatInnerRef));
 
 	let wasStreaming = false;
 	createEffect(() => {
@@ -1173,22 +1160,11 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 			<main
 				class="chat"
 				ref={chatRef}
-				onWheel={() => {
-					userScrollingTranscript = true;
-					releaseTranscriptScrollSoon();
-				}}
-				onTouchStart={() => {
-					userScrollingTranscript = true;
-				}}
-				onTouchEnd={() => {
-					userScrollingTranscript = false;
-					autoScroll = chatAtBottom();
-				}}
-				onScroll={() => {
-					autoScroll = chatAtBottom();
-				}}
+				onTouchStart={() => stickToBottom.handleTouchStart()}
+				onTouchEnd={() => stickToBottom.handleTouchEnd()}
+				onScroll={() => stickToBottom.handleScroll()}
 			>
-				<div class="chat-inner">
+				<div class="chat-inner" ref={chatInnerRef}>
 					<Show when={session()} fallback={<p class="muted">loading transcript…</p>}>
 						<For each={session()!.widgets.above}>{(line) => <div class="widget-block">{line}</div>}</For>
 						<Transcript entries={session()!.entries} resetKey={props.sessionKey} />

--- a/packages/dashboard/src/client/screens/session.tsx
+++ b/packages/dashboard/src/client/screens/session.tsx
@@ -761,8 +761,14 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	});
 
 	// Re-pin when transcript content grows asynchronously (e.g. late syntax
-	// highlighting of a long tool output) without a new envelope.
-	onMount(() => stickToBottom.observeContent(chatInnerRef));
+	// highlighting of a long tool output) without a new envelope, and when the
+	// scroll viewport itself resizes (tasks list / subagent strip toggling, the
+	// composer textarea auto-growing) — those change clientHeight with no content
+	// change and no scroll event, so nothing else would re-pin.
+	onMount(() => {
+		stickToBottom.observeContent(chatInnerRef);
+		stickToBottom.observeViewport(chatRef);
+	});
 
 	let wasStreaming = false;
 	createEffect(() => {
@@ -1162,6 +1168,7 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 				ref={chatRef}
 				onTouchStart={() => stickToBottom.handleTouchStart()}
 				onTouchEnd={() => stickToBottom.handleTouchEnd()}
+				onTouchCancel={() => stickToBottom.handleTouchCancel()}
 				onScroll={() => stickToBottom.handleScroll()}
 			>
 				<div class="chat-inner" ref={chatInnerRef}>

--- a/packages/dashboard/src/client/screens/session.tsx
+++ b/packages/dashboard/src/client/screens/session.tsx
@@ -22,7 +22,7 @@ import { api } from "../api.js";
 import { Modal } from "../components/common.js";
 import { Transcript } from "../components/transcript.js";
 import { isAbortError } from "../errors.js";
-import { createStickToBottom } from "../scrolling.js";
+import { bindStickToBottom, createStickToBottom } from "../scrolling.js";
 import {
 	addComposerHistoryEntry,
 	getComposerDraft,
@@ -768,6 +768,7 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 	onMount(() => {
 		stickToBottom.observeContent(chatInnerRef);
 		stickToBottom.observeViewport(chatRef);
+		if (chatRef) onCleanup(bindStickToBottom(stickToBottom, chatRef, { keyboard: "window" }));
 	});
 
 	let wasStreaming = false;
@@ -1163,14 +1164,7 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 				</div>
 			</Show>
 
-			<main
-				class="chat"
-				ref={chatRef}
-				onTouchStart={() => stickToBottom.handleTouchStart()}
-				onTouchEnd={() => stickToBottom.handleTouchEnd()}
-				onTouchCancel={() => stickToBottom.handleTouchCancel()}
-				onScroll={() => stickToBottom.handleScroll()}
-			>
+			<main class="chat" ref={chatRef}>
 				<div class="chat-inner" ref={chatInnerRef}>
 					<Show when={session()} fallback={<p class="muted">loading transcript…</p>}>
 						<For each={session()!.widgets.above}>{(line) => <div class="widget-block">{line}</div>}</For>

--- a/packages/dashboard/src/client/screens/subagent.tsx
+++ b/packages/dashboard/src/client/screens/subagent.tsx
@@ -40,8 +40,13 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 		props.store.revisions[props.sessionKey];
 		stickToBottom.notifyContentChanged();
 	});
-	// Re-pin when content grows asynchronously (e.g. late syntax highlighting).
-	onMount(() => stickToBottom.observeContent(chatInnerRef));
+	// Re-pin when content grows asynchronously (e.g. late syntax highlighting) and
+	// when the scroll viewport resizes (surrounding chrome changing clientHeight
+	// with no content change and no scroll event).
+	onMount(() => {
+		stickToBottom.observeContent(chatInnerRef);
+		stickToBottom.observeViewport(chatRef);
+	});
 	onCleanup(() => stickToBottom.dispose());
 
 	return (
@@ -71,6 +76,7 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 				ref={chatRef}
 				onTouchStart={() => stickToBottom.handleTouchStart()}
 				onTouchEnd={() => stickToBottom.handleTouchEnd()}
+				onTouchCancel={() => stickToBottom.handleTouchCancel()}
 				onScroll={() => stickToBottom.handleScroll()}
 			>
 				<div class="chat-inner" ref={chatInnerRef}>

--- a/packages/dashboard/src/client/screens/subagent.tsx
+++ b/packages/dashboard/src/client/screens/subagent.tsx
@@ -9,7 +9,7 @@ import { createEffect, createMemo, createSignal, type JSX, onCleanup, onMount, S
 import { StatusChip } from "../components/common.js";
 import { Transcript } from "../components/transcript.js";
 import { isAbortError } from "../errors.js";
-import { createStickToBottom } from "../scrolling.js";
+import { bindStickToBottom, createStickToBottom } from "../scrolling.js";
 import type { AppStore } from "../state/store.js";
 
 export function SubagentScreen(props: { store: AppStore; sessionKey: string; agentId: string }): JSX.Element {
@@ -46,6 +46,7 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 	onMount(() => {
 		stickToBottom.observeContent(chatInnerRef);
 		stickToBottom.observeViewport(chatRef);
+		if (chatRef) onCleanup(bindStickToBottom(stickToBottom, chatRef, { keyboard: "window" }));
 	});
 	onCleanup(() => stickToBottom.dispose());
 
@@ -71,14 +72,7 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 				</div>
 			</header>
 
-			<main
-				class="chat"
-				ref={chatRef}
-				onTouchStart={() => stickToBottom.handleTouchStart()}
-				onTouchEnd={() => stickToBottom.handleTouchEnd()}
-				onTouchCancel={() => stickToBottom.handleTouchCancel()}
-				onScroll={() => stickToBottom.handleScroll()}
-			>
+			<main class="chat" ref={chatRef}>
 				<div class="chat-inner" ref={chatInnerRef}>
 					<Show when={hydrateError()}>
 						<p class="pair-error">{hydrateError()}</p>

--- a/packages/dashboard/src/client/screens/subagent.tsx
+++ b/packages/dashboard/src/client/screens/subagent.tsx
@@ -9,7 +9,7 @@ import { createEffect, createMemo, createSignal, type JSX, onCleanup, onMount, S
 import { StatusChip } from "../components/common.js";
 import { Transcript } from "../components/transcript.js";
 import { isAbortError } from "../errors.js";
-import { createCoalescedBottomScroller } from "../scrolling.js";
+import { createStickToBottom } from "../scrolling.js";
 import type { AppStore } from "../state/store.js";
 
 export function SubagentScreen(props: { store: AppStore; sessionKey: string; agentId: string }): JSX.Element {
@@ -21,12 +21,8 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 	const [hydrateError, setHydrateError] = createSignal<string>();
 
 	let chatRef: HTMLDivElement | undefined;
-	let autoScroll = true;
-	const chatAtBottom = () => !chatRef || chatRef.scrollTop + chatRef.clientHeight >= chatRef.scrollHeight - 40;
-	const bottomScroller = createCoalescedBottomScroller({
-		element: () => chatRef,
-		shouldScroll: () => autoScroll,
-	});
+	let chatInnerRef: HTMLDivElement | undefined;
+	const stickToBottom = createStickToBottom({ scroller: () => chatRef });
 
 	onMount(() => {
 		const hydration = new AbortController();
@@ -42,9 +38,11 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 	// Stick-to-bottom autoscroll during streaming (revision bumps per envelope).
 	createEffect(() => {
 		props.store.revisions[props.sessionKey];
-		if (autoScroll) bottomScroller.request();
+		stickToBottom.notifyContentChanged();
 	});
-	onCleanup(() => bottomScroller.cancel());
+	// Re-pin when content grows asynchronously (e.g. late syntax highlighting).
+	onMount(() => stickToBottom.observeContent(chatInnerRef));
+	onCleanup(() => stickToBottom.dispose());
 
 	return (
 		<div class="session-screen">
@@ -71,11 +69,11 @@ export function SubagentScreen(props: { store: AppStore; sessionKey: string; age
 			<main
 				class="chat"
 				ref={chatRef}
-				onScroll={() => {
-					autoScroll = chatAtBottom();
-				}}
+				onTouchStart={() => stickToBottom.handleTouchStart()}
+				onTouchEnd={() => stickToBottom.handleTouchEnd()}
+				onScroll={() => stickToBottom.handleScroll()}
 			>
-				<div class="chat-inner">
+				<div class="chat-inner" ref={chatInnerRef}>
 					<Show when={hydrateError()}>
 						<p class="pair-error">{hydrateError()}</p>
 					</Show>

--- a/packages/dashboard/src/client/scrolling.ts
+++ b/packages/dashboard/src/client/scrolling.ts
@@ -89,11 +89,12 @@ export interface StickToBottomController {
 	 */
 	handleWheel: (deltaY: number, target?: EventTarget | null) => void;
 	/**
-	 * Bind to a `keydown` event — arms upward intent for scroll-up navigation keys
-	 * (ArrowUp/PageUp/Home, and Shift+Space). The caller is responsible for not
-	 * forwarding keys consumed by an editable target.
+	 * Bind to a `keydown` event — arms directional user intent for scroll
+	 * navigation keys. Pass the event target so a nested scrollable that will
+	 * consume an upward key does not arm the outer controller. The caller is
+	 * responsible for not forwarding keys consumed by an editable target.
 	 */
-	handleKeyDown: (key: string, shiftKey?: boolean) => void;
+	handleKeyDown: (key: string, shiftKey?: boolean, target?: EventTarget | null) => void;
 	/**
 	 * Bind to the scroller's `pointerdown`. Pass `onScrollbar: true` only when
 	 * the press landed on the scrollbar region — a plain click / text-selection
@@ -106,12 +107,13 @@ export interface StickToBottomController {
 	/** Bind to the scroller's `touchstart` event (suspends pinning during a drag). */
 	handleTouchStart: (clientY?: number) => void;
 	/**
-	 * Bind to the scroller's `touchmove` event with the touch's `clientY`.
-	 * Directional: a finger moving DOWN the screen (clientY increasing) drags the
-	 * content down, i.e. scrolls UP — that arms upward intent. Movement in the
-	 * other direction disarms it.
+	 * Bind to the scroller's `touchmove` event with the touch's `clientY` and
+	 * event target. Directional: a finger moving DOWN the screen (clientY
+	 * increasing) drags the content down, i.e. scrolls UP — that arms upward
+	 * intent unless a nested scroller consumes it. Movement in the other
+	 * direction arms downward intent under the same routing rule.
 	 */
-	handleTouchMove: (clientY: number) => void;
+	handleTouchMove: (clientY: number, target?: EventTarget | null) => void;
 	/** Bind to the scroller's `touchend` event (ends the drag and replays the pin). */
 	handleTouchEnd: () => void;
 	/** Bind to the scroller's `touchcancel` event (same finish path as touchend). */
@@ -131,18 +133,23 @@ export interface StickToBottomController {
 }
 
 /**
- * Walk from a wheel event's target up to (but excluding) the scroller looking
- * for a nested scrollable element that can still consume an upward wheel
- * (overflow-y auto/scroll, scrollable content, and scrollTop > 0). When such an
- * element exists the browser routes the wheel to IT, so the outer scroller will
- * not move and the wheel must not arm upward intent on the outer controller.
+ * Walk from an input event's target up to (but excluding) the scroller looking
+ * for a nested scrollable element that can consume that direction. Both wheel
+ * and keyboard events bubble from the focusable tool-output `<pre>`; when that
+ * nested element will move, the outer scroller must not inherit its intent.
  */
-function upwardWheelConsumedByNestedScroller(target: EventTarget | null | undefined, scroller: HTMLElement): boolean {
+function inputConsumedByNestedScroller(
+	target: EventTarget | null | undefined,
+	scroller: HTMLElement,
+	direction: "up" | "down",
+): boolean {
 	let node: Node | null = target instanceof Node ? target : null;
 	while (node && node !== scroller) {
-		if (node instanceof HTMLElement && node.scrollTop > 0 && node.scrollHeight > node.clientHeight + 1) {
+		if (node instanceof HTMLElement && node.scrollHeight > node.clientHeight + 1) {
+			const canConsume =
+				direction === "up" ? node.scrollTop > 0 : node.scrollTop + node.clientHeight < node.scrollHeight - 1;
 			const overflowY = typeof getComputedStyle === "function" ? getComputedStyle(node).overflowY : "";
-			if (overflowY === "auto" || overflowY === "scroll") return true;
+			if (canConsume && (overflowY === "auto" || overflowY === "scroll")) return true;
 		}
 		node = node.parentNode;
 	}
@@ -204,15 +211,21 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 	// hold or a downward drag never does.
 	let lastTouchY: number | undefined;
 	let touchUpwardIntent = false;
+	let touchDownwardIntent = false;
 	// True while a scrollbar drag is active (pointer pressed on the scrollbar
 	// region). Plain clicks / text-selection presses do NOT set this.
 	let scrollbarDragActive = false;
-	// Timestamp of the last discrete upward input (wheel-up / scroll-up key /
-	// lifted upward touch entering inertia). Sequence-scoped clearing (scrollend,
-	// downward movement) is primary; this stamp plus intentWindowMs is only the
-	// bounded fallback for platforms that never fire scrollend.
+	// Timestamps of the last discrete input. Sequence-scoped clearing (scrollend
+	// and movement in the opposite direction) is primary; these stamps plus
+	// intentWindowMs are only the bounded fallback for platforms without scrollend.
 	let lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
+	let lastDownwardIntentAt = Number.NEGATIVE_INFINITY;
 	let lastTop = 0;
+	// Keep the start of an upward sequence separate from lastTop. Precision
+	// trackpads can emit fractional (or exactly 1px) decreases; advancing lastTop
+	// after each of those jitter-sized events used to discard their cumulative
+	// deliberate movement before it could release follow.
+	let upwardSequenceBaseline = 0;
 	let contentObserver: ResizeObserver | undefined;
 	let viewportObserver: ResizeObserver | undefined;
 	let warnedMissingObserver = false;
@@ -229,7 +242,10 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 			// echo scroll event — or a concurrent content growth before that echo
 			// fires — reads as a user up-scroll and silently latches follow off.
 			const el = options.scroller();
-			if (el) lastTop = Math.max(0, el.scrollHeight - el.clientHeight);
+			if (el) {
+				lastTop = Math.max(0, el.scrollHeight - el.clientHeight);
+				upwardSequenceBaseline = lastTop;
+			}
 			return true;
 		},
 		requestAnimationFrame: options.requestAnimationFrame,
@@ -237,10 +253,37 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 	});
 
 	function armUpwardIntent(): void {
+		// A new upward input supersedes any prior downward sequence.
+		clearDownwardDiscreteIntent();
+		if (now() - lastUpwardIntentAt > intentWindowMs) {
+			// A first user input can precede this controller's first scroll event.
+			// Seed from the live position, not the default zero, so its initial tiny
+			// scroll deltas still accumulate against the true resting point.
+			const top = options.scroller()?.scrollTop ?? lastTop;
+			// Event listeners normally run before the browser applies the scroll, but
+			// programmatic callers/tests may present the moved position first. The
+			// higher known position is the only valid start for an up-scroll sequence.
+			upwardSequenceBaseline = Math.max(lastTop, top);
+		}
 		lastUpwardIntentAt = now();
 	}
-	function clearDiscreteIntent(): void {
+	function armDownwardIntent(): void {
+		// A new downward input supersedes any prior upward discrete sequence before
+		// its scroll event arrives; otherwise a reflow between opposite-direction
+		// keys/wheels could still consume the stale upward authorization.
+		clearUpwardDiscreteIntent();
+		upwardSequenceBaseline = lastTop;
+		lastDownwardIntentAt = now();
+	}
+	function clearUpwardDiscreteIntent(): void {
 		lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
+	}
+	function clearDownwardDiscreteIntent(): void {
+		lastDownwardIntentAt = Number.NEGATIVE_INFINITY;
+	}
+	function resetUpwardSequence(top: number): void {
+		clearUpwardDiscreteIntent();
+		upwardSequenceBaseline = top;
 	}
 	// A follow release is authorized only by a genuine upward user input: an
 	// upward touch drag, an active scrollbar drag, or a discrete wheel/keyboard
@@ -248,6 +291,14 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 	function upwardIntentActive(): boolean {
 		return (
 			(gestureActive && touchUpwardIntent) || scrollbarDragActive || now() - lastUpwardIntentAt <= intentWindowMs
+		);
+	}
+	// A released reader only re-engages after genuine downward input and an actual
+	// downward scroll arrival at the bottom. Geometry-only clamp events caused by
+	// content shrink must never turn follow back on.
+	function downwardIntentActive(): boolean {
+		return (
+			(gestureActive && touchDownwardIntent) || scrollbarDragActive || now() - lastDownwardIntentAt <= intentWindowMs
 		);
 	}
 
@@ -258,47 +309,66 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		const el = options.scroller();
 		if (!el) return;
 		const top = el.scrollTop;
-		if (top + el.clientHeight >= el.scrollHeight - threshold) {
-			// Reached (or programmatically pinned to) the bottom — (re-)engage follow.
+		const anyDownwardMovement = top > lastTop;
+		const atBottom = top + el.clientHeight >= el.scrollHeight - threshold;
+		if (atBottom && (following || (anyDownwardMovement && downwardIntentActive()))) {
+			// Initial/programmatic following stays engaged. Once released, however,
+			// only a real downward user return to the bottom may re-engage it. Do not
+			// consume an already-armed upward input merely because its first scroll
+			// event still lies within the bottom threshold.
 			following = true;
-		} else if (top < lastTop - 1 && upwardIntentActive()) {
-			// Moved up AND a genuine upward input authorized it — release follow.
-			// Without the intent gate a layout-induced scrollTop decrease (assistant→
-			// tool boundary reflow / DOM recreation) would masquerade as a user
-			// up-scroll and silently latch follow off. Appended content never
-			// decreases scrollTop, so it cannot reach this branch regardless.
+			if (!upwardIntentActive() || anyDownwardMovement) resetUpwardSequence(top);
+		} else if (following && top < upwardSequenceBaseline - 1 && upwardIntentActive()) {
+			// Moved up cumulatively from a stable sequence baseline AND a genuine
+			// upward input authorized it — release follow. The separate baseline lets
+			// fractional/exact-1px scroll events accumulate past the jitter threshold.
 			following = false;
-		} else if (top > lastTop + 1) {
+		} else if (anyDownwardMovement) {
 			// Downward movement ends any upward sequence: a stale wheel-up/key stamp
 			// must not survive an intervening down-scroll to authorize a later
 			// layout-induced decrease.
-			clearDiscreteIntent();
+			resetUpwardSequence(top);
+		} else if (!upwardIntentActive()) {
+			// With no live upward sequence, layout movement is merely a new resting
+			// baseline; it must not contaminate a later genuine input sequence.
+			upwardSequenceBaseline = top;
 		}
 		lastTop = top;
 	}
 	function handleScrollEnd(): void {
-		// The scroll sequence settled — discrete upward intent is consumed. This is
-		// the primary clearing mechanism; the intentWindowMs stamp is only a
-		// fallback for platforms that never deliver scrollend.
-		clearDiscreteIntent();
+		// The scroll sequence settled — discrete input is consumed. This is the
+		// primary clearing mechanism; intentWindowMs is only a fallback.
+		clearUpwardDiscreteIntent();
+		clearDownwardDiscreteIntent();
+		upwardSequenceBaseline = lastTop;
 	}
 
 	const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
 	function handleWheel(deltaY: number, target?: EventTarget | null): void {
-		if (deltaY >= 0) return;
-		// Wheel/trackpad up. This only *arms* intent; a release still requires the
-		// outer scroller's scrollTop to actually decrease. Additionally, a wheel
-		// over a nested inner scroller (e.g. a bash-output <pre>) that can still
-		// scroll up is consumed by that inner element — the outer scroller will not
-		// move — so arming here would leave a live intent stamp that an unrelated
-		// layout reflow could later hijack into a false release. Refuse to arm in
-		// that case (causality, not just coincidence-window narrowing).
 		const el = options.scroller();
-		if (el && target && upwardWheelConsumedByNestedScroller(target, el)) return;
-		armUpwardIntent();
+		if (deltaY < 0) {
+			// Wheel/trackpad up. This only *arms* intent; a release still requires the
+			// outer scroller's scrollTop to actually decrease. Additionally, a wheel
+			// over a nested inner scroller (e.g. a bash-output <pre>) that can still
+			// scroll up is consumed by that inner element — the outer scroller will not
+			// move — so arming here would leave a live intent stamp that an unrelated
+			// layout reflow could later hijack into a false release.
+			if (el && target && inputConsumedByNestedScroller(target, el, "up")) return;
+			armUpwardIntent();
+		} else if (deltaY > 0) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "down")) return;
+			armDownwardIntent();
+		}
 	}
-	function handleKeyDown(key: string, shiftKey = false): void {
-		if (SCROLL_UP_KEYS.has(key) || (shiftKey && key === " ")) armUpwardIntent();
+	function handleKeyDown(key: string, shiftKey = false, target?: EventTarget | null): void {
+		const el = options.scroller();
+		if (SCROLL_UP_KEYS.has(key) || (shiftKey && key === " ")) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "up")) return;
+			armUpwardIntent();
+		} else if (key === "ArrowDown" || key === "PageDown" || key === "End" || (!shiftKey && key === " ")) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "down")) return;
+			armDownwardIntent();
+		}
 	}
 	function handlePointerDown(onScrollbar: boolean): void {
 		// Only a scrollbar-region press can express scroll intent. A plain click or
@@ -314,14 +384,37 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		gestureActive = true;
 		lastTouchY = Number.isFinite(clientY) ? clientY : undefined;
 		touchUpwardIntent = false;
+		touchDownwardIntent = false;
 	}
 
-	function handleTouchMove(clientY: number): void {
+	function handleTouchMove(clientY: number, target?: EventTarget | null): void {
 		if (!gestureActive || !Number.isFinite(clientY)) return;
 		if (lastTouchY !== undefined) {
+			const el = options.scroller();
 			// Finger moving DOWN the screen drags content down = scrolls UP.
-			if (clientY > lastTouchY + 1) touchUpwardIntent = true;
-			else if (clientY < lastTouchY - 1) touchUpwardIntent = false;
+			if (clientY > lastTouchY + 1) {
+				if (el && target && inputConsumedByNestedScroller(target, el, "up")) {
+					touchUpwardIntent = false;
+					touchDownwardIntent = false;
+					clearUpwardDiscreteIntent();
+					clearDownwardDiscreteIntent();
+				} else {
+					touchUpwardIntent = true;
+					touchDownwardIntent = false;
+					armUpwardIntent();
+				}
+			} else if (clientY < lastTouchY - 1) {
+				if (el && target && inputConsumedByNestedScroller(target, el, "down")) {
+					touchUpwardIntent = false;
+					touchDownwardIntent = false;
+					clearUpwardDiscreteIntent();
+					clearDownwardDiscreteIntent();
+				} else {
+					touchUpwardIntent = false;
+					touchDownwardIntent = true;
+					armDownwardIntent();
+				}
+			}
 		}
 		lastTouchY = clientY;
 	}
@@ -336,8 +429,13 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 			// that survives until the sequence settles (scrollend) or the bounded
 			// fallback expires.
 			armUpwardIntent();
+		} else if (touchDownwardIntent) {
+			// Preserve a downward fling long enough for an actual arrival at bottom
+			// to re-engage an intentionally released transcript.
+			armDownwardIntent();
 		}
 		touchUpwardIntent = false;
+		touchDownwardIntent = false;
 		// Do NOT re-derive follow from absolute at-bottom geometry — that is the
 		// latch-off bug this controller exists to remove. handleScroll (which fires
 		// during the drag) already owns follow state via up-scroll detection, so if
@@ -480,7 +578,7 @@ export function bindStickToBottom(
 	on(scroller, "touchstart", (event) => controller.handleTouchStart(event.touches?.[0]?.clientY));
 	on(scroller, "touchmove", (event) => {
 		const y = event.touches?.[0]?.clientY;
-		if (y !== undefined) controller.handleTouchMove(y);
+		if (y !== undefined) controller.handleTouchMove(y, event.target);
 	});
 	on(scroller, "touchend", () => controller.handleTouchEnd());
 	on(scroller, "touchcancel", () => controller.handleTouchCancel());
@@ -494,12 +592,12 @@ export function bindStickToBottom(
 	if (options.keyboard === "window") {
 		on(window, "keydown", (event) => {
 			if (isEditableTarget(event.target)) return;
-			controller.handleKeyDown(event.key, event.shiftKey);
+			controller.handleKeyDown(event.key, event.shiftKey, event.target);
 		});
 	} else {
 		on(scroller, "keydown", (event) => {
 			if (isEditableTarget(event.target)) return;
-			controller.handleKeyDown(event.key, event.shiftKey);
+			controller.handleKeyDown(event.key, event.shiftKey, event.target);
 		});
 	}
 

--- a/packages/dashboard/src/client/scrolling.ts
+++ b/packages/dashboard/src/client/scrolling.ts
@@ -48,3 +48,134 @@ export function createCoalescedBottomScroller<T extends { scrollTop: number; scr
 
 	return { request, cancel };
 }
+
+export interface StickToBottomOptions {
+	/** The element that actually scrolls (its `scrollTop` is driven to the bottom). */
+	scroller: () => HTMLElement | undefined;
+	/** Distance from the bottom (px) still treated as "at the bottom". */
+	threshold?: number;
+	requestAnimationFrame?: typeof requestAnimationFrame;
+	cancelAnimationFrame?: typeof cancelAnimationFrame;
+	/** Injectable for tests; defaults to the global `ResizeObserver` when present. */
+	ResizeObserverImpl?: typeof ResizeObserver;
+}
+
+export interface StickToBottomController {
+	/** Request a pin to the bottom (honored only while following and no gesture is active). */
+	request: () => void;
+	/** Call whenever transcript content changes (e.g. per store revision). */
+	notifyContentChanged: () => void;
+	/** Bind to the scroller's `scroll` event. */
+	handleScroll: () => void;
+	/** Bind to the scroller's `touchstart` event (suspends pinning during a drag). */
+	handleTouchStart: () => void;
+	/** Bind to the scroller's `touchend` event (re-evaluates follow state). */
+	handleTouchEnd: () => void;
+	/** Observe a content element so async growth (e.g. late tool output) re-pins. */
+	observeContent: (element: Element | undefined) => void;
+	/** Current follow state — exposed for tests and diagnostics. */
+	isFollowing: () => boolean;
+	/** Tear down observers and pending frames. */
+	dispose: () => void;
+}
+
+/**
+ * Stick-to-bottom follow controller shared by live transcript surfaces.
+ *
+ * Follow intent is released only on a genuine user **up-scroll** (a decrease in
+ * `scrollTop`), never re-derived from absolute at-bottom geometry. This is the
+ * fix for the silent follow drop-out: appended content grows `scrollHeight`
+ * without decreasing `scrollTop`, so it can no longer latch follow off — and the
+ * delta signal is input-agnostic (wheel, touch, scrollbar, keyboard all lower
+ * `scrollTop` on an up-scroll). A `ResizeObserver` re-pins when content grows
+ * after the last envelope (e.g. throttled syntax highlighting of a long tool
+ * output), and an active touch drag suspends pinning so the view never yanks
+ * out from under the user's finger.
+ */
+export function createStickToBottom(options: StickToBottomOptions): StickToBottomController {
+	const threshold = options.threshold ?? 40;
+	const ResizeObserverImpl =
+		options.ResizeObserverImpl ?? (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+	let following = true;
+	let gestureActive = false;
+	let lastTop = 0;
+	let observer: ResizeObserver | undefined;
+
+	const scroller = createCoalescedBottomScroller({
+		element: options.scroller,
+		shouldScroll: () => {
+			if (!(following && !gestureActive)) return false;
+			// About to pin to the bottom: record the target so the next genuine
+			// user up-scroll is measured against the pinned position, not a stale
+			// pre-pin one (which would otherwise fail to release follow).
+			const el = options.scroller();
+			if (el) lastTop = el.scrollHeight;
+			return true;
+		},
+		requestAnimationFrame: options.requestAnimationFrame,
+		cancelAnimationFrame: options.cancelAnimationFrame,
+	});
+
+	const atBottom = (): boolean => {
+		const el = options.scroller();
+		return !el || el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
+	};
+
+	function request(): void {
+		scroller.request();
+	}
+
+	function notifyContentChanged(): void {
+		if (following && !gestureActive) scroller.request();
+	}
+
+	function handleScroll(): void {
+		const el = options.scroller();
+		if (!el) return;
+		const top = el.scrollTop;
+		if (top + el.clientHeight >= el.scrollHeight - threshold) {
+			// Reached (or programmatically pinned to) the bottom — (re-)engage follow.
+			following = true;
+		} else if (top < lastTop - 1) {
+			// Moved up on purpose — release follow. Content growth never decreases
+			// scrollTop, so it cannot reach this branch.
+			following = false;
+		}
+		lastTop = top;
+	}
+
+	function handleTouchStart(): void {
+		gestureActive = true;
+	}
+
+	function handleTouchEnd(): void {
+		gestureActive = false;
+		following = atBottom();
+	}
+
+	function observeContent(element: Element | undefined): void {
+		if (!element || !ResizeObserverImpl) return;
+		observer?.disconnect();
+		observer = new ResizeObserverImpl(() => {
+			if (following && !gestureActive) scroller.request();
+		});
+		observer.observe(element);
+	}
+
+	function dispose(): void {
+		observer?.disconnect();
+		observer = undefined;
+		scroller.cancel();
+	}
+
+	return {
+		request,
+		notifyContentChanged,
+		handleScroll,
+		handleTouchStart,
+		handleTouchEnd,
+		observeContent,
+		isFollowing: () => following,
+		dispose,
+	};
+}

--- a/packages/dashboard/src/client/scrolling.ts
+++ b/packages/dashboard/src/client/scrolling.ts
@@ -61,18 +61,24 @@ export interface StickToBottomOptions {
 }
 
 export interface StickToBottomController {
-	/** Request a pin to the bottom (honored only while following and no gesture is active). */
-	request: () => void;
 	/** Call whenever transcript content changes (e.g. per store revision). */
 	notifyContentChanged: () => void;
 	/** Bind to the scroller's `scroll` event. */
 	handleScroll: () => void;
 	/** Bind to the scroller's `touchstart` event (suspends pinning during a drag). */
 	handleTouchStart: () => void;
-	/** Bind to the scroller's `touchend` event (re-evaluates follow state). */
+	/** Bind to the scroller's `touchend` event (ends the drag and replays the pin). */
 	handleTouchEnd: () => void;
+	/** Bind to the scroller's `touchcancel` event (same finish path as touchend). */
+	handleTouchCancel: () => void;
 	/** Observe a content element so async growth (e.g. late tool output) re-pins. */
 	observeContent: (element: Element | undefined) => void;
+	/**
+	 * Observe the scroll *viewport* element so that surrounding-chrome resizes
+	 * (tasks list / subagent strip toggling, composer textarea auto-growing) that
+	 * change `clientHeight` — without a content change or a scroll event — re-pin.
+	 */
+	observeViewport: (element: Element | undefined) => void;
 	/** Current follow state — exposed for tests and diagnostics. */
 	isFollowing: () => boolean;
 	/** Tear down observers and pending frames. */
@@ -87,10 +93,14 @@ export interface StickToBottomController {
  * fix for the silent follow drop-out: appended content grows `scrollHeight`
  * without decreasing `scrollTop`, so it can no longer latch follow off — and the
  * delta signal is input-agnostic (wheel, touch, scrollbar, keyboard all lower
- * `scrollTop` on an up-scroll). A `ResizeObserver` re-pins when content grows
- * after the last envelope (e.g. throttled syntax highlighting of a long tool
- * output), and an active touch drag suspends pinning so the view never yanks
- * out from under the user's finger.
+ * `scrollTop` on an up-scroll). Two `ResizeObserver`s keep the view pinned when
+ * geometry changes without a scroll event: `observeContent` re-pins when the
+ * transcript *content* grows after the last envelope (e.g. throttled syntax
+ * highlighting of a long tool output), and `observeViewport` re-pins when the
+ * scroll *viewport* itself resizes (surrounding chrome such as the tasks list,
+ * subagent strip, or auto-growing composer changes `clientHeight`). An active
+ * touch drag suspends pinning so the view never yanks out from under the user's
+ * finger.
  */
 export function createStickToBottom(options: StickToBottomOptions): StickToBottomController {
 	const threshold = options.threshold ?? 40;
@@ -99,7 +109,9 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 	let following = true;
 	let gestureActive = false;
 	let lastTop = 0;
-	let observer: ResizeObserver | undefined;
+	let contentObserver: ResizeObserver | undefined;
+	let viewportObserver: ResizeObserver | undefined;
+	let warnedMissingObserver = false;
 
 	const scroller = createCoalescedBottomScroller({
 		element: options.scroller,
@@ -120,14 +132,9 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		cancelAnimationFrame: options.cancelAnimationFrame,
 	});
 
-	function request(): void {
-		scroller.request();
-	}
-
 	function notifyContentChanged(): void {
 		if (following && !gestureActive) scroller.request();
 	}
-
 	function handleScroll(): void {
 		const el = options.scroller();
 		if (!el) return;
@@ -147,7 +154,7 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		gestureActive = true;
 	}
 
-	function handleTouchEnd(): void {
+	function finishGesture(): void {
 		gestureActive = false;
 		// Do NOT re-derive follow from absolute at-bottom geometry — that is the
 		// latch-off bug this controller exists to remove. handleScroll (which fires
@@ -157,37 +164,67 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		if (following) scroller.request();
 	}
 
-	function observeContent(element: Element | undefined): void {
-		if (!element) return;
+	function handleTouchEnd(): void {
+		finishGesture();
+	}
+
+	function handleTouchCancel(): void {
+		// touchcancel (system gesture takeover, too many touch points, etc.) fires
+		// *instead of* touchend. Without clearing gestureActive here it would stay
+		// true forever, silently suppressing every pin until the next complete touch
+		// sequence — a real mobile follow drop-out. Same finish path as touchend.
+		finishGesture();
+	}
+
+	function makeObserver(element: Element): ResizeObserver | undefined {
 		if (!ResizeObserverImpl) {
-			// The async-growth re-pin is a core part of the follow fix; if the
+			// The observer-driven re-pin is a core part of the follow fix; if the
 			// platform lacks ResizeObserver we lose it silently. Surface that rather
 			// than degrading quietly (repo convention: loud failure over silent
 			// fallback). ResizeObserver is baseline in all target browsers, so this
-			// should never fire in practice.
-			console.warn(
-				"[dashboard] ResizeObserver unavailable — stick-to-bottom async re-pin disabled; the transcript may lag behind live output until the next envelope arrives.",
-			);
-			return;
+			// should never fire in practice. Warn once per controller so a screen
+			// with both content and viewport observers doesn't double-log.
+			if (!warnedMissingObserver) {
+				warnedMissingObserver = true;
+				console.warn(
+					"[dashboard] ResizeObserver unavailable — stick-to-bottom async re-pin disabled; the transcript may lag behind live output until the next envelope arrives.",
+				);
+			}
+			return undefined;
 		}
-		observer?.disconnect();
-		observer = new ResizeObserverImpl(() => notifyContentChanged());
-		observer.observe(element);
+		const created = new ResizeObserverImpl(() => notifyContentChanged());
+		created.observe(element);
+		return created;
+	}
+
+	function observeContent(element: Element | undefined): void {
+		if (!element) return;
+		contentObserver?.disconnect();
+		contentObserver = makeObserver(element);
+	}
+
+	function observeViewport(element: Element | undefined): void {
+		if (!element) return;
+		viewportObserver?.disconnect();
+		viewportObserver = makeObserver(element);
 	}
 
 	function dispose(): void {
-		observer?.disconnect();
-		observer = undefined;
+		contentObserver?.disconnect();
+		viewportObserver?.disconnect();
+		contentObserver = undefined;
+		viewportObserver = undefined;
 		scroller.cancel();
 	}
 
 	return {
-		request,
 		notifyContentChanged,
 		handleScroll,
 		handleTouchStart,
 		handleTouchEnd,
+		handleTouchCancel,
 		observeContent,
+		observeViewport,
 		isFollowing: () => following,
 		dispose,
 	};

--- a/packages/dashboard/src/client/scrolling.ts
+++ b/packages/dashboard/src/client/scrolling.ts
@@ -58,6 +58,17 @@ export interface StickToBottomOptions {
 	cancelAnimationFrame?: typeof cancelAnimationFrame;
 	/** Injectable for tests; defaults to the global `ResizeObserver` when present. */
 	ResizeObserverImpl?: typeof ResizeObserver;
+	/** Injectable clock (ms) for the upward-intent fallback window; defaults to `Date.now`. */
+	now?: () => number;
+	/**
+	 * Bounded FALLBACK for how long (ms) a discrete upward input (wheel-up /
+	 * scroll-up key / lifted upward touch) can still authorize a follow release
+	 * when the platform never delivers a `scrollend`. The primary clearing
+	 * mechanism is sequence-scoped: `handleScrollEnd` (the scroll sequence
+	 * settled) and any downward movement clear intent immediately. Defaults to
+	 * 400ms.
+	 */
+	intentWindowMs?: number;
 }
 
 export interface StickToBottomController {
@@ -65,8 +76,42 @@ export interface StickToBottomController {
 	notifyContentChanged: () => void;
 	/** Bind to the scroller's `scroll` event. */
 	handleScroll: () => void;
+	/**
+	 * Bind to the scroller's `scrollend` event — the scroll sequence settled, so
+	 * any discrete upward intent is consumed and cleared.
+	 */
+	handleScrollEnd: () => void;
+	/**
+	 * Bind to the scroller's `wheel` event — arms upward intent when scrolling
+	 * up. Pass the event target: a wheel over a nested inner scroller (e.g. a
+	 * bash-output `<pre>` that can still scroll up) is consumed by that inner
+	 * element and must NOT arm intent on this controller.
+	 */
+	handleWheel: (deltaY: number, target?: EventTarget | null) => void;
+	/**
+	 * Bind to a `keydown` event — arms upward intent for scroll-up navigation keys
+	 * (ArrowUp/PageUp/Home, and Shift+Space). The caller is responsible for not
+	 * forwarding keys consumed by an editable target.
+	 */
+	handleKeyDown: (key: string, shiftKey?: boolean) => void;
+	/**
+	 * Bind to the scroller's `pointerdown`. Pass `onScrollbar: true` only when
+	 * the press landed on the scrollbar region — a plain click / text-selection
+	 * press must NOT arm upward intent (a concurrent layout reflow would
+	 * otherwise be misread as a scrollbar up-drag).
+	 */
+	handlePointerDown: (onScrollbar: boolean) => void;
+	/** Bind to `pointerup`/`pointercancel` (window-level so state cannot stick). */
+	handlePointerUp: () => void;
 	/** Bind to the scroller's `touchstart` event (suspends pinning during a drag). */
-	handleTouchStart: () => void;
+	handleTouchStart: (clientY?: number) => void;
+	/**
+	 * Bind to the scroller's `touchmove` event with the touch's `clientY`.
+	 * Directional: a finger moving DOWN the screen (clientY increasing) drags the
+	 * content down, i.e. scrolls UP — that arms upward intent. Movement in the
+	 * other direction disarms it.
+	 */
+	handleTouchMove: (clientY: number) => void;
 	/** Bind to the scroller's `touchend` event (ends the drag and replays the pin). */
 	handleTouchEnd: () => void;
 	/** Bind to the scroller's `touchcancel` event (same finish path as touchend). */
@@ -86,28 +131,87 @@ export interface StickToBottomController {
 }
 
 /**
+ * Walk from a wheel event's target up to (but excluding) the scroller looking
+ * for a nested scrollable element that can still consume an upward wheel
+ * (overflow-y auto/scroll, scrollable content, and scrollTop > 0). When such an
+ * element exists the browser routes the wheel to IT, so the outer scroller will
+ * not move and the wheel must not arm upward intent on the outer controller.
+ */
+function upwardWheelConsumedByNestedScroller(target: EventTarget | null | undefined, scroller: HTMLElement): boolean {
+	let node: Node | null = target instanceof Node ? target : null;
+	while (node && node !== scroller) {
+		if (node instanceof HTMLElement && node.scrollTop > 0 && node.scrollHeight > node.clientHeight + 1) {
+			const overflowY = typeof getComputedStyle === "function" ? getComputedStyle(node).overflowY : "";
+			if (overflowY === "auto" || overflowY === "scroll") return true;
+		}
+		node = node.parentNode;
+	}
+	return false;
+}
+
+/**
  * Stick-to-bottom follow controller shared by live transcript surfaces.
  *
- * Follow intent is released only on a genuine user **up-scroll** (a decrease in
- * `scrollTop`), never re-derived from absolute at-bottom geometry. This is the
- * fix for the silent follow drop-out: appended content grows `scrollHeight`
- * without decreasing `scrollTop`, so it can no longer latch follow off — and the
- * delta signal is input-agnostic (wheel, touch, scrollbar, keyboard all lower
- * `scrollTop` on an up-scroll). Two `ResizeObserver`s keep the view pinned when
- * geometry changes without a scroll event: `observeContent` re-pins when the
- * transcript *content* grows after the last envelope (e.g. throttled syntax
- * highlighting of a long tool output), and `observeViewport` re-pins when the
- * scroll *viewport* itself resizes (surrounding chrome such as the tasks list,
- * subagent strip, or auto-growing composer changes `clientHeight`). An active
- * touch drag suspends pinning so the view never yanks out from under the user's
- * finger.
+ * Follow intent is released only on a genuine user **up-scroll**, and never
+ * re-derived from absolute at-bottom geometry. A release requires BOTH signals:
+ *
+ *  1. the scroller's `scrollTop` actually decreased (`top < lastTop - 1`), and
+ *  2. a genuine upward user input authorized it — an upward touch drag, an
+ *     active scrollbar drag, or a recent wheel-up / scroll-up key press whose
+ *     scroll sequence has not yet settled.
+ *
+ * Requirement 1 alone is not enough: at an assistant→tool boundary the outer
+ * transcript reflows (the streamed message is replaced by its authoritative
+ * full-markdown render and a tool card is appended below), and the browser can
+ * *lower* `scrollTop` during that relayout with no user input. Treating that
+ * layout-induced decrease as a user up-scroll is exactly the silent follow
+ * drop-out this controller exists to remove.
+ *
+ * Requirement 2 is **sequence-scoped**, not merely time-windowed:
+ *  - a wheel-up arms intent only when the outer scroller (not a nested inner
+ *    scroller that can still scroll up) will consume it;
+ *  - intent is cleared as soon as the scroll sequence settles (`scrollend`) or
+ *    any downward movement occurs;
+ *  - a bounded time window remains only as a fallback for platforms without
+ *    `scrollend`.
+ *  - touch is directional: intent arms only while the finger movement would
+ *    lower `scrollTop`, and survives past `touchend` through the inertial
+ *    scroll until the sequence settles;
+ *  - a pointer press arms only when it lands on the scrollbar region — plain
+ *    clicks and text-selection drags never authorize a release.
+ *
+ * Appended content grows `scrollHeight` without decreasing `scrollTop`, so it
+ * can never reach the release branch either way. Two `ResizeObserver`s keep the
+ * view pinned when geometry changes without a scroll event: `observeContent`
+ * re-pins when the transcript *content* grows after the last envelope (e.g.
+ * throttled syntax highlighting of a long tool output), and `observeViewport`
+ * re-pins when the scroll *viewport* itself resizes (surrounding chrome such as
+ * the tasks list, subagent strip, or auto-growing composer changes
+ * `clientHeight`). An active touch drag suspends pinning so the view never
+ * yanks out from under the user's finger.
  */
 export function createStickToBottom(options: StickToBottomOptions): StickToBottomController {
 	const threshold = options.threshold ?? 40;
+	const now = options.now ?? (() => Date.now());
+	const intentWindowMs = options.intentWindowMs ?? 400;
 	const ResizeObserverImpl =
 		options.ResizeObserverImpl ?? (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
 	let following = true;
 	let gestureActive = false;
+	// Directional touch state: the finger's last known clientY, and whether the
+	// most recent movement expressed an up-scroll (finger moving DOWN the screen
+	// lowers scrollTop). Only an upward touch authorizes a release; a stationary
+	// hold or a downward drag never does.
+	let lastTouchY: number | undefined;
+	let touchUpwardIntent = false;
+	// True while a scrollbar drag is active (pointer pressed on the scrollbar
+	// region). Plain clicks / text-selection presses do NOT set this.
+	let scrollbarDragActive = false;
+	// Timestamp of the last discrete upward input (wheel-up / scroll-up key /
+	// lifted upward touch entering inertia). Sequence-scoped clearing (scrollend,
+	// downward movement) is primary; this stamp plus intentWindowMs is only the
+	// bounded fallback for platforms that never fire scrollend.
+	let lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
 	let lastTop = 0;
 	let contentObserver: ResizeObserver | undefined;
 	let viewportObserver: ResizeObserver | undefined;
@@ -132,6 +236,21 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		cancelAnimationFrame: options.cancelAnimationFrame,
 	});
 
+	function armUpwardIntent(): void {
+		lastUpwardIntentAt = now();
+	}
+	function clearDiscreteIntent(): void {
+		lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
+	}
+	// A follow release is authorized only by a genuine upward user input: an
+	// upward touch drag, an active scrollbar drag, or a discrete wheel/keyboard
+	// up-scroll whose scroll sequence has not yet settled.
+	function upwardIntentActive(): boolean {
+		return (
+			(gestureActive && touchUpwardIntent) || scrollbarDragActive || now() - lastUpwardIntentAt <= intentWindowMs
+		);
+	}
+
 	function notifyContentChanged(): void {
 		if (following && !gestureActive) scroller.request();
 	}
@@ -142,20 +261,83 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		if (top + el.clientHeight >= el.scrollHeight - threshold) {
 			// Reached (or programmatically pinned to) the bottom — (re-)engage follow.
 			following = true;
-		} else if (top < lastTop - 1) {
-			// Moved up on purpose — release follow. Content growth never decreases
-			// scrollTop, so it cannot reach this branch.
+		} else if (top < lastTop - 1 && upwardIntentActive()) {
+			// Moved up AND a genuine upward input authorized it — release follow.
+			// Without the intent gate a layout-induced scrollTop decrease (assistant→
+			// tool boundary reflow / DOM recreation) would masquerade as a user
+			// up-scroll and silently latch follow off. Appended content never
+			// decreases scrollTop, so it cannot reach this branch regardless.
 			following = false;
+		} else if (top > lastTop + 1) {
+			// Downward movement ends any upward sequence: a stale wheel-up/key stamp
+			// must not survive an intervening down-scroll to authorize a later
+			// layout-induced decrease.
+			clearDiscreteIntent();
 		}
 		lastTop = top;
 	}
+	function handleScrollEnd(): void {
+		// The scroll sequence settled — discrete upward intent is consumed. This is
+		// the primary clearing mechanism; the intentWindowMs stamp is only a
+		// fallback for platforms that never deliver scrollend.
+		clearDiscreteIntent();
+	}
 
-	function handleTouchStart(): void {
+	const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+	function handleWheel(deltaY: number, target?: EventTarget | null): void {
+		if (deltaY >= 0) return;
+		// Wheel/trackpad up. This only *arms* intent; a release still requires the
+		// outer scroller's scrollTop to actually decrease. Additionally, a wheel
+		// over a nested inner scroller (e.g. a bash-output <pre>) that can still
+		// scroll up is consumed by that inner element — the outer scroller will not
+		// move — so arming here would leave a live intent stamp that an unrelated
+		// layout reflow could later hijack into a false release. Refuse to arm in
+		// that case (causality, not just coincidence-window narrowing).
+		const el = options.scroller();
+		if (el && target && upwardWheelConsumedByNestedScroller(target, el)) return;
+		armUpwardIntent();
+	}
+	function handleKeyDown(key: string, shiftKey = false): void {
+		if (SCROLL_UP_KEYS.has(key) || (shiftKey && key === " ")) armUpwardIntent();
+	}
+	function handlePointerDown(onScrollbar: boolean): void {
+		// Only a scrollbar-region press can express scroll intent. A plain click or
+		// text-selection press must not — otherwise a layout-induced scrollTop
+		// decrease while the pointer happens to be held would falsely release.
+		if (onScrollbar) scrollbarDragActive = true;
+	}
+	function handlePointerUp(): void {
+		scrollbarDragActive = false;
+	}
+
+	function handleTouchStart(clientY?: number): void {
 		gestureActive = true;
+		lastTouchY = Number.isFinite(clientY) ? clientY : undefined;
+		touchUpwardIntent = false;
+	}
+
+	function handleTouchMove(clientY: number): void {
+		if (!gestureActive || !Number.isFinite(clientY)) return;
+		if (lastTouchY !== undefined) {
+			// Finger moving DOWN the screen drags content down = scrolls UP.
+			if (clientY > lastTouchY + 1) touchUpwardIntent = true;
+			else if (clientY < lastTouchY - 1) touchUpwardIntent = false;
+		}
+		lastTouchY = clientY;
 	}
 
 	function finishGesture(): void {
 		gestureActive = false;
+		lastTouchY = undefined;
+		if (touchUpwardIntent) {
+			// The finger lifted mid-up-scroll: inertial scrolling continues AFTER
+			// touchend, and its first significant decrease must still be able to
+			// release. Convert the directional touch intent into a discrete stamp
+			// that survives until the sequence settles (scrollend) or the bounded
+			// fallback expires.
+			armUpwardIntent();
+		}
+		touchUpwardIntent = false;
 		// Do NOT re-derive follow from absolute at-bottom geometry — that is the
 		// latch-off bug this controller exists to remove. handleScroll (which fires
 		// during the drag) already owns follow state via up-scroll detection, so if
@@ -220,12 +402,108 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 	return {
 		notifyContentChanged,
 		handleScroll,
+		handleScrollEnd,
+		handleWheel,
+		handleKeyDown,
+		handlePointerDown,
+		handlePointerUp,
 		handleTouchStart,
+		handleTouchMove,
 		handleTouchEnd,
 		handleTouchCancel,
 		observeContent,
 		observeViewport,
 		isFollowing: () => following,
 		dispose,
+	};
+}
+
+export interface BindStickToBottomOptions {
+	/**
+	 * Live gate — when it returns false the events are ignored (e.g. a tool
+	 * output pre whose auto-scroll preference is off).
+	 */
+	enabled?: () => boolean;
+	/**
+	 * Where to listen for scroll-up navigation keys:
+	 *  - "window": a window-level listener with editable-target exclusion — used
+	 *    by full-screen transcripts where the browser may scroll the transcript
+	 *    from a key press that targets `body` or unrelated chrome.
+	 *  - "element": listen on the scroller itself — used by nested scrollers
+	 *    (focusable tool-output pres).
+	 */
+	keyboard: "window" | "element";
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+	return target instanceof Element && target.closest("input, textarea, select, [contenteditable]") !== null;
+}
+
+/**
+ * Bind a StickToBottomController to a live DOM scroller. This is THE wiring —
+ * shared by the session screen, the subagent screen, the tool-output pre, and
+ * the real-browser regression harness, so the exact listeners the app installs
+ * are the ones the browser test exercises.
+ *
+ * Wiring notes:
+ *  - `pointerdown` detects scrollbar presses via `offsetX >= clientWidth`
+ *    (the vertical scrollbar renders outside the client box); `pointerup` /
+ *    `pointercancel` are window-level so a press-in/release-out drag can never
+ *    leave the drag state stuck on.
+ *  - keyboard uses editable-target exclusion so keys consumed by the composer
+ *    (or any input) never arm scroll intent.
+ *
+ * Returns a cleanup function that removes every listener.
+ */
+export function bindStickToBottom(
+	controller: StickToBottomController,
+	scroller: HTMLElement,
+	options: BindStickToBottomOptions,
+): () => void {
+	const enabled = options.enabled ?? (() => true);
+	const cleanups: Array<() => void> = [];
+	function on<K extends keyof HTMLElementEventMap>(
+		target: HTMLElement | Window,
+		type: K,
+		listener: (event: HTMLElementEventMap[K]) => void,
+	): void {
+		const wrapped = ((event: Event) => {
+			if (enabled()) listener(event as HTMLElementEventMap[K]);
+		}) as EventListener;
+		target.addEventListener(type, wrapped, { passive: true });
+		cleanups.push(() => target.removeEventListener(type, wrapped));
+	}
+
+	on(scroller, "scroll", () => controller.handleScroll());
+	on(scroller, "scrollend", () => controller.handleScrollEnd());
+	on(scroller, "wheel", (event) => controller.handleWheel(event.deltaY, event.target));
+	on(scroller, "touchstart", (event) => controller.handleTouchStart(event.touches?.[0]?.clientY));
+	on(scroller, "touchmove", (event) => {
+		const y = event.touches?.[0]?.clientY;
+		if (y !== undefined) controller.handleTouchMove(y);
+	});
+	on(scroller, "touchend", () => controller.handleTouchEnd());
+	on(scroller, "touchcancel", () => controller.handleTouchCancel());
+	on(scroller, "pointerdown", (event) => {
+		controller.handlePointerDown(event.pointerType === "mouse" && event.offsetX >= scroller.clientWidth);
+	});
+	// Window-level: a scrollbar drag released outside the element (or canceled by
+	// the system) must still end the drag state.
+	on(window, "pointerup", () => controller.handlePointerUp());
+	on(window, "pointercancel", () => controller.handlePointerUp());
+	if (options.keyboard === "window") {
+		on(window, "keydown", (event) => {
+			if (isEditableTarget(event.target)) return;
+			controller.handleKeyDown(event.key, event.shiftKey);
+		});
+	} else {
+		on(scroller, "keydown", (event) => {
+			if (isEditableTarget(event.target)) return;
+			controller.handleKeyDown(event.key, event.shiftKey);
+		});
+	}
+
+	return () => {
+		for (const cleanup of cleanups) cleanup();
 	};
 }

--- a/packages/dashboard/src/client/scrolling.ts
+++ b/packages/dashboard/src/client/scrolling.ts
@@ -105,21 +105,20 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 		element: options.scroller,
 		shouldScroll: () => {
 			if (!(following && !gestureActive)) return false;
-			// About to pin to the bottom: record the target so the next genuine
-			// user up-scroll is measured against the pinned position, not a stale
-			// pre-pin one (which would otherwise fail to release follow).
+			// About to pin to the bottom: record the *resting* scrollTop the browser
+			// will settle at after `scrollTop = scrollHeight` (it clamps to
+			// `scrollHeight - clientHeight`), NOT the raw scrollHeight. `lastTop` is
+			// compared against real `scrollTop` values in handleScroll; seeding it
+			// with a height leaves it ~clientHeight too high, so the pin's own async
+			// echo scroll event — or a concurrent content growth before that echo
+			// fires — reads as a user up-scroll and silently latches follow off.
 			const el = options.scroller();
-			if (el) lastTop = el.scrollHeight;
+			if (el) lastTop = Math.max(0, el.scrollHeight - el.clientHeight);
 			return true;
 		},
 		requestAnimationFrame: options.requestAnimationFrame,
 		cancelAnimationFrame: options.cancelAnimationFrame,
 	});
-
-	const atBottom = (): boolean => {
-		const el = options.scroller();
-		return !el || el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
-	};
 
 	function request(): void {
 		scroller.request();
@@ -150,15 +149,29 @@ export function createStickToBottom(options: StickToBottomOptions): StickToBotto
 
 	function handleTouchEnd(): void {
 		gestureActive = false;
-		following = atBottom();
+		// Do NOT re-derive follow from absolute at-bottom geometry — that is the
+		// latch-off bug this controller exists to remove. handleScroll (which fires
+		// during the drag) already owns follow state via up-scroll detection, so if
+		// the user did not scroll up, `following` is still true even when content
+		// grew during the gesture. Just replay the pin that gestureActive suppressed.
+		if (following) scroller.request();
 	}
 
 	function observeContent(element: Element | undefined): void {
-		if (!element || !ResizeObserverImpl) return;
+		if (!element) return;
+		if (!ResizeObserverImpl) {
+			// The async-growth re-pin is a core part of the follow fix; if the
+			// platform lacks ResizeObserver we lose it silently. Surface that rather
+			// than degrading quietly (repo convention: loud failure over silent
+			// fallback). ResizeObserver is baseline in all target browsers, so this
+			// should never fire in practice.
+			console.warn(
+				"[dashboard] ResizeObserver unavailable — stick-to-bottom async re-pin disabled; the transcript may lag behind live output until the next envelope arrives.",
+			);
+			return;
+		}
 		observer?.disconnect();
-		observer = new ResizeObserverImpl(() => {
-			if (following && !gestureActive) scroller.request();
-		});
+		observer = new ResizeObserverImpl(() => notifyContentChanged());
 		observer.observe(element);
 	}
 

--- a/packages/dashboard/test/client/pwa.test.tsx
+++ b/packages/dashboard/test/client/pwa.test.tsx
@@ -8,6 +8,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// jsdom lacks ResizeObserver; real browsers always have it. Install a no-op so
+// the stick-to-bottom controller (mounted via <App>'s SessionScreen) attaches
+// quietly instead of logging its (correct) "ResizeObserver unavailable" warning.
+if (!(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver) {
+	class NoopResizeObserver {
+		observe(): void {}
+		unobserve(): void {}
+		disconnect(): void {}
+	}
+	(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+		NoopResizeObserver as unknown as typeof ResizeObserver;
+}
+
 // Mock the API + SSE so <App> mounts without a server. Mirrors screens.test.tsx.
 vi.mock("../../src/client/api.js", () => ({
 	api: {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -663,16 +663,19 @@ describe("app store integration", () => {
 		expect(chat.scrollTop).toBe(300);
 	});
 
-	it("re-pins the transcript when observed content grows without a new envelope (ResizeObserver path)", async () => {
-		// Wire a controllable global ResizeObserver so the controller's
-		// observeContent() actually attaches (jsdom lacks ResizeObserver, which
-		// would otherwise silently disable the async-growth re-pin).
-		let roCallback: ResizeObserverCallback | undefined;
+	it("re-pins the transcript when observed content or viewport changes without a new envelope", async () => {
+		// Record each registration: the screen must attach two independent
+		// observers, one to .chat-inner content and one to the .chat viewport.
+		const observers: Array<{ callback: ResizeObserverCallback; observed?: Element }> = [];
 		class FakeRO {
-			constructor(cb: ResizeObserverCallback) {
-				roCallback = cb;
+			private readonly registration: { callback: ResizeObserverCallback; observed?: Element };
+			constructor(callback: ResizeObserverCallback) {
+				this.registration = { callback };
+				observers.push(this.registration);
 			}
-			observe(): void {}
+			observe(element: Element): void {
+				this.registration.observed = element;
+			}
 			unobserve(): void {}
 			disconnect(): void {}
 		}
@@ -692,9 +695,22 @@ describe("app store integration", () => {
 			captured.onEnvelope({ seq: 1, key: "k-ro", event: { type: "agent_start" } });
 			await new Promise((resolve) => setTimeout(resolve, 0));
 			const chat = el.querySelector(".chat") as HTMLElement;
+			const chatInner = el.querySelector(".chat-inner") as HTMLElement;
 			let scrollHeight = 500;
-			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+			let clientHeight = 100;
+			let scrollTop = 0;
+			let scrollWrites = 0;
+			Object.defineProperty(chat, "clientHeight", { configurable: true, get: () => clientHeight });
 			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+			Object.defineProperty(chat, "scrollTop", {
+				configurable: true,
+				get: () => scrollTop,
+				set: (value: number) => {
+					scrollTop = value;
+					scrollWrites++;
+				},
+			});
+			expect(observers.map((observer) => observer.observed)).toEqual([chatInner, chat]);
 
 			// Flush any pending mount/revision pin FIRST, so the assertion below can
 			// only be satisfied by the ResizeObserver-driven re-pin — not by a
@@ -705,14 +721,27 @@ describe("app store integration", () => {
 			// Parked at the bottom.
 			chat.scrollTop = 400;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+			scrollWrites = 0;
 
 			// Content grows asynchronously (e.g. late syntax highlighting) with NO
-			// new envelope — only the ResizeObserver fires. The transcript must
+			// new envelope — only the content observer fires. The transcript must
 			// re-pin to the new bottom.
-			expect(roCallback).toBeDefined();
+			const contentObserver = observers.find((observer) => observer.observed === chatInner);
+			expect(contentObserver).toBeDefined();
 			scrollHeight = 1000;
-			roCallback?.([], {} as ResizeObserver);
+			contentObserver?.callback([], {} as ResizeObserver);
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(chat.scrollTop).toBe(1000);
+
+			// A dock/composer resize changes only the viewport geometry. Its separate
+			// observer must independently request the pin.
+			const viewportObserver = observers.find((observer) => observer.observed === chat);
+			expect(viewportObserver).toBeDefined();
+			scrollWrites = 0;
+			clientHeight = 200;
+			viewportObserver?.callback([], {} as ResizeObserver);
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(scrollWrites).toBe(1);
 			expect(chat.scrollTop).toBe(1000);
 		} finally {
 			(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = priorRO;
@@ -2892,13 +2921,17 @@ describe("dashboard client regressions", () => {
 		expect(el.textContent).toContain("No session log found for this agent");
 	});
 
-	it("subagent transcript re-pins on observed content growth and respects a user up-scroll", async () => {
-		let roCallback: ResizeObserverCallback | undefined;
+	it("subagent transcript independently observes content and viewport geometry", async () => {
+		const observers: Array<{ callback: ResizeObserverCallback; observed?: Element }> = [];
 		class FakeRO {
-			constructor(cb: ResizeObserverCallback) {
-				roCallback = cb;
+			private readonly registration: { callback: ResizeObserverCallback; observed?: Element };
+			constructor(callback: ResizeObserverCallback) {
+				this.registration = { callback };
+				observers.push(this.registration);
 			}
-			observe(): void {}
+			observe(element: Element): void {
+				this.registration.observed = element;
+			}
 			unobserve(): void {}
 			disconnect(): void {}
 		}
@@ -2920,9 +2953,22 @@ describe("dashboard client regressions", () => {
 			const el = mount(() => <SubagentScreen store={store} sessionKey="k-ro-sub" agentId="bg-ro" />);
 			await new Promise((resolve) => setTimeout(resolve, 10));
 			const chat = el.querySelector(".chat") as HTMLElement;
+			const chatInner = el.querySelector(".chat-inner") as HTMLElement;
 			let scrollHeight = 500;
-			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+			let clientHeight = 100;
+			let scrollTop = 0;
+			let scrollWrites = 0;
+			Object.defineProperty(chat, "clientHeight", { configurable: true, get: () => clientHeight });
 			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+			Object.defineProperty(chat, "scrollTop", {
+				configurable: true,
+				get: () => scrollTop,
+				set: (value: number) => {
+					scrollTop = value;
+					scrollWrites++;
+				},
+			});
+			expect(observers.map((observer) => observer.observed)).toEqual([chatInner, chat]);
 
 			// Parked at the bottom; async growth with no revision must re-pin. Flush
 			// any pending mount pin first so only the observer-driven re-pin can
@@ -2930,11 +2976,22 @@ describe("dashboard client regressions", () => {
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 			chat.scrollTop = 400;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
-			expect(roCallback).toBeDefined();
+			scrollWrites = 0;
+
+			const contentObserver = observers.find((observer) => observer.observed === chatInner);
+			expect(contentObserver).toBeDefined();
 			scrollHeight = 1000;
-			roCallback?.([], {} as ResizeObserver);
+			contentObserver?.callback([], {} as ResizeObserver);
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 			expect(chat.scrollTop).toBe(1000);
+
+			const viewportObserver = observers.find((observer) => observer.observed === chat);
+			expect(viewportObserver).toBeDefined();
+			scrollWrites = 0;
+			clientHeight = 200;
+			viewportObserver?.callback([], {} as ResizeObserver);
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(scrollWrites).toBe(1);
 
 			// A deliberate up-scroll (wheel-up) suspends follow; later observed growth
 			// must not yank the view back down.
@@ -2942,7 +2999,7 @@ describe("dashboard client regressions", () => {
 			chat.scrollTop = 200;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
 			scrollHeight = 1600;
-			roCallback?.([], {} as ResizeObserver);
+			contentObserver?.callback([], {} as ResizeObserver);
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 			expect(chat.scrollTop).toBe(200);
 		} finally {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -133,7 +133,12 @@ vi.mock("../../src/client/api.js", () => ({
 }));
 
 import { api, connectEvents, type EventStreamHandlers } from "../../src/client/api.js";
-import { TRANSCRIPT_WINDOW_SIZE, Transcript, transcriptRenderItems } from "../../src/client/components/transcript.js";
+import {
+	TRANSCRIPT_WINDOW_SIZE,
+	Transcript,
+	type TranscriptRenderItem,
+	transcriptRenderItems,
+} from "../../src/client/components/transcript.js";
 import { FilesScreen } from "../../src/client/screens/files.js";
 import { FleetScreen, fleetGroupKey } from "../../src/client/screens/fleet.js";
 import { PairingScreen } from "../../src/client/screens/pairing.js";
@@ -511,7 +516,12 @@ describe("app store integration", () => {
 		chat.scrollTop = 400;
 		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
 
-		chat.dispatchEvent(new Event("touchstart", { bubbles: true }));
+		const touchEvent = (type: string, clientY: number) => {
+			const event = new Event(type, { bubbles: true }) as Event & { touches: Array<{ clientY: number }> };
+			event.touches = [{ clientY }];
+			return event;
+		};
+		chat.dispatchEvent(touchEvent("touchstart", 300));
 		scrollHeight = 900;
 		captured.onEnvelope({
 			seq: 2,
@@ -521,6 +531,8 @@ describe("app store integration", () => {
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(chat.scrollTop).toBe(400);
 
+		// The finger drags DOWN the screen (clientY increases) — an up-scroll.
+		chat.dispatchEvent(touchEvent("touchmove", 360));
 		chat.scrollTop = 200;
 		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
 		chat.dispatchEvent(new Event("touchend", { bubbles: true }));
@@ -570,6 +582,85 @@ describe("app store integration", () => {
 		});
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(chat.scrollTop).toBe(1000);
+	});
+
+	it("keeps following when an assistant→tool reflow lowers scrollTop with no user input", async () => {
+		// The residual drop-out: at a tool boundary the transcript reflows (streamed
+		// message replaced by full markdown, assistant-turn DOM recreated) and the
+		// browser LOWERS scrollTop while a tool card is appended below. No wheel /
+		// touch / pointer / key input precedes the resulting scroll event, so it must
+		// not be misread as a user up-scroll.
+		let captured: EventStreamHandlers | undefined;
+		vi.mocked(connectEvents).mockImplementation((handlers) => {
+			captured = handlers;
+			return () => {};
+		});
+		const store = makeStore();
+		await store.start();
+		if (!captured) throw new Error("connectEvents was not called");
+		const el = mount(() => <SessionScreen store={store} sessionKey="k-reflow" />);
+		captured.onEnvelope({ seq: 1, key: "k-reflow", event: { type: "agent_start" } });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const chat = el.querySelector(".chat") as HTMLElement;
+		let scrollHeight = 900;
+		Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+		Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+
+		// Parked at the resting bottom.
+		chat.scrollTop = 800;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// Reflow: assistant completion lowers scrollTop by 300, a tool card grows the
+		// content far below, and the browser emits a scroll event — WITHOUT any input.
+		scrollHeight = 1500;
+		chat.scrollTop = 500;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// The next envelope must still pin to the new bottom (follow survived).
+		scrollHeight = 1600;
+		captured.onEnvelope({
+			seq: 2,
+			key: "k-reflow",
+			event: { type: "tool_execution_start", toolCallId: "t1", toolName: "bash", args: { command: "yes" } },
+		});
+		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+		expect(chat.scrollTop).toBe(1600);
+	});
+
+	it("releases follow when the user wheels up before a scroll (deliberate up-scroll)", async () => {
+		let captured: EventStreamHandlers | undefined;
+		vi.mocked(connectEvents).mockImplementation((handlers) => {
+			captured = handlers;
+			return () => {};
+		});
+		const store = makeStore();
+		await store.start();
+		if (!captured) throw new Error("connectEvents was not called");
+		const el = mount(() => <SessionScreen store={store} sessionKey="k-wheelup" />);
+		captured.onEnvelope({ seq: 1, key: "k-wheelup", event: { type: "agent_start" } });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const chat = el.querySelector(".chat") as HTMLElement;
+		let scrollHeight = 900;
+		Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+		Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+
+		chat.scrollTop = 800;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// A genuine wheel-up followed by the resulting decreased scrollTop releases.
+		chat.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+		chat.scrollTop = 300;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// Later growth must NOT yank the released view back to the bottom.
+		scrollHeight = 1600;
+		captured.onEnvelope({
+			seq: 2,
+			key: "k-wheelup",
+			event: { type: "tool_execution_start", toolCallId: "t2", toolName: "bash", args: { command: "yes" } },
+		});
+		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+		expect(chat.scrollTop).toBe(300);
 	});
 
 	it("re-pins the transcript when observed content grows without a new envelope (ResizeObserver path)", async () => {
@@ -1068,8 +1159,49 @@ describe("dashboard client regressions", () => {
 		expect(nextItems[0]).toBe(firstItems[0]);
 		expect(nextItems[1]).toBe(firstItems[1]);
 		expect(nextItems[2]).toBe(firstItems[2]);
-		expect(nextItems[3]).not.toBe(firstItems[3]);
-		expect(nextItems[3]).toMatchObject({ kind: "assistant-turn", entries: [entries[4], entries[5]] });
+		// Appending a tool to the ACTIVE assistant turn must keep the turn item —
+		// and therefore its rendered wrapper DOM — stable. Recreating the wrapper
+		// tears down and re-renders the assistant markdown, a reflow that lowers
+		// scrollTop at the assistant→tool boundary.
+		expect(nextItems[3]).toBe(firstItems[3]);
+		const turn = nextItems[3] as Extract<TranscriptRenderItem, { kind: "assistant-turn" }>;
+		expect(turn.kind).toBe("assistant-turn");
+		expect(turn.entries()).toEqual([entries[4], entries[5]]);
+	});
+
+	it("appending a tool keeps the rendered assistant-turn DOM node stable (no destroy/recreate reflow)", async () => {
+		const assistant = {
+			kind: "assistant" as const,
+			blocks: [{ kind: "text" as const, text: "long analysis" }],
+			streaming: false,
+		};
+		const [entries, setEntries] = createSignal<Parameters<typeof transcriptRenderItems>[0]>([assistant]);
+		const el = mount(() => <Transcript entries={entries()} />);
+		const turnBefore = el.querySelector('[data-testid="assistant-turn"]');
+		expect(turnBefore).not.toBeNull();
+		const markdownBefore = turnBefore?.querySelector(".entry-body");
+
+		setEntries([
+			assistant,
+			{
+				kind: "tool",
+				toolCallId: "t-append",
+				toolName: "bash",
+				args: { command: "pwd" },
+				status: "running",
+				resultText: "",
+				startedAt: Date.now(),
+			},
+		]);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const turnAfter = el.querySelector('[data-testid="assistant-turn"]');
+		// SAME DOM nodes — the wrapper and the already-rendered assistant markdown
+		// were not torn down when the tool card was appended.
+		expect(turnAfter).toBe(turnBefore);
+		expect(turnAfter?.querySelector(".entry-body")).toBe(markdownBefore);
+		// …and the tool card actually rendered inside the same wrapper.
+		expect(turnAfter?.querySelector(".tool")).not.toBeNull();
 	});
 
 	it("tool card bodies mount lazily and running tools stay mounted", () => {
@@ -2398,6 +2530,7 @@ describe("dashboard client regressions", () => {
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(pre.scrollTop).toBe(600);
 
+		pre.dispatchEvent(new WheelEvent("wheel", { deltaY: -20 }));
 		pre.scrollTop = 100;
 		pre.dispatchEvent(new Event("scroll"));
 		scrollHeight = 900;
@@ -2803,8 +2936,9 @@ describe("dashboard client regressions", () => {
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 			expect(chat.scrollTop).toBe(1000);
 
-			// A deliberate up-scroll suspends follow; later observed growth must not
-			// yank the view back down.
+			// A deliberate up-scroll (wheel-up) suspends follow; later observed growth
+			// must not yank the view back down.
+			chat.dispatchEvent(new WheelEvent("wheel", { deltaY: -20, bubbles: true }));
 			chat.scrollTop = 200;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
 			scrollHeight = 1600;

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -605,6 +605,12 @@ describe("app store integration", () => {
 			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
 			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
 
+			// Flush any pending mount/revision pin FIRST, so the assertion below can
+			// only be satisfied by the ResizeObserver-driven re-pin — not by a
+			// leftover coalesced pin that would reach the new bottom regardless of
+			// whether observeViewport/observeContent actually attached.
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
 			// Parked at the bottom.
 			chat.scrollTop = 400;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
@@ -612,6 +618,7 @@ describe("app store integration", () => {
 			// Content grows asynchronously (e.g. late syntax highlighting) with NO
 			// new envelope — only the ResizeObserver fires. The transcript must
 			// re-pin to the new bottom.
+			expect(roCallback).toBeDefined();
 			scrollHeight = 1000;
 			roCallback?.([], {} as ResizeObserver);
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -2784,9 +2791,13 @@ describe("dashboard client regressions", () => {
 			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
 			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
 
-			// Parked at the bottom; async growth with no revision must re-pin.
+			// Parked at the bottom; async growth with no revision must re-pin. Flush
+			// any pending mount pin first so only the observer-driven re-pin can
+			// satisfy the assertion.
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 			chat.scrollTop = 400;
 			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+			expect(roCallback).toBeDefined();
 			scrollHeight = 1000;
 			roCallback?.([], {} as ResizeObserver);
 			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -518,6 +518,44 @@ describe("app store integration", () => {
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(chat.scrollTop).toBe(200);
 	});
+
+	it("keeps following when content grows without a user scroll (no silent drop-out)", async () => {
+		let captured: EventStreamHandlers | undefined;
+		vi.mocked(connectEvents).mockImplementation((handlers) => {
+			captured = handlers;
+			return () => {};
+		});
+		const store = makeStore();
+		await store.start();
+		if (!captured) throw new Error("connectEvents was not called");
+		const el = mount(() => <SessionScreen store={store} sessionKey="k-grow" />);
+		captured.onEnvelope({ seq: 1, key: "k-grow", event: { type: "agent_start" } });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const chat = el.querySelector(".chat") as HTMLElement;
+		let scrollHeight = 500;
+		Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+		Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+
+		// User is parked at the bottom.
+		chat.scrollTop = 400;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// Content grows below (e.g. a long tool output) and a spurious scroll event
+		// fires while the viewport now measures "not at bottom" — the old absolute
+		// at-bottom check would latch follow off here.
+		scrollHeight = 900;
+		chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+		// A subsequent envelope must still pin to the new bottom.
+		scrollHeight = 1000;
+		captured.onEnvelope({
+			seq: 2,
+			key: "k-grow",
+			event: { type: "tool_execution_start", toolCallId: "t1", toolName: "bash", args: { command: "yes" } },
+		});
+		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+		expect(chat.scrollTop).toBe(1000);
+	});
 });
 
 describe("screen smoke tests", () => {
@@ -2297,6 +2335,46 @@ describe("dashboard client regressions", () => {
 		refreshPre();
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(pre.scrollTop).toBe(100);
+	});
+
+	it("bash tool output keeps following when output grows without a user scroll", async () => {
+		let scrollHeight = 300;
+		const bashEntry = (resultText: string) => ({
+			kind: "tool" as const,
+			toolCallId: "b-grow",
+			toolName: "bash",
+			args: { command: "for i in {1..100}; do echo $i; done" },
+			status: "running" as const,
+			resultText,
+			startedAt: Date.now(),
+		});
+		const entry = bashEntry("line 1");
+		const [entries, setEntries] = createSignal([entry]);
+		const el = mount(() => <Transcript entries={entries()} />);
+		let pre = el.querySelector(".tool-result pre") as HTMLPreElement;
+		const refreshPre = () => {
+			pre = el.querySelector(".tool-result pre") as HTMLPreElement;
+			Object.defineProperty(pre, "clientHeight", { configurable: true, value: 100 });
+			Object.defineProperty(pre, "scrollHeight", { configurable: true, get: () => scrollHeight });
+		};
+		refreshPre();
+
+		// Parked at the bottom.
+		pre.scrollTop = 200;
+		pre.dispatchEvent(new Event("scroll"));
+
+		// Output grows and a spurious scroll fires while not-at-bottom — must not
+		// latch follow off.
+		scrollHeight = 600;
+		pre.dispatchEvent(new Event("scroll"));
+
+		// Further streamed output pins back to the new bottom.
+		scrollHeight = 900;
+		entry.resultText = "line 1\n".repeat(120);
+		setEntries([entry]);
+		refreshPre();
+		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+		expect(pre.scrollTop).toBe(900);
 	});
 
 	it("fork modal rewinds to a selected user message and prefills the composer", async () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -153,6 +153,21 @@ import { MAX_TOTAL_IMAGE_BYTES } from "../../src/shared/protocol.js";
 
 const disposers: Array<() => void> = [];
 
+// jsdom lacks ResizeObserver; real browsers always have it. Install a no-op so
+// the stick-to-bottom controller's observeContent() attaches quietly instead of
+// logging its (correct) "ResizeObserver unavailable" warning on every screen
+// mount. Tests that exercise the observer path override this with a capturing
+// fake and restore it afterward.
+if (!(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver) {
+	class NoopResizeObserver {
+		observe(): void {}
+		unobserve(): void {}
+		disconnect(): void {}
+	}
+	(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+		NoopResizeObserver as unknown as typeof ResizeObserver;
+}
+
 beforeEach(() => {
 	if (window.localStorage) return;
 	const values = new Map<string, string>();
@@ -555,6 +570,55 @@ describe("app store integration", () => {
 		});
 		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 		expect(chat.scrollTop).toBe(1000);
+	});
+
+	it("re-pins the transcript when observed content grows without a new envelope (ResizeObserver path)", async () => {
+		// Wire a controllable global ResizeObserver so the controller's
+		// observeContent() actually attaches (jsdom lacks ResizeObserver, which
+		// would otherwise silently disable the async-growth re-pin).
+		let roCallback: ResizeObserverCallback | undefined;
+		class FakeRO {
+			constructor(cb: ResizeObserverCallback) {
+				roCallback = cb;
+			}
+			observe(): void {}
+			unobserve(): void {}
+			disconnect(): void {}
+		}
+		const priorRO = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+		(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+			FakeRO as unknown as typeof ResizeObserver;
+		try {
+			let captured: EventStreamHandlers | undefined;
+			vi.mocked(connectEvents).mockImplementation((handlers) => {
+				captured = handlers;
+				return () => {};
+			});
+			const store = makeStore();
+			await store.start();
+			if (!captured) throw new Error("connectEvents was not called");
+			const el = mount(() => <SessionScreen store={store} sessionKey="k-ro" />);
+			captured.onEnvelope({ seq: 1, key: "k-ro", event: { type: "agent_start" } });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			const chat = el.querySelector(".chat") as HTMLElement;
+			let scrollHeight = 500;
+			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+
+			// Parked at the bottom.
+			chat.scrollTop = 400;
+			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+			// Content grows asynchronously (e.g. late syntax highlighting) with NO
+			// new envelope — only the ResizeObserver fires. The transcript must
+			// re-pin to the new bottom.
+			scrollHeight = 1000;
+			roCallback?.([], {} as ResizeObserver);
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(chat.scrollTop).toBe(1000);
+		} finally {
+			(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = priorRO;
+		}
 	});
 });
 
@@ -2686,6 +2750,59 @@ describe("dashboard client regressions", () => {
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
 		expect(el.textContent).toContain("No session log found for this agent");
+	});
+
+	it("subagent transcript re-pins on observed content growth and respects a user up-scroll", async () => {
+		let roCallback: ResizeObserverCallback | undefined;
+		class FakeRO {
+			constructor(cb: ResizeObserverCallback) {
+				roCallback = cb;
+			}
+			observe(): void {}
+			unobserve(): void {}
+			disconnect(): void {}
+		}
+		const priorRO = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+		(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+			FakeRO as unknown as typeof ResizeObserver;
+		try {
+			vi.mocked(api.subagentMessages).mockResolvedValue({
+				agent: {
+					agentId: "bg-ro",
+					agentType: "Explore",
+					taskSummary: "streaming task",
+					startedAt: new Date().toISOString(),
+					status: "running",
+				},
+				messages: [{ role: "assistant", content: [{ type: "text", text: "streaming output" }] }],
+			});
+			const store = makeStore();
+			const el = mount(() => <SubagentScreen store={store} sessionKey="k-ro-sub" agentId="bg-ro" />);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			const chat = el.querySelector(".chat") as HTMLElement;
+			let scrollHeight = 500;
+			Object.defineProperty(chat, "clientHeight", { configurable: true, value: 100 });
+			Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => scrollHeight });
+
+			// Parked at the bottom; async growth with no revision must re-pin.
+			chat.scrollTop = 400;
+			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+			scrollHeight = 1000;
+			roCallback?.([], {} as ResizeObserver);
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(chat.scrollTop).toBe(1000);
+
+			// A deliberate up-scroll suspends follow; later observed growth must not
+			// yank the view back down.
+			chat.scrollTop = 200;
+			chat.dispatchEvent(new Event("scroll", { bubbles: true }));
+			scrollHeight = 1600;
+			roCallback?.([], {} as ResizeObserver);
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			expect(chat.scrollTop).toBe(200);
+		} finally {
+			(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = priorRO;
+		}
 	});
 
 	it("hydrateSession re-seeds background agents from the runtime registry", async () => {

--- a/packages/dashboard/test/client/scrolling.browser.test.ts
+++ b/packages/dashboard/test/client/scrolling.browser.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Real-browser regression tests for the stick-to-bottom follow controller.
+ *
+ * jsdom cannot model the mechanisms this bug lives in: scrollTop clamping,
+ * scroll anchoring, DOM-replacement reflow, async scroll event ordering, and
+ * real wheel/keyboard/touch input routing (including nested-scroller wheel
+ * consumption). These tests run the REAL `createStickToBottom` +
+ * `bindStickToBottom` production wiring inside headless Chromium against a
+ * page that replicates the dashboard's scroll geometry (.chat outer scroller,
+ * nested max-height tool-output <pre>), and drive genuine input through
+ * Playwright's mouse/keyboard/CDP touch.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { type Browser, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const scrollingSource = fileURLToPath(new URL("../../src/client/scrolling.ts", import.meta.url));
+
+let browser: Browser;
+let page: Page;
+let pageUrl: string;
+let tempDir: string;
+
+const HARNESS_HTML = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+	* { margin: 0; padding: 0; box-sizing: border-box; }
+	html, body { height: 100%; }
+	body { display: flex; flex-direction: column; overflow: hidden; }
+	.chat { flex: 1; overflow-y: auto; }
+	.chat-inner { padding: 16px; }
+	.entry { margin-bottom: 12px; }
+	.tool-result pre { max-height: 340px; overflow-y: auto; background: #eee; }
+	textarea { height: 60px; }
+</style>
+</head>
+<body>
+	<main class="chat"><div class="chat-inner"></div></main>
+	<textarea class="composer"></textarea>
+	<script src="./harness.js"></script>
+</body>
+</html>`;
+
+const HARNESS_SETUP = String.raw`
+	const chat = document.querySelector(".chat");
+	const inner = document.querySelector(".chat-inner");
+	const controller = Scrolling.createStickToBottom({ scroller: () => chat });
+	controller.observeContent(inner);
+	controller.observeViewport(chat);
+	Scrolling.bindStickToBottom(controller, chat, { keyboard: "window" });
+
+	window.harness = {
+		controller,
+		isFollowing: () => controller.isFollowing(),
+		atBottom: () => Math.abs(chat.scrollTop - (chat.scrollHeight - chat.clientHeight)) <= 2,
+		scrollTop: () => chat.scrollTop,
+		addAssistantMarkdown(lines) {
+			const div = document.createElement("div");
+			div.className = "entry assistant";
+			div.textContent = Array.from({ length: lines }, (_, i) => "assistant line " + i).join("\n");
+			div.style.whiteSpace = "pre";
+			inner.appendChild(div);
+			controller.notifyContentChanged();
+			return div;
+		},
+		// The assistant→tool boundary reflow: the streamed assistant DOM is
+		// destroyed and recreated (message_end replaces streamed blocks with the
+		// authoritative render) and a tool card is appended below — all in one
+		// synchronous mutation batch, which is what lowers scrollTop in the wild.
+		assistantToolBoundary(el, preLines) {
+			const replacement = document.createElement("div");
+			replacement.className = "entry assistant";
+			replacement.style.whiteSpace = "pre";
+			replacement.textContent = el.textContent;
+			el.replaceWith(replacement);
+			const tool = document.createElement("div");
+			tool.className = "entry tool";
+			const result = document.createElement("div");
+			result.className = "tool-result";
+			const pre = document.createElement("pre");
+			pre.textContent = Array.from({ length: preLines }, (_, i) => "tool output " + i).join("\n");
+			result.appendChild(pre);
+			tool.appendChild(result);
+			inner.appendChild(tool);
+			// The production tool-output pre has its own stick-to-bottom controller
+			// pinning it while output streams; replicate its resting state.
+			pre.scrollTop = pre.scrollHeight;
+			controller.notifyContentChanged();
+			return pre;
+		},
+		streamIntoPre(pre, lines) {
+			pre.textContent += "\n" + Array.from({ length: lines }, (_, i) => "more " + i).join("\n");
+			controller.notifyContentChanged();
+		},
+	};
+`;
+
+async function settleFrames(count = 4): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
+	}
+}
+
+/** Wait until the outer scroller's scrollTop has been stable for ~20 frames
+ * (smooth keyboard scrolling / touch inertia continue after the input ends). */
+async function waitForScrollSettle(): Promise<void> {
+	await page.evaluate(() => {
+		const w = window as unknown as { lastY?: number; stableFrames?: number };
+		w.lastY = undefined;
+		w.stableFrames = 0;
+	});
+	await page.waitForFunction(() => {
+		const w = window as unknown as { lastY?: number; stableFrames?: number };
+		const chat = document.querySelector(".chat") as HTMLElement;
+		if (w.lastY === chat.scrollTop) w.stableFrames = (w.stableFrames ?? 0) + 1;
+		else w.stableFrames = 0;
+		w.lastY = chat.scrollTop;
+		return (w.stableFrames ?? 0) > 20;
+	});
+}
+
+beforeAll(async () => {
+	tempDir = mkdtempSync(join(tmpdir(), "dreb-scroll-browser-"));
+	const bundle = await build({
+		entryPoints: [scrollingSource],
+		bundle: true,
+		format: "iife",
+		globalName: "Scrolling",
+		write: false,
+	});
+	writeFileSync(join(tempDir, "harness.js"), `${bundle.outputFiles[0]!.text}\n${HARNESS_SETUP}`);
+	writeFileSync(join(tempDir, "index.html"), HARNESS_HTML);
+	pageUrl = `file://${join(tempDir, "index.html")}`;
+	browser = await chromium.launch();
+	page = await browser.newPage({ viewport: { width: 800, height: 600 }, hasTouch: true });
+}, 60_000);
+
+afterAll(async () => {
+	await browser?.close();
+	if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+	await page.goto(pageUrl);
+	await page.waitForFunction(() => (window as unknown as { harness?: unknown }).harness !== undefined);
+});
+
+type Harness = {
+	isFollowing: () => boolean;
+	atBottom: () => boolean;
+	scrollTop: () => number;
+	addAssistantMarkdown: (lines: number) => HTMLElement;
+	assistantToolBoundary: (el: HTMLElement, preLines: number) => HTMLElement;
+	streamIntoPre: (pre: HTMLElement, lines: number) => void;
+};
+declare const window: { harness: Harness } & typeof globalThis;
+
+async function harness<T>(fn: (h: Harness) => T): Promise<T> {
+	// Serialize the callback and invoke it with the page's harness object —
+	// page.evaluate(fn) alone would call fn(undefined).
+	return page.evaluate(`(${fn.toString()})(window.harness)`) as Promise<T>;
+}
+
+describe("stick-to-bottom in a real browser", () => {
+	it("survives the assistant→tool boundary reflow and keeps pinning (the original drop-out)", async () => {
+		// Stream a long assistant message so the transcript scrolls; the pin keeps
+		// the view at the bottom.
+		await harness((h) => {
+			const el = h.addAssistantMarkdown(200);
+			(window as unknown as { el: HTMLElement }).el = el;
+		});
+		await settleFrames();
+		expect(await harness((h) => h.atBottom())).toBe(true);
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+
+		// The boundary: assistant DOM destroyed+recreated, tool card with a long
+		// nested pre appended — the browser reflows and may lower scrollTop with
+		// no user input. Follow must survive and the view must pin to the new
+		// bottom.
+		await harness((h) => {
+			const el = (window as unknown as { el: HTMLElement }).el;
+			const pre = h.assistantToolBoundary(el, 400);
+			(window as unknown as { pre: HTMLElement }).pre = pre;
+		});
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+		expect(await harness((h) => h.atBottom())).toBe(true);
+
+		// Continued streaming into the nested pre keeps the outer view pinned.
+		await harness((h) => h.streamIntoPre((window as unknown as { pre: HTMLElement }).pre, 200));
+		await settleFrames();
+		expect(await harness((h) => h.atBottom())).toBe(true);
+	});
+
+	it("a real wheel-up releases follow and later growth does not yank the view back", async () => {
+		await harness((h) => h.addAssistantMarkdown(300));
+		await settleFrames();
+		expect(await harness((h) => h.atBottom())).toBe(true);
+
+		// Genuine mouse wheel up over the transcript (not over the nested pre).
+		await page.mouse.move(400, 100);
+		await page.mouse.wheel(0, -600);
+		await page.waitForFunction(() => !window.harness.isFollowing());
+		await waitForScrollSettle();
+		const parkedAt = await harness((h) => h.scrollTop());
+
+		// New content grows the transcript — the released view must not move.
+		await harness((h) => h.addAssistantMarkdown(100));
+		await settleFrames();
+		expect(await harness((h) => h.scrollTop())).toBe(parkedAt);
+
+		// Scrolling back to the bottom re-engages follow.
+		await harness(() => {
+			const chat = document.querySelector(".chat") as HTMLElement;
+			chat.scrollTop = chat.scrollHeight;
+		});
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+	});
+
+	it("wheeling up over the nested tool pre scrolls the pre without releasing the outer follow", async () => {
+		await harness((h) => {
+			const el = h.addAssistantMarkdown(50);
+			const pre = h.assistantToolBoundary(el, 400);
+			(window as unknown as { pre: HTMLElement }).pre = pre;
+		});
+		await settleFrames();
+		expect(await harness((h) => h.atBottom())).toBe(true);
+
+		// The nested pre is pinned to ITS bottom (scrollTop > 0), so an upward
+		// wheel over it is consumed by the pre. The outer controller must stay
+		// following — including through a subsequent boundary-style reflow within
+		// what used to be the vulnerable intent window.
+		const preBox = await page.evaluate(() => {
+			const pre = (window as unknown as { pre: HTMLElement }).pre;
+			const rect = pre.getBoundingClientRect();
+			return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2, scrollTop: pre.scrollTop };
+		});
+		expect(preBox.scrollTop).toBeGreaterThan(0);
+		await page.mouse.move(preBox.x, preBox.y);
+		await page.mouse.wheel(0, -200);
+		await settleFrames();
+		const preScrolled = await page.evaluate(() => (window as unknown as { pre: HTMLElement }).pre.scrollTop);
+		expect(preScrolled).toBeLessThan(preBox.scrollTop);
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+
+		// Immediately (inside any fallback window) grow content below — the outer
+		// view must pin to the new bottom, not falsely release.
+		await harness((h) => h.addAssistantMarkdown(80));
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+		expect(await harness((h) => h.atBottom())).toBe(true);
+	});
+
+	it("a real keyboard PageUp releases follow; keys in the composer never do", async () => {
+		await harness((h) => h.addAssistantMarkdown(300));
+		await settleFrames();
+
+		// Keys typed into the composer (an editable target) are excluded.
+		await page.focus(".composer");
+		await page.keyboard.press("PageUp");
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+		expect(await harness((h) => h.atBottom())).toBe(true);
+
+		// PageUp with focus on the page body scrolls the transcript and releases.
+		await page.click(".chat", { position: { x: 400, y: 100 } });
+		await harness(() => (document.activeElement as HTMLElement | null)?.blur?.());
+		await page.keyboard.press("PageUp");
+		await page.waitForFunction(() => !window.harness.isFollowing());
+		await waitForScrollSettle();
+		expect(await harness((h) => h.atBottom())).toBe(false);
+
+		// Growth while released must not yank the view down.
+		const parkedAt = await harness((h) => h.scrollTop());
+		await harness((h) => h.addAssistantMarkdown(50));
+		await settleFrames();
+		expect(await harness((h) => h.scrollTop())).toBe(parkedAt);
+	});
+
+	it("a real touch up-drag releases follow; a stationary touch hold during growth does not", async () => {
+		await harness((h) => h.addAssistantMarkdown(300));
+		await settleFrames();
+
+		// Stationary hold while content grows: pinning is suspended during the
+		// contact, and follow must survive (no release) once it ends.
+		const cdp = await page.context().newCDPSession(page);
+		await cdp.send("Input.dispatchTouchEvent", {
+			type: "touchStart",
+			touchPoints: [{ x: 400, y: 300 }],
+		});
+		await harness((h) => h.addAssistantMarkdown(50));
+		await settleFrames();
+		await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+		expect(await harness((h) => h.atBottom())).toBe(true);
+
+		// Upward drag: finger moves DOWN the screen, content scrolls up → release.
+		await cdp.send("Input.dispatchTouchEvent", {
+			type: "touchStart",
+			touchPoints: [{ x: 400, y: 200 }],
+		});
+		for (let y = 200; y <= 440; y += 40) {
+			await cdp.send("Input.dispatchTouchEvent", {
+				type: "touchMove",
+				touchPoints: [{ x: 400, y }],
+			});
+		}
+		await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+		await page.waitForFunction(() => !window.harness.isFollowing());
+		// The fling's inertial scrolling continues after touchend — wait for the
+		// scroll position to settle before sampling the parked position.
+		await waitForScrollSettle();
+		const parkedAt = await harness((h) => h.scrollTop());
+		expect(await harness((h) => h.atBottom())).toBe(false);
+
+		// Growth while released must not yank the view down.
+		await harness((h) => h.addAssistantMarkdown(60));
+		await settleFrames();
+		expect(await harness((h) => h.scrollTop())).toBe(parkedAt);
+	});
+});

--- a/packages/dashboard/test/client/scrolling.browser.test.ts
+++ b/packages/dashboard/test/client/scrolling.browser.test.ts
@@ -51,7 +51,10 @@ const HARNESS_HTML = `<!DOCTYPE html>
 const HARNESS_SETUP = String.raw`
 	const chat = document.querySelector(".chat");
 	const inner = document.querySelector(".chat-inner");
-	const controller = Scrolling.createStickToBottom({ scroller: () => chat });
+	// Keep fallback intent live well beyond CI frame variance; browser tests that
+	// verify nested-input routing must fail because routing is wrong, never pass
+	// merely because the default 400ms fallback expired while waiting for settle.
+	const controller = Scrolling.createStickToBottom({ scroller: () => chat, intentWindowMs: 10_000 });
 	controller.observeContent(inner);
 	controller.observeViewport(chat);
 	Scrolling.bindStickToBottom(controller, chat, { keyboard: "window" });
@@ -85,6 +88,7 @@ const HARNESS_SETUP = String.raw`
 			const result = document.createElement("div");
 			result.className = "tool-result";
 			const pre = document.createElement("pre");
+			pre.tabIndex = 0; // production tool-output pres are keyboard-scrollable
 			pre.textContent = Array.from({ length: preLines }, (_, i) => "tool output " + i).join("\n");
 			result.appendChild(pre);
 			tool.appendChild(result);
@@ -216,12 +220,10 @@ describe("stick-to-bottom in a real browser", () => {
 		await settleFrames();
 		expect(await harness((h) => h.scrollTop())).toBe(parkedAt);
 
-		// Scrolling back to the bottom re-engages follow.
-		await harness(() => {
-			const chat = document.querySelector(".chat") as HTMLElement;
-			chat.scrollTop = chat.scrollHeight;
-		});
-		await settleFrames();
+		// A deliberate downward wheel return to the bottom re-engages follow.
+		await page.mouse.move(400, 100);
+		await page.mouse.wheel(0, 10_000);
+		await page.waitForFunction(() => window.harness.atBottom());
 		expect(await harness((h) => h.isFollowing())).toBe(true);
 	});
 
@@ -259,6 +261,43 @@ describe("stick-to-bottom in a real browser", () => {
 		expect(await harness((h) => h.atBottom())).toBe(true);
 	});
 
+	it("PageUp focused in a nested tool pre does not arm outer intent during a layout decrease", async () => {
+		await harness((h) => {
+			const assistant = h.addAssistantMarkdown(50);
+			const pre = h.assistantToolBoundary(assistant, 400);
+			(window as unknown as { pre: HTMLElement }).pre = pre;
+		});
+		await settleFrames();
+		const before = await page.evaluate(() => {
+			const chat = document.querySelector(".chat") as HTMLElement;
+			const pre = (window as unknown as { pre: HTMLElement }).pre;
+			pre.focus();
+			return { outerTop: chat.scrollTop, preTop: pre.scrollTop };
+		});
+		expect(before.preTop).toBeGreaterThan(0);
+
+		// Chromium routes PageUp to the focused nested pre. The bubbling window
+		// listener must recognize that consumption and leave outer intent unarmed.
+		await page.keyboard.press("PageUp");
+		await waitForScrollSettle();
+		const afterKey = await page.evaluate(() => {
+			const chat = document.querySelector(".chat") as HTMLElement;
+			const pre = (window as unknown as { pre: HTMLElement }).pre;
+			return { outerTop: chat.scrollTop, preTop: pre.scrollTop };
+		});
+		expect(afterKey.preTop).toBeLessThan(before.preTop);
+		expect(afterKey.outerTop).toBe(before.outerTop);
+
+		// Reproduce a coincident layout/anchor decrease inside the old intent
+		// fallback window. It is a real browser scroll event, but not user intent.
+		await page.evaluate(() => {
+			const chat = document.querySelector(".chat") as HTMLElement;
+			chat.scrollTop -= 120;
+			chat.dispatchEvent(new Event("scroll"));
+		});
+		expect(await harness((h) => h.isFollowing())).toBe(true);
+	});
+
 	it("a real keyboard PageUp releases follow; keys in the composer never do", async () => {
 		await harness((h) => h.addAssistantMarkdown(300));
 		await settleFrames();
@@ -283,6 +322,36 @@ describe("stick-to-bottom in a real browser", () => {
 		await harness((h) => h.addAssistantMarkdown(50));
 		await settleFrames();
 		expect(await harness((h) => h.scrollTop())).toBe(parkedAt);
+	});
+
+	it("content shrink clamps a released reader without re-engaging or yanking on later growth", async () => {
+		await harness((h) => h.addAssistantMarkdown(300));
+		await settleFrames();
+		await page.mouse.move(400, 100);
+		await page.mouse.wheel(0, -600);
+		await page.waitForFunction(() => !window.harness.isFollowing());
+		await waitForScrollSettle();
+
+		// Remove enough content below the parked reader that Chromium clamps the
+		// outer scrollTop to its new geometric bottom and emits scroll/resize.
+		await page.evaluate(() => {
+			const inner = document.querySelector(".chat-inner") as HTMLElement;
+			inner.textContent = "short";
+		});
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(false);
+
+		// Later growth must not revive follow solely because the shrink clamp landed
+		// at bottom; the reader stays put until they deliberately scroll downward.
+		await harness((h) => h.addAssistantMarkdown(300));
+		await settleFrames();
+		expect(await harness((h) => h.isFollowing())).toBe(false);
+		expect(await harness((h) => h.scrollTop())).toBe(0);
+
+		await page.mouse.move(400, 100);
+		await page.mouse.wheel(0, 10_000);
+		await page.waitForFunction(() => window.harness.atBottom());
+		expect(await harness((h) => h.isFollowing())).toBe(true);
 	});
 
 	it("a real touch up-drag releases follow; a stationary touch hold during growth does not", async () => {

--- a/packages/dashboard/test/client/scrolling.test.ts
+++ b/packages/dashboard/test/client/scrolling.test.ts
@@ -292,4 +292,113 @@ describe("createStickToBottom", () => {
 		controller.dispose();
 		expect(ro.disconnectedCount()).toBeGreaterThanOrEqual(1);
 	});
+
+	it("keeps following when a pin's echo scroll fires after further growth (browser clamp mechanism)", () => {
+		// Reproduces the real-browser mechanism the jsdom screen tests cannot: a
+		// programmatic pin clamps `scrollTop` to `scrollHeight - clientHeight` and
+		// fires an async echo `scroll` event. If content grows again before that
+		// echo arrives, the echo must NOT be misread as a user up-scroll.
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 0, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		// Parked at the resting bottom (scrollHeight - clientHeight).
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// A long tool output lands: content grows and the pin fires.
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		// The browser clamps `scrollTop = scrollHeight` to `scrollHeight - clientHeight`.
+		element.scrollTop = element.scrollHeight - element.clientHeight; // 800
+
+		// Late syntax highlighting grows the block again BEFORE the pin's async echo
+		// scroll event is delivered.
+		element.scrollHeight = 1100;
+
+		// The echo scroll arrives with the clamped (unchanged) scrollTop against the
+		// grown height. The old code seeded `lastTop = scrollHeight` (900), so
+		// `800 < 899` released follow here — the silent drop-out reported after a
+		// `read` tool call. The fix seeds `lastTop = scrollHeight - clientHeight`.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Follow survives, so the next growth re-pins to the true bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1100);
+	});
+
+	it("touch end keeps following when content grew during the drag without an up-scroll", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // at bottom → following
+		controller.handleTouchStart();
+
+		// Content grows while the finger is down; the user never scrolls up, so the
+		// viewport measures "not at bottom" purely because of the growth.
+		element.scrollHeight = 900;
+
+		// Lifting the finger must NOT re-derive follow from absolute at-bottom
+		// geometry (the old bug), and must replay the pin suppressed during the drag.
+		controller.handleTouchEnd();
+		expect(controller.isFollowing()).toBe(true);
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("observeContent rebinds to a replacement element and ignores undefined", () => {
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+
+		// Undefined element (ref not ready yet) is a safe no-op.
+		controller.observeContent(undefined);
+		expect(ro.observedCount()).toBe(0);
+
+		// First real element.
+		controller.observeContent({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Rebinding disconnects the prior observer and observes the replacement.
+		controller.observeContent({} as Element);
+		expect(ro.disconnectedCount()).toBe(1);
+		expect(ro.observedCount()).toBe(2);
+
+		// Only the current observer drives re-pins.
+		element.scrollHeight = 900;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("warns loudly instead of silently disabling re-pin when ResizeObserver is unavailable", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: undefined,
+		});
+		controller.observeContent({} as Element);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[0]).toContain("ResizeObserver unavailable");
+		warn.mockRestore();
+	});
 });

--- a/packages/dashboard/test/client/scrolling.test.ts
+++ b/packages/dashboard/test/client/scrolling.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from "vitest";
-import { createCoalescedBottomScroller, createStickToBottom } from "../../src/client/scrolling.js";
+import { bindStickToBottom, createCoalescedBottomScroller, createStickToBottom } from "../../src/client/scrolling.js";
 
 function flushNextFrame(callbacks: FrameRequestCallback[]): void {
 	const callback = callbacks.shift();
@@ -227,7 +227,9 @@ describe("createStickToBottom", () => {
 		queue.flushAll();
 		expect(element.scrollTop).toBe(200);
 
-		// User returns to the bottom — follow re-engages and pins resume.
+		// User returns to the bottom with deliberate downward input — follow
+		// re-engages and pins resume.
+		controller.handleWheel(1);
 		element.scrollTop = 800;
 		controller.handleScroll();
 		expect(controller.isFollowing()).toBe(true);
@@ -718,8 +720,9 @@ describe("createStickToBottom", () => {
 		controller.handleScroll();
 		expect(controller.isFollowing()).toBe(false);
 
-		// After the inertial sequence settles, the carried intent is consumed: a
-		// later layout-induced decrease cannot release.
+		// Return deliberately to the bottom, then settle: a later layout-induced
+		// decrease cannot release.
+		controller.handleWheel(1);
 		element.scrollTop = 800;
 		controller.handleScroll(); // back at bottom → re-engage
 		controller.handleScrollEnd();
@@ -785,6 +788,7 @@ describe("createStickToBottom", () => {
 
 		// After the pointer lifts, a later layout-induced decrease must not release.
 		ptrCtl.handlePointerUp();
+		ptrCtl.handleWheel(1);
 		ptrEl.scrollTop = 800;
 		ptrCtl.handleScroll(); // back at bottom → re-engage
 		expect(ptrCtl.isFollowing()).toBe(true);
@@ -792,5 +796,265 @@ describe("createStickToBottom", () => {
 		ptrEl.scrollTop = 500;
 		ptrCtl.handleScroll();
 		expect(ptrCtl.isFollowing()).toBe(true);
+	});
+
+	it("accumulates fractional and exact-1px upward scrolls against a stable baseline", () => {
+		const fractional: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const fractionalCtl = createStickToBottom({ scroller: () => fractional as unknown as HTMLElement });
+		fractionalCtl.handleScroll();
+		fractionalCtl.handleWheel(-1);
+		fractional.scrollTop = 799.6;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(true);
+		fractional.scrollTop = 799.1;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(true);
+		fractional.scrollTop = 798.5;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(false);
+
+		const exactPixel: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const exactPixelCtl = createStickToBottom({ scroller: () => exactPixel as unknown as HTMLElement });
+		exactPixelCtl.handleScroll();
+		exactPixelCtl.handleWheel(-1);
+		exactPixel.scrollTop = 799;
+		exactPixelCtl.handleScroll();
+		expect(exactPixelCtl.isFollowing()).toBe(true);
+		exactPixel.scrollTop = 798;
+		exactPixelCtl.handleScroll();
+		expect(exactPixelCtl.isFollowing()).toBe(false);
+	});
+
+	it("does not re-engage a released reader after a shrink clamp without a real downward return", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		element.scrollTop = 300;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// Content below the reader disappears; Chrome clamps the position to the
+		// new bottom and emits scroll. Geometry alone must not re-arm follow.
+		element.scrollHeight = 350;
+		element.scrollTop = 250;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(250);
+
+		// A genuine downward wheel plus actual arrival at bottom re-engages follow.
+		controller.handleWheel(1);
+		element.scrollTop = 800;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		element.scrollHeight = 1000;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1000);
+	});
+
+	it("re-engages when a deliberate downward return crosses the threshold in a 1px step", () => {
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		element.scrollTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		controller.handleWheel(1);
+		element.scrollTop = 759;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollTop = 760; // enters the 40px at-bottom threshold by exactly 1px
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("does not inherit downward keyboard intent consumed by a nested scroller", () => {
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperties(inner, {
+			scrollHeight: { configurable: true, value: 600 },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		inner.scrollTop = 250;
+		let outerTop = 800;
+		const element = {
+			get scrollTop() {
+				return outerTop;
+			},
+			set scrollTop(value: number) {
+				outerTop = value;
+			},
+			scrollHeight: 900,
+			clientHeight: 100,
+		};
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		outerTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// The focused inner pre consumes PageDown, so a coincident outer movement
+		// into the bottom threshold must not re-engage the released transcript.
+		controller.handleKeyDown("PageDown", false, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// At the inner bottom, PageDown chains to the outer scroller and can
+		// legitimately re-engage it after actual downward movement.
+		inner.scrollTop = 500;
+		outerTop = 758;
+		controller.handleScroll();
+		controller.handleKeyDown("PageDown", false, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		outer.remove();
+	});
+
+	it("does not inherit touch intent consumed by a nested scroller", () => {
+		const queue = createManualAnimationFrameQueue();
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperties(inner, {
+			scrollHeight: { configurable: true, value: 600 },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		inner.scrollTop = 250;
+		let outerTop = 800;
+		let outerHeight = 900;
+		Object.defineProperties(outer, {
+			scrollTop: {
+				configurable: true,
+				get: () => outerTop,
+				set: (value: number) => {
+					outerTop = value;
+				},
+			},
+			scrollHeight: { configurable: true, get: () => outerHeight },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		const controller = createStickToBottom({
+			scroller: () => outer,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+
+		// The inner pre consumes the upward touch drag. A coincident outer layout
+		// decrease must not inherit that intent and release outer follow.
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(340, inner);
+		outerHeight = 1500;
+		outerTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		controller.handleTouchCancel();
+		queue.flushAll();
+
+		// Release outer follow genuinely, then verify a downward drag consumed by
+		// the inner pre cannot re-engage it on coincident outer movement.
+		outerHeight = 900;
+		outerTop = 800;
+		controller.handleScroll();
+		controller.handleWheel(-1, outer);
+		outerTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(260, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		outer.remove();
+	});
+
+	it("binds touchcancel through the production listener and resumes outer pinning", () => {
+		const queue = createManualAnimationFrameQueue();
+		const scroller = document.createElement("div");
+		Object.defineProperties(scroller, {
+			clientHeight: { configurable: true, value: 100 },
+			scrollHeight: { configurable: true, value: 500 },
+		});
+		scroller.scrollTop = 400;
+		const controller = createStickToBottom({
+			scroller: () => scroller,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		const cleanup = bindStickToBottom(controller, scroller, { keyboard: "window" });
+		scroller.dispatchEvent(new Event("scroll"));
+		const touch = (type: "touchstart" | "touchcancel") => {
+			const event = new Event(type) as Event & { touches: Array<{ clientY: number }> };
+			event.touches = [{ clientY: 300 }];
+			return event;
+		};
+		scroller.dispatchEvent(touch("touchstart"));
+		Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: 900 });
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(scroller.scrollTop).toBe(400);
+		scroller.dispatchEvent(touch("touchcancel"));
+		queue.flushAll();
+		expect(scroller.scrollTop).toBe(900);
+		cleanup();
+	});
+
+	it("binds scrollbar-region pointer intent and clears outside pointerup/pointercancel", () => {
+		const pointer = (type: "pointerdown" | "pointerup" | "pointercancel", offsetX = 0) => {
+			const event = new Event(type, { bubbles: true }) as Event & { pointerType: string; offsetX: number };
+			event.pointerType = "mouse";
+			event.offsetX = offsetX;
+			return event;
+		};
+		const makeBoundController = () => {
+			const scroller = document.createElement("div");
+			Object.defineProperties(scroller, {
+				clientHeight: { configurable: true, value: 100 },
+				clientWidth: { configurable: true, value: 100 },
+				scrollHeight: { configurable: true, writable: true, value: 900 },
+			});
+			scroller.scrollTop = 800;
+			const controller = createStickToBottom({ scroller: () => scroller });
+			const cleanup = bindStickToBottom(controller, scroller, { keyboard: "window" });
+			scroller.dispatchEvent(new Event("scroll"));
+			return { scroller, controller, cleanup };
+		};
+
+		const active = makeBoundController();
+		active.scroller.dispatchEvent(pointer("pointerdown", 100));
+		active.scroller.scrollTop = 300;
+		active.scroller.dispatchEvent(new Event("scroll"));
+		expect(active.controller.isFollowing()).toBe(false);
+		active.cleanup();
+
+		for (const endType of ["pointerup", "pointercancel"] as const) {
+			const releasedOutside = makeBoundController();
+			releasedOutside.scroller.dispatchEvent(pointer("pointerdown", 100));
+			window.dispatchEvent(pointer(endType)); // release outside the scrollbar
+			(releasedOutside.scroller as unknown as FakeScrollElement).scrollHeight = 1500;
+			releasedOutside.scroller.scrollTop = 500;
+			releasedOutside.scroller.dispatchEvent(new Event("scroll"));
+			expect(releasedOutside.controller.isFollowing()).toBe(true);
+			releasedOutside.cleanup();
+		}
 	});
 });

--- a/packages/dashboard/test/client/scrolling.test.ts
+++ b/packages/dashboard/test/client/scrolling.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from "vitest";
-import { createCoalescedBottomScroller } from "../../src/client/scrolling.js";
+import { createCoalescedBottomScroller, createStickToBottom } from "../../src/client/scrolling.js";
 
 function flushNextFrame(callbacks: FrameRequestCallback[]): void {
 	const callback = callbacks.shift();
@@ -145,5 +145,151 @@ describe("createCoalescedBottomScroller", () => {
 		expect(element.scrollTop).toBe(900);
 		expect(queue.raf).toHaveBeenCalledTimes(3);
 		expect(queue.callbacks).toHaveLength(0);
+	});
+});
+
+interface FakeScrollElement {
+	scrollTop: number;
+	scrollHeight: number;
+	clientHeight: number;
+}
+
+/** Minimal controllable ResizeObserver: exposes the registered callback for manual firing. */
+function createFakeResizeObserver() {
+	let callback: ResizeObserverCallback | undefined;
+	let observed = 0;
+	let disconnected = 0;
+	class FakeResizeObserver {
+		constructor(cb: ResizeObserverCallback) {
+			callback = cb;
+		}
+		observe(): void {
+			observed++;
+		}
+		unobserve(): void {}
+		disconnect(): void {
+			disconnected++;
+		}
+	}
+	return {
+		Impl: FakeResizeObserver as unknown as typeof ResizeObserver,
+		fire: () => callback?.([], {} as ResizeObserver),
+		observedCount: () => observed,
+		disconnectedCount: () => disconnected,
+	};
+}
+
+describe("createStickToBottom", () => {
+	it("keeps following through content growth when the user has not scrolled up", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		// User is at the bottom.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Content grows below without the user scrolling; a spurious scroll event
+		// fires while the viewport now measures "not at bottom" (the old latch bug).
+		element.scrollHeight = 900;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Next content notification pins back to the new bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("releases follow on a user up-scroll and re-engages at the bottom", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+
+		// User scrolls up (scrollTop decreases) — follow releases.
+		element.scrollHeight = 900;
+		element.scrollTop = 200;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// Growth no longer pins while released.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(200);
+
+		// User returns to the bottom — follow re-engages and pins resume.
+		element.scrollTop = 800;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		element.scrollHeight = 1000;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1000);
+	});
+
+	it("suspends pinning during an active touch drag", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		controller.handleTouchStart();
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		// Finger down: no yank even though still following.
+		expect(element.scrollTop).toBe(400);
+
+		// Lifting the finger at the bottom re-enables pinning.
+		element.scrollTop = 860;
+		controller.handleTouchEnd();
+		expect(controller.isFollowing()).toBe(true);
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("re-pins on ResizeObserver growth while following but not after release", () => {
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeContent({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Async growth with no envelope re-pins.
+		element.scrollHeight = 900;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+
+		// After a user up-scroll, observer growth must not yank the view back.
+		element.scrollTop = 300;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollHeight = 1400;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(300);
+
+		controller.dispose();
+		expect(ro.disconnectedCount()).toBeGreaterThanOrEqual(1);
 	});
 });

--- a/packages/dashboard/test/client/scrolling.test.ts
+++ b/packages/dashboard/test/client/scrolling.test.ts
@@ -215,9 +215,10 @@ describe("createStickToBottom", () => {
 		});
 		controller.handleScroll();
 
-		// User scrolls up (scrollTop decreases) — follow releases.
+		// User scrolls up (scrollTop decreases) with a genuine wheel-up — follow releases.
 		element.scrollHeight = 900;
 		element.scrollTop = 200;
+		controller.handleWheel(-1);
 		controller.handleScroll();
 		expect(controller.isFollowing()).toBe(false);
 
@@ -282,6 +283,7 @@ describe("createStickToBottom", () => {
 
 		// After a user up-scroll, observer growth must not yank the view back.
 		element.scrollTop = 300;
+		controller.handleWheel(-1);
 		controller.handleScroll();
 		expect(controller.isFollowing()).toBe(false);
 		element.scrollHeight = 1400;
@@ -442,6 +444,7 @@ describe("createStickToBottom", () => {
 
 		// After a user up-scroll, a later viewport resize must not yank the view back.
 		element.scrollTop = 200;
+		controller.handleWheel(-1);
 		controller.handleScroll();
 		expect(controller.isFollowing()).toBe(false);
 		element.clientHeight = 100;
@@ -507,5 +510,287 @@ describe("createStickToBottom", () => {
 
 		controller.dispose();
 		expect(ro.disconnectedCount()).toBe(2);
+	});
+
+	it("keeps following on a layout-induced scrollTop decrease with no user input (assistant→tool boundary)", () => {
+		// The core residual bug: at an assistant→tool boundary the transcript
+		// reflows (streamed message replaced by full markdown, assistant-turn DOM
+		// recreated) and the browser lowers scrollTop while a tool card is appended
+		// below. That is NOT a user up-scroll — no wheel/touch/pointer/key input —
+		// so follow must survive even though scrollTop decreased and the new bottom
+		// is far away.
+		const queue = createManualAnimationFrameQueue();
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			now: () => intentClock,
+		});
+
+		// Parked at the resting bottom, following.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Reflow: assistant completion lowers scrollTop by 300 and a tool card adds
+		// content far below (new bottom is 1400, >40px from the clamped top). No
+		// input event preceded this scroll.
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// The next content notification re-pins to the true new bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1500);
+	});
+
+	it("releases on a wheel-up whose scroll sequence has not settled, but not after scrollend", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll(); // following at bottom
+
+		// A wheel-up whose scroll has not landed yet: no decrease, no release.
+		controller.handleWheel(-1);
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// The outer scroller then moves up under the same gesture — releases.
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+	});
+
+	it("scrollend consumes discrete upward intent (sequence-scoped, not merely time-windowed)", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock, // frozen clock — the 400ms fallback can NEVER expire
+		});
+		controller.handleScroll();
+
+		// A wheel-up arms intent, its (no-op) scroll sequence settles…
+		controller.handleWheel(-1);
+		controller.handleScrollEnd();
+
+		// …then a layout-induced reflow lowers scrollTop. Even though the fallback
+		// window never expired (frozen clock), scrollend already consumed the
+		// intent, so this must NOT release.
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("downward movement clears discrete upward intent", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		element.scrollTop = 800;
+		controller.handleScroll(); // not at bottom (2000-100=1900), lastTop=800
+		expect(controller.isFollowing()).toBe(true);
+
+		// Wheel-up arms, but the user then scrolls DOWN (still above the bottom).
+		controller.handleWheel(-1);
+		element.scrollTop = 1000;
+		controller.handleScroll();
+		// A later layout-induced decrease must not be released by the stale stamp.
+		element.scrollTop = 700;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("wheel-up over a nested inner scroller that can still scroll up does NOT arm outer intent", () => {
+		// The false-release coincidence: a wheel over the nested bash <pre> bubbles
+		// to the outer scroller but is consumed by the pre (it scrolls up instead).
+		// If that armed outer intent, an unrelated assistant→tool reflow within the
+		// fallback window would satisfy both release conditions — the original
+		// silent drop-out. The wheel handler must detect the consuming inner
+		// scroller from the event target and refuse to arm.
+		const intentClock = 1000;
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperty(inner, "scrollHeight", { configurable: true, value: 600 });
+		Object.defineProperty(inner, "clientHeight", { configurable: true, value: 100 });
+		inner.scrollTop = 250; // can still scroll up → consumes the wheel
+		let outerScrollTop = 800;
+		const element = {
+			get scrollTop() {
+				return outerScrollTop;
+			},
+			set scrollTop(v: number) {
+				outerScrollTop = v;
+			},
+			scrollHeight: 900,
+			clientHeight: 100,
+		};
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll(); // following at bottom
+
+		controller.handleWheel(-1, inner);
+		// Reflow lowers outer scrollTop within the (frozen, never-expiring) window.
+		element.scrollHeight = 1500;
+		outerScrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Same wheel but the inner pre is already at its top → it cannot consume,
+		// the outer will scroll, so intent DOES arm and a real decrease releases.
+		inner.scrollTop = 0;
+		outerScrollTop = 1400;
+		controller.handleScroll(); // re-engage at the new bottom
+		expect(controller.isFollowing()).toBe(true);
+		controller.handleWheel(-1, inner);
+		outerScrollTop = 900;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		outer.remove();
+	});
+
+	it("touch is directional: an upward drag releases, a stationary hold plus reflow does not", () => {
+		// Upward drag: finger moves DOWN the screen (clientY increases) → content
+		// drags down → scrollTop decreases → release.
+		const upEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const upCtl = createStickToBottom({ scroller: () => upEl as unknown as HTMLElement });
+		upCtl.handleScroll();
+		upCtl.handleTouchStart(300);
+		upCtl.handleTouchMove(340);
+		upEl.scrollTop = 700;
+		upCtl.handleScroll();
+		expect(upCtl.isFollowing()).toBe(false);
+
+		// Stationary hold: finger down, no movement — a concurrent layout reflow
+		// lowers scrollTop. That is NOT an up-scroll; follow must survive.
+		const holdEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const holdCtl = createStickToBottom({ scroller: () => holdEl as unknown as HTMLElement });
+		holdCtl.handleScroll();
+		holdCtl.handleTouchStart(300);
+		holdEl.scrollHeight = 1500;
+		holdEl.scrollTop = 500;
+		holdCtl.handleScroll();
+		expect(holdCtl.isFollowing()).toBe(true);
+
+		// Downward drag (finger moving UP the screen scrolls down): a concurrent
+		// reflow decrease must not release either.
+		const downEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const downCtl = createStickToBottom({ scroller: () => downEl as unknown as HTMLElement });
+		downEl.scrollTop = 1900;
+		downCtl.handleScroll();
+		downCtl.handleTouchStart(300);
+		downCtl.handleTouchMove(260); // finger up = scroll down intent
+		downEl.scrollHeight = 2600;
+		downEl.scrollTop = 1700; // layout-induced decrease during the drag
+		downCtl.handleScroll();
+		expect(downCtl.isFollowing()).toBe(true);
+	});
+
+	it("touch intent survives past touchend through the inertial scroll until scrollend", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll();
+
+		// Upward flick: drag up, lift — the FIRST significant decrease arrives only
+		// during post-touch inertia, after gestureActive already cleared.
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(320);
+		controller.handleTouchEnd();
+		element.scrollTop = 600; // inertial decrease after the finger lifted
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// After the inertial sequence settles, the carried intent is consumed: a
+		// later layout-induced decrease cannot release.
+		element.scrollTop = 800;
+		controller.handleScroll(); // back at bottom → re-engage
+		controller.handleScrollEnd();
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("a plain (non-scrollbar) pointer press never authorizes a release", () => {
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+
+		// Click / text-selection press (not on the scrollbar) while a reflow lowers
+		// scrollTop — must NOT be misread as a scrollbar up-drag.
+		controller.handlePointerDown(false);
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		controller.handlePointerUp();
+	});
+
+	it("does not release when the upward intent has gone stale", () => {
+		let intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+			intentWindowMs: 400,
+		});
+		controller.handleScroll();
+
+		// A wheel-up happened long ago; by the time a layout-induced decrease fires
+		// the intent window has elapsed, so it must not authorize a release.
+		controller.handleWheel(-1);
+		intentClock += 1000; // 1000ms later, window is 400ms
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("releases on a scroll-up key press and on an active pointer (scrollbar) drag", () => {
+		const intentClock = 1000;
+		// Keyboard: at bottom first to seed lastTop, then a PageUp + decrease.
+		const keyEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const keyCtl = createStickToBottom({ scroller: () => keyEl as unknown as HTMLElement, now: () => intentClock });
+		keyCtl.handleScroll();
+		keyCtl.handleKeyDown("PageUp");
+		keyEl.scrollTop = 300;
+		keyCtl.handleScroll();
+		expect(keyCtl.isFollowing()).toBe(false);
+
+		// Scrollbar drag: pointerdown on the scrollbar region, then an up movement.
+		const ptrEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const ptrCtl = createStickToBottom({ scroller: () => ptrEl as unknown as HTMLElement, now: () => intentClock });
+		ptrCtl.handleScroll();
+		ptrCtl.handlePointerDown(true);
+		ptrEl.scrollTop = 300;
+		ptrCtl.handleScroll();
+		expect(ptrCtl.isFollowing()).toBe(false);
+
+		// After the pointer lifts, a later layout-induced decrease must not release.
+		ptrCtl.handlePointerUp();
+		ptrEl.scrollTop = 800;
+		ptrCtl.handleScroll(); // back at bottom → re-engage
+		expect(ptrCtl.isFollowing()).toBe(true);
+		ptrEl.scrollHeight = 2000;
+		ptrEl.scrollTop = 500;
+		ptrCtl.handleScroll();
+		expect(ptrCtl.isFollowing()).toBe(true);
 	});
 });

--- a/packages/dashboard/test/client/scrolling.test.ts
+++ b/packages/dashboard/test/client/scrolling.test.ts
@@ -401,4 +401,111 @@ describe("createStickToBottom", () => {
 		expect(warn.mock.calls[0]?.[0]).toContain("ResizeObserver unavailable");
 		warn.mockRestore();
 	});
+
+	it("warns only once when both content and viewport observers are attached without ResizeObserver", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: undefined,
+		});
+		// A screen attaches both a content and a viewport observer; the missing-RO
+		// diagnostic must not double-log.
+		controller.observeContent({} as Element);
+		controller.observeViewport({} as Element);
+		expect(warn).toHaveBeenCalledTimes(1);
+		warn.mockRestore();
+	});
+
+	it("re-pins on viewport resize while following but not after release (observeViewport)", () => {
+		// A dock/chrome resize (tasks list, subagent strip, composer auto-grow)
+		// changes the scroller's clientHeight without a content change or a scroll
+		// event. Only the viewport observer catches it.
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeViewport({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Viewport grows (dock shrank) — clientHeight increased with no scroll event.
+		// While following, the observer must re-pin to the new resting bottom.
+		element.clientHeight = 300;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+
+		// After a user up-scroll, a later viewport resize must not yank the view back.
+		element.scrollTop = 200;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.clientHeight = 100;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(200);
+	});
+
+	it("touch cancel clears the gesture and re-enables pinning (touchcancel)", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // at bottom → following
+		controller.handleTouchStart();
+
+		// Finger down suppresses pinning even while following.
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(400);
+
+		// The gesture is canceled (system takeover) instead of ending cleanly.
+		// gestureActive must clear so pinning resumes — otherwise every future pin
+		// is silently suppressed.
+		controller.handleTouchCancel();
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("dispose cancels a pending pin so a detached scroller is never mutated", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // following
+
+		// Schedule a pin, then dispose before either frame fires.
+		controller.notifyContentChanged();
+		controller.dispose();
+		queue.flushAll();
+		// The pin was cancelled — scrollTop is untouched.
+		expect(element.scrollTop).toBe(400);
+	});
+
+	it("dispose disconnects both the content and viewport observers", () => {
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeContent({} as Element);
+		controller.observeViewport({} as Element);
+		expect(ro.observedCount()).toBe(2);
+
+		controller.dispose();
+		expect(ro.disconnectedCount()).toBe(2);
+	});
 });

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.39.0",
+	"version": "2.40.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #358

Fixes the dashboard session transcript silently dropping stick-to-bottom follow mode. Root-cause mechanism fix only — replaces absolute at-bottom re-derivation with delta-based follow release plus a ResizeObserver re-pin, centralized in a shared controller adopted by session, subagent, and HighlightedPre surfaces.

Implementation plan posted as a comment below.
