### PR TITLE
Fix mobile fleet card overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The same agent runtime powers multiple surfaces:
 
 The dashboard is the visual face of dreb: every agent session on the host, live in the browser, with the same fidelity as the terminal.
 
-**One host, every screen.** The dashboard server and the TUI share the same sessions on disk and the same agent runtime. Start a refactor in the terminal, open the dashboard on your desktop to watch its subagents fan out, then pick the same session up from your phone on the couch — one synchronized state everywhere, streaming live over SSE. The layout is responsive by design: on a desktop it's a dense multi-column fleet; on a phone it prioritizes read-and-steer, because steering a running agent from wherever you are is the point.
+**One host, every screen.** The dashboard server and the TUI share the same sessions on disk and the same agent runtime. Start a refactor in the terminal, open the dashboard on your desktop to watch its subagents fan out, then pick the same session up from your phone on the couch — one synchronized state everywhere, streaming live over SSE. The layout is responsive by design: on a desktop it's a dense multi-column fleet; on a phone, fleet cards stack and their content wraps instead of overflowing, while the session view prioritizes read-and-steer because steering a running agent from wherever you are is the point.
 
 <!-- screenshot: fleet overview, desktop (light) -->
 <!-- screenshot: session view, mobile -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.40.0",
+			"version": "2.40.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/dashboard.md
+++ b/packages/coding-agent/docs/dashboard.md
@@ -256,11 +256,13 @@ Background subagents are first-class:
 
 ## Responsive behavior
 
-Single breakpoint at 700px. On mobile: fleet cards stack, the session view
-prioritizes read-and-steer (model/thinking switchers collapse into ⋯, tasks
-default collapsed), file table shows name + download only. Composer modes,
-abort, and needs-attention affordances are never reduced away — steering a
-running agent from a phone is the primary remote use case.
+Single breakpoint at 700px. At <=700px, fleet cards stack; long session names,
+status chips, project paths, activity and subagent text, and past-session
+labels wrap within their cards or rows rather than spilling off-screen. The
+session view prioritizes read-and-steer (model/thinking switchers collapse into
+⋯, tasks default collapsed), and the file table shows name + download only.
+Composer modes, abort, and needs-attention affordances are never reduced away
+— steering a running agent from a phone is the primary remote use case.
 
 ## Architecture
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -35,7 +35,9 @@ Open `http://127.0.0.1:5343`.
   project path, status chip, current activity, live subagents, task progress,
   ctx%, model, cost, last-assistant preview). Below, past sessions grouped by project — three
   compact rows each with an "all N on disk" expander — with resume/delete.
-  `+ new session` anywhere.
+  At <=700px, cards stack; long session names, status chips, project paths,
+  activity/subagent text, and past-session labels wrap within cards or rows
+  rather than spilling off-screen. `+ new session` anywhere.
 - **Session view** — full chat parity: markdown streaming transcript, tool
   cards, thinking blocks, compaction summaries, per-message copy, tasks panel,
   suggest-next chip, slash-command autocomplete, image attach/paste,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/client/styles/app.css
+++ b/packages/dashboard/src/client/styles/app.css
@@ -2075,6 +2075,8 @@ details.thinking .thinking-body {
 		grid-template-columns: minmax(0, 1fr);
 	}
 
+	/* Session cards are column flex containers: constrain them without adding
+	   flex-wrap, which would turn their vertical content into columns. */
 	.session-card,
 	.disk-row,
 	.session-meta,
@@ -2082,7 +2084,96 @@ details.thinking .thinking-body {
 	.disk-row .actions {
 		min-width: 0;
 		max-width: 100%;
+	}
+
+	.disk-row,
+	.session-meta,
+	.session-actions,
+	.disk-row .actions {
 		flex-wrap: wrap;
+	}
+
+	/* Keep titles in their natural row flow, but let either item take a new line. */
+	.session-title {
+		justify-content: flex-start;
+		flex-wrap: wrap;
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	.session-title .name {
+		flex: 1 1 12rem;
+		min-width: 0;
+		max-width: 100%;
+		overflow: visible;
+		text-overflow: clip;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	/* Tokens keep the status labels intact; this scope only lets a chip move
+	   below the session name when both cannot share a title row. */
+	.session-title .chip {
+		flex: 0 0 auto;
+		max-width: 100%;
+	}
+
+	.session-project,
+	.attention-reason,
+	.error-reason,
+	.activity,
+	.subagents,
+	.session-meta,
+	.group-head h3 {
+		min-width: 0;
+		max-width: 100%;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.session-project {
+		overflow: visible;
+		text-overflow: clip;
+	}
+
+	/* Retain the activity two-line clamp while allowing words and identifiers
+	   to wrap inside those two lines. */
+	.activity {
+		text-overflow: clip;
+	}
+
+	.subagents .agent-line {
+		min-width: 0;
+		max-width: 100%;
+		overflow: visible;
+		text-overflow: clip;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.session-meta > span {
+		min-width: 0;
+		max-width: 100%;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.group-head h3 {
+		flex: 1 1 0;
+	}
+
+	.disk-row .name,
+	.disk-row .meta {
+		min-width: 0;
+		max-width: 100%;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+
+	.disk-row .name {
+		flex: 1 1 0;
+		overflow: visible;
+		text-overflow: clip;
 	}
 
 	.disk-row .meta {

--- a/packages/dashboard/test/client/fleet-layout.browser.test.ts
+++ b/packages/dashboard/test/client/fleet-layout.browser.test.ts
@@ -117,6 +117,7 @@ type MobileMeasurements = {
 	criticalWithinParents: boolean;
 	internalOverflowFree: boolean;
 	allWrapped: boolean;
+	activitiesClampedToTwoLines: boolean;
 	chipsContained: boolean;
 	diskMetadataAndActionsVisible: boolean;
 	attentionChipMoved: boolean;
@@ -143,6 +144,7 @@ async function mobileMeasurements(): Promise<MobileMeasurements> {
 		const critical = [...document.querySelectorAll<HTMLElement>("[data-critical]")];
 		const overflowChecked = [...document.querySelectorAll<HTMLElement>("[data-no-overflow]")];
 		const wrapped = [...document.querySelectorAll<HTMLElement>("[data-wrap]")];
+		const activities = [...document.querySelectorAll<HTMLElement>(".activity")];
 		const chips = [...document.querySelectorAll<HTMLElement>("[data-chip]")];
 		const diskRow = document.querySelector<HTMLElement>("[data-disk-row]")!;
 		const diskMeta = diskRow.querySelector<HTMLElement>(".meta")!;
@@ -160,6 +162,16 @@ async function mobileMeasurements(): Promise<MobileMeasurements> {
 				(element) => element.scrollWidth <= element.clientWidth + tolerance,
 			),
 			allWrapped: wrapped.every(isMultiline),
+			activitiesClampedToTwoLines: activities.every((activity) => {
+				const style = getComputedStyle(activity);
+				const lineHeight = Number.parseFloat(style.lineHeight);
+				const height = activity.getBoundingClientRect().height;
+				return (
+					style.webkitLineClamp === "2" &&
+					Math.abs(height - 2 * lineHeight) <= tolerance &&
+					activity.scrollHeight > activity.clientHeight + tolerance
+				);
+			}),
 			chipsContained: chips.every((chip) => {
 				const card = chip.closest(".session-card")!;
 				return rectWithin(chip, card) && chip.scrollWidth <= chip.clientWidth + tolerance;
@@ -186,6 +198,7 @@ describe("fleet layout in a real browser", () => {
 			expect(measured.criticalWithinParents).toBe(true);
 			expect(measured.internalOverflowFree).toBe(true);
 			expect(measured.allWrapped).toBe(true);
+			expect(measured.activitiesClampedToTwoLines).toBe(true);
 			expect(measured.chipsContained).toBe(true);
 			expect(measured.diskMetadataAndActionsVisible).toBe(true);
 			if (width === 320) expect(measured.attentionChipMoved).toBe(true);
@@ -200,6 +213,7 @@ describe("fleet layout in a real browser", () => {
 			const agent = document.querySelector<HTMLElement>('[data-card="running"] .agent-line')!;
 			const diskName = document.querySelector<HTMLElement>(".disk-row .name")!;
 			const title = document.querySelector<HTMLElement>(".session-title")!;
+			const activity = document.querySelector<HTMLElement>('[data-card="running"] .activity')!;
 			const desktopEllipsis = [name, project, agent, diskName].every((element) => {
 				const style = getComputedStyle(element);
 				return (
@@ -209,10 +223,22 @@ describe("fleet layout in a real browser", () => {
 					element.scrollWidth > element.clientWidth
 				);
 			});
-			return { desktopEllipsis, titleWrap: getComputedStyle(title).flexWrap };
+			const activityStyle = getComputedStyle(activity);
+			const activityLineHeight = Number.parseFloat(activityStyle.lineHeight);
+			const activityHeight = activity.getBoundingClientRect().height;
+			const activityClampedToTwoLines =
+				activityStyle.webkitLineClamp === "2" &&
+				Math.abs(activityHeight - 2 * activityLineHeight) <= 1 &&
+				activity.scrollHeight > activity.clientHeight + 1;
+			return {
+				desktopEllipsis,
+				titleWrap: getComputedStyle(title).flexWrap,
+				activityClampedToTwoLines,
+			};
 		});
 
 		expect(desktop.desktopEllipsis).toBe(true);
 		expect(desktop.titleWrap).toBe("nowrap");
+		expect(desktop.activityClampedToTwoLines).toBe(true);
 	});
 });

--- a/packages/dashboard/test/client/fleet-layout.browser.test.ts
+++ b/packages/dashboard/test/client/fleet-layout.browser.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Real-browser mobile layout regression coverage for fleet cards.
+ *
+ * jsdom does not perform flex line collection, text wrapping, line clamping, or
+ * document overflow layout. This test loads the production stylesheets in their
+ * production order and measures the fleet DOM in real Chromium.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { type Browser, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const tokensCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/tokens.css", import.meta.url)), "utf8");
+const appCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/app.css", import.meta.url)), "utf8");
+
+const prose =
+	"This deliberately long prose describes a live fleet session whose details must remain readable on a narrow mobile screen ";
+const unbroken = "unbrokenfleetidentifierwithnospacesandmanycharacters".repeat(3);
+
+function sessionCard(status: "running" | "attention" | "idle" | "error"): string {
+	const statuses = {
+		running: { glyph: "●", label: "running" },
+		attention: { glyph: "◆", label: "needs attention" },
+		idle: { glyph: "○", label: "idle" },
+		error: { glyph: "✕", label: "error" },
+	};
+	const statusDisplay = statuses[status];
+	const conditional =
+		status === "attention"
+			? `<p class="attention-reason" data-critical data-wrap>${prose}${unbroken}</p>`
+			: status === "error"
+				? `<p class="error-reason" data-critical data-wrap>${prose}${unbroken}</p>`
+				: "";
+
+	return `<article class="session-card ${status}" data-card="${status}" data-no-overflow>
+		<div class="session-title" data-no-overflow>
+			<span class="name" data-critical data-wrap>${prose}${unbroken}</span>
+			<span class="chip chip-${status}" data-chip="${status}" data-critical><span class="dot">${statusDisplay.glyph}</span> ${statusDisplay.label}</span>
+		</div>
+		<p class="session-project" data-critical data-wrap>${prose}${unbroken}</p>
+		${conditional}
+		<p class="activity" data-critical data-wrap>${prose}${unbroken}</p>
+		<div class="subagents" data-critical data-no-overflow>
+			<span data-wrap>${prose}${unbroken}</span>
+			<span class="agent-line" data-critical data-wrap>● ${prose}${unbroken}</span>
+		</div>
+		<div class="session-meta" data-critical data-no-overflow>
+			<span>tasks 1/100</span><span>·</span>
+			<span class="model-id" data-critical data-wrap>provider/${prose}${unbroken}</span><span>·</span>
+			<span>ctx 95%</span><span>·</span><span>999 msgs</span><span>·</span><span>just now</span>
+		</div>
+		<div class="session-actions" data-critical data-no-overflow>
+			<button type="button" class="btn btn-small btn-primary">open</button>
+			<button type="button" class="btn btn-small btn-danger">stop runtime</button>
+		</div>
+	</article>`;
+}
+
+const HARNESS_HTML = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<style>${tokensCss}</style>
+<style>${appCss}</style>
+</head>
+<body>
+	<main class="container">
+		<section class="live-sessions">
+			<div class="session-grid">
+				${sessionCard("running")}
+				${sessionCard("attention")}
+				${sessionCard("idle")}
+				${sessionCard("error")}
+			</div>
+		</section>
+		<section class="past-sessions">
+			<section class="project-group">
+				<div class="group-head" data-no-overflow>
+					<h3 data-critical data-wrap>${prose}${unbroken}</h3>
+					<span class="muted small">100 on disk</span>
+					<button type="button" class="btn btn-small">+ new</button>
+				</div>
+				<div class="disk-row" data-disk-row data-no-overflow>
+					<span class="name" data-critical data-wrap>${prose}${unbroken}</span>
+					<span class="meta" data-critical>${prose}${unbroken}</span>
+					<span class="actions" data-critical data-no-overflow>
+						<button type="button" class="btn btn-small" data-disk-action>resume</button>
+						<button type="button" class="btn btn-small btn-danger" data-disk-action>delete</button>
+					</span>
+				</div>
+			</section>
+		</section>
+	</main>
+</body>
+</html>`;
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+	browser = await chromium.launch();
+	page = await browser.newPage({ viewport: { width: 800, height: 800 } });
+}, 60_000);
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+beforeEach(async () => {
+	await page.setContent(HARNESS_HTML);
+});
+
+type MobileMeasurements = {
+	documentFits: boolean;
+	criticalWithinParents: boolean;
+	internalOverflowFree: boolean;
+	allWrapped: boolean;
+	chipsContained: boolean;
+	diskMetadataAndActionsVisible: boolean;
+	attentionChipMoved: boolean;
+};
+
+async function mobileMeasurements(): Promise<MobileMeasurements> {
+	return page.evaluate(() => {
+		const tolerance = 1;
+		const rectWithin = (child: Element, parent: Element) => {
+			const childRect = child.getBoundingClientRect();
+			const parentRect = parent.getBoundingClientRect();
+			return (
+				childRect.left >= parentRect.left - tolerance &&
+				childRect.right <= parentRect.right + tolerance &&
+				childRect.top >= parentRect.top - tolerance &&
+				childRect.bottom <= parentRect.bottom + tolerance
+			);
+		};
+		const isMultiline = (element: HTMLElement) => {
+			const style = getComputedStyle(element);
+			const lineHeight = Number.parseFloat(style.lineHeight);
+			return style.whiteSpace === "normal" && element.getBoundingClientRect().height > lineHeight + tolerance;
+		};
+		const critical = [...document.querySelectorAll<HTMLElement>("[data-critical]")];
+		const overflowChecked = [...document.querySelectorAll<HTMLElement>("[data-no-overflow]")];
+		const wrapped = [...document.querySelectorAll<HTMLElement>("[data-wrap]")];
+		const chips = [...document.querySelectorAll<HTMLElement>("[data-chip]")];
+		const diskRow = document.querySelector<HTMLElement>("[data-disk-row]")!;
+		const diskMeta = diskRow.querySelector<HTMLElement>(".meta")!;
+		const diskActions = [...diskRow.querySelectorAll<HTMLElement>("[data-disk-action]")];
+		const attentionName = document.querySelector<HTMLElement>('[data-card="attention"] .name')!;
+		const attentionChip = document.querySelector<HTMLElement>('[data-chip="attention"]')!;
+
+		return {
+			documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
+			criticalWithinParents: critical.every((element) => {
+				const parent = element.closest(".session-card, .disk-row, .group-head");
+				return parent !== null && rectWithin(element, parent);
+			}),
+			internalOverflowFree: [...new Set([...overflowChecked, ...critical])].every(
+				(element) => element.scrollWidth <= element.clientWidth + tolerance,
+			),
+			allWrapped: wrapped.every(isMultiline),
+			chipsContained: chips.every((chip) => {
+				const card = chip.closest(".session-card")!;
+				return rectWithin(chip, card) && chip.scrollWidth <= chip.clientWidth + tolerance;
+			}),
+			diskMetadataAndActionsVisible:
+				rectWithin(diskMeta, diskRow) &&
+				diskActions.every(
+					(action) => rectWithin(action, diskRow) && action.offsetWidth > 0 && action.offsetHeight > 0,
+				),
+			attentionChipMoved:
+				attentionChip.getBoundingClientRect().top > attentionName.getBoundingClientRect().top + tolerance,
+		};
+	});
+}
+
+describe("fleet layout in a real browser", () => {
+	it.each([320, 390, 700])(
+		"contains every live and disk-card value at %ipx without horizontal overflow",
+		async (width) => {
+			await page.setViewportSize({ width, height: 1600 });
+			const measured = await mobileMeasurements();
+
+			expect(measured.documentFits).toBe(true);
+			expect(measured.criticalWithinParents).toBe(true);
+			expect(measured.internalOverflowFree).toBe(true);
+			expect(measured.allWrapped).toBe(true);
+			expect(measured.chipsContained).toBe(true);
+			expect(measured.diskMetadataAndActionsVisible).toBe(true);
+			if (width === 320) expect(measured.attentionChipMoved).toBe(true);
+		},
+	);
+
+	it("turns the mobile wrapping rules off at 701px and preserves desktop ellipsis", async () => {
+		await page.setViewportSize({ width: 701, height: 1000 });
+		const desktop = await page.evaluate(() => {
+			const name = document.querySelector<HTMLElement>('[data-card="running"] .name')!;
+			const project = document.querySelector<HTMLElement>('[data-card="running"] .session-project')!;
+			const agent = document.querySelector<HTMLElement>('[data-card="running"] .agent-line')!;
+			const diskName = document.querySelector<HTMLElement>(".disk-row .name")!;
+			const title = document.querySelector<HTMLElement>(".session-title")!;
+			const desktopEllipsis = [name, project, agent, diskName].every((element) => {
+				const style = getComputedStyle(element);
+				return (
+					style.whiteSpace === "nowrap" &&
+					style.overflow === "hidden" &&
+					style.textOverflow === "ellipsis" &&
+					element.scrollWidth > element.clientWidth
+				);
+			});
+			return { desktopEllipsis, titleWrap: getComputedStyle(title).flexWrap };
+		});
+
+		expect(desktop.desktopEllipsis).toBe(true);
+		expect(desktop.titleWrap).toBe("nowrap");
+	});
+});

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.40.0",
+	"version": "2.40.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #350

Fix mobile fleet layout overflow so long live-session and past-session content wraps within cards and rows, including status chips, while preserving the compact desktop presentation. Add real-browser geometry coverage for the responsive boundary and long unbroken content.

Implementation plan posted as a comment below.
