### PR TITLE
Clarify subagent parallel mode usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.40.1",
+			"version": "2.40.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.40.1",
+  "version": "2.40.2",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -1670,15 +1670,15 @@ export function createSubagentToolDefinition(
 		label: "subagent",
 		description:
 			"Delegate tasks to independent subagents (Explore for codebase research, Sandbox for isolated /tmp-only analysis). " +
-			"Supports single task, parallel (up to 8, max 4 concurrent), " +
-			"and chain (sequential pipeline with {previous} substitution) modes. " +
+			"Supports `task` for a single task, `tasks` for parallel execution in one call (up to 8, max 4 concurrent), " +
+			"and `chain` for a sequential pipeline with {previous} substitution. " +
 			"All subagents run in background — returns immediately, notifies on completion.",
 		promptSnippet: "Delegate tasks to independent subagents",
 		promptGuidelines: [
 			"Use `subagent` to delegate focused, independent tasks to child agents",
 			"Available agent types can be discovered from ~/.dreb/agents/ and .dreb/agents/ markdown files",
 			builtInAgentsLine,
-			"Use parallel mode for independent tasks that can run concurrently",
+			'Use the `tasks` array to run multiple independent tasks in a single `subagent` call (parallel mode), not separate calls. Typical mach6-review batch: `{ "tasks": [{ "agent": "code-reviewer", "task": "Review code changes" }, { "agent": "error-auditor", "task": "Audit runtime failures" }, { "agent": "test-reviewer", "task": "Review test coverage" }, { "agent": "completeness-checker", "task": "Check issue completeness" }] }`',
 			"Use chain mode when each step depends on the previous step's output (reference with {previous})",
 			"All subagents run in background — the tool returns immediately and you are notified when each agent completes.",
 			"Subagents have their own context window — provide enough context in the task prompt",

--- a/packages/coding-agent/test/subagent-model-fallback.test.ts
+++ b/packages/coding-agent/test/subagent-model-fallback.test.ts
@@ -1465,6 +1465,44 @@ describe("subagent truncation (stopReason length) surfacing", () => {
 });
 
 describe("subagent promptGuidelines", () => {
+	test("tool description maps each mode to its parameter", () => {
+		const description = subagentToolDefinition.description;
+		expect(description).toContain("`task` for a single task");
+		expect(description).toContain("`tasks` for parallel execution in one call");
+		expect(description).toContain("`chain` for a sequential pipeline");
+	});
+
+	test("parallel guideline requires one tasks-array call", () => {
+		const guidelines = subagentToolDefinition.promptGuidelines ?? [];
+		const parallelGuideline = guidelines.find((g) => g.includes("Typical mach6-review batch"));
+		expect(parallelGuideline).toBeDefined();
+		expect(parallelGuideline).toContain("`tasks` array");
+		expect(parallelGuideline).toContain("single `subagent` call");
+		expect(parallelGuideline).toContain("not separate calls");
+	});
+
+	test("parallel guideline includes a valid mach6-review batch", () => {
+		const guidelines = subagentToolDefinition.promptGuidelines ?? [];
+		const parallelGuideline = guidelines.find((g) => g.includes("Typical mach6-review batch"));
+		expect(parallelGuideline).toBeDefined();
+
+		const marker = "Typical mach6-review batch: `";
+		const exampleStart = parallelGuideline!.indexOf(marker) + marker.length;
+		const exampleEnd = parallelGuideline!.indexOf("`", exampleStart);
+		expect(exampleEnd).toBeGreaterThan(exampleStart);
+
+		const example = JSON.parse(parallelGuideline!.slice(exampleStart, exampleEnd)) as {
+			tasks: Array<{ agent: string; task: string }>;
+		};
+		expect(example.tasks.map(({ agent }) => agent)).toEqual([
+			"code-reviewer",
+			"error-auditor",
+			"test-reviewer",
+			"completeness-checker",
+		]);
+		expect(example.tasks.every(({ task }) => task.length > 0)).toBe(true);
+	});
+
 	test("waiting guideline mentions agent_end explicitly", () => {
 		const guidelines = subagentToolDefinition.promptGuidelines ?? [];
 		const waitingGuideline = guidelines.find((g) => g.includes("Each agent notifies independently when done"));

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.40.1",
+  "version": "2.40.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.40.1",
+	"version": "2.40.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #351

Clarifies the built-in subagent tool metadata so models use one `tasks` array call for independent parallel work, with a concise mach6-review batch example and regression coverage.

Implementation plan posted as a comment below.
