### PR TITLE
Fix agent definition context select layout in dashboard settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.43.0",
+			"version": "2.43.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.43.1",
+			"version": "2.43.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.43.0",
+			"version": "2.43.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.43.0",
+  "version": "2.43.1",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.43.0",
+  "version": "2.43.2",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.43.1",
+  "version": "2.43.0",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -282,8 +282,14 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		if (selected && roots.length > 0 && !roots.includes(selected)) setAgentContextCwd(undefined);
 	});
 
+	// While the fleet reports no roots, the retained selection is recovery
+	// metadata only: request global/home agent definitions instead of rendering
+	// (and allowing edits to) a project context that is not currently reachable.
+	// When roots repopulate with the project, its definitions return with it.
+	const agentTypesCwd = () => (agentProjectRoots().length === 0 ? undefined : agentContextCwd());
+
 	const [agentTypes] = createResource(
-		() => ({ settings: settings(), cwd: agentContextCwd() }),
+		() => ({ settings: settings(), cwd: agentTypesCwd() }),
 		async ({ cwd }) => {
 			if (!settings()) return [];
 			try {

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -207,6 +207,8 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 	const homePrefixOf = (cwd: string): string | undefined =>
 		cwd.match(/^\/(?:home|Users)\/[^/]+/)?.[0] ?? (cwd === "/root" || cwd.startsWith("/root/") ? "/root" : undefined);
 
+	const homeAliasOf = (home: string): string => (home === "/root" ? "root" : (home.split("/").pop() ?? ""));
+
 	const distinctHomePrefixes = createMemo(() => {
 		const homes = new Set<string>();
 		for (const root of agentProjectRoots()) {
@@ -216,12 +218,27 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		return homes;
 	});
 
+	// Aliases are not unique across home roots: /root vs /home/root and
+	// /home/alice vs /Users/alice all share a final segment. Detect collisions
+	// so displayCwd can namespace-qualify the affected labels.
+	const collidingHomeAliases = createMemo(() => {
+		const counts = new Map<string, number>();
+		for (const home of distinctHomePrefixes()) {
+			const alias = homeAliasOf(home);
+			counts.set(alias, (counts.get(alias) ?? 0) + 1);
+		}
+		return new Set([...counts].filter(([, count]) => count > 1).map(([alias]) => alias));
+	});
+
 	const displayCwd = (cwd: string): string => {
 		const home = homePrefixOf(cwd);
 		if (!home) return cwd;
 		const rest = cwd.slice(home.length); // "" or "/…"
 		if (distinctHomePrefixes().size <= 1) return `~${rest}`;
-		return `~${home === "/root" ? "root" : (home.split("/").pop() ?? "")}${rest}`;
+		const alias = homeAliasOf(home);
+		if (home === "/root" || !collidingHomeAliases().has(alias)) return `~${alias}${rest}`;
+		// Namespace-qualify colliding labels: ~home/root/…, ~Users/alice/….
+		return `~${home.split("/")[1]}/${alias}${rest}`;
 	};
 
 	const [agentTypes] = createResource(

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -240,7 +240,7 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		return new Set([...counts].filter(([, count]) => count > 1).map(([alias]) => alias));
 	});
 
-	const displayCwd = (cwd: string): string => {
+	const candidateLabel = (cwd: string): string => {
 		const home = homePrefixOf(cwd);
 		if (!home) return cwd;
 		const rest = cwd.slice(home.length); // "" or "/…"
@@ -251,12 +251,35 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		return `~${home.split("/")[1]}/${alias}${rest}`;
 	};
 
+	// Labels must be unique — distinct cwds with identical labels would be
+	// indistinguishable in the native popup. Disambiguation covers home-alias
+	// collisions, but crafted names can still duplicate a qualified label (a
+	// user literally named "home": /home/home/alice vs qualified /home/alice).
+	// Any remaining duplicate falls back to the unambiguous full cwd.
+	const displayLabels = createMemo(() => {
+		const labels = new Map<string, string>();
+		for (const root of agentProjectRoots()) labels.set(root, candidateLabel(root));
+		const counts = new Map<string, number>();
+		for (const label of labels.values()) counts.set(label, (counts.get(label) ?? 0) + 1);
+		for (const [root, label] of labels) {
+			if ((counts.get(label) ?? 0) > 1) labels.set(root, root);
+		}
+		return labels;
+	});
+
+	const displayCwd = (cwd: string): string => displayLabels().get(cwd) ?? cwd;
+
 	// Keep the selection reconciled with the fleet: when the selected project
 	// disappears, fall back to global so the select value, title tooltip, and
-	// agentTypes context stay in sync instead of retaining a stale cwd.
+	// agentTypes context stay in sync instead of retaining a stale cwd. Empty
+	// snapshots are tolerated — resync windows and out-of-order refreshes can
+	// transiently report no roots, and the select is hidden while roots are
+	// empty anyway, so a retained selection is neither visible nor harmful.
+	// (General refreshFleet response ordering is tracked separately.)
 	createEffect(() => {
 		const selected = agentContextCwd();
-		if (selected && !agentProjectRoots().includes(selected)) setAgentContextCwd(undefined);
+		const roots = agentProjectRoots();
+		if (selected && roots.length > 0 && !roots.includes(selected)) setAgentContextCwd(undefined);
 	});
 
 	const [agentTypes] = createResource(

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -3,7 +3,17 @@
  * shown verbatim) + paired-devices management + version footer.
  */
 
-import { createMemo, createResource, createSignal, For, type JSX, onCleanup, onMount, Show } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createResource,
+	createSignal,
+	For,
+	type JSX,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
 import type { AgentTypeDto, ModelInfoDto, PairingCodeDto, SettingsDto } from "../../shared/protocol.js";
 import { api } from "../api.js";
 import { Modal, relativeTime, Topbar } from "../components/common.js";
@@ -240,6 +250,14 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		// Namespace-qualify colliding labels: ~home/root/…, ~Users/alice/….
 		return `~${home.split("/")[1]}/${alias}${rest}`;
 	};
+
+	// Keep the selection reconciled with the fleet: when the selected project
+	// disappears, fall back to global so the select value, title tooltip, and
+	// agentTypes context stay in sync instead of retaining a stale cwd.
+	createEffect(() => {
+		const selected = agentContextCwd();
+		if (selected && !agentProjectRoots().includes(selected)) setAgentContextCwd(undefined);
+	});
 
 	const [agentTypes] = createResource(
 		() => ({ settings: settings(), cwd: agentContextCwd() }),

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -300,13 +300,11 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		() => ({ settings: settings(), cwd: agentTypesCwd() }),
 		async ({ cwd }) => {
 			if (!settings()) return [];
-			try {
-				const { agentTypes } = await api.agentTypes(cwd);
-				return agentTypes;
-			} catch (err) {
-				setError(err instanceof Error ? err.message : String(err));
-				return [];
-			}
+			// Failures route through the resource's error state: Solid ignores
+			// superseded fetches entirely (no stale error banners), and the next
+			// successful load clears the error automatically.
+			const { agentTypes } = await api.agentTypes(cwd);
+			return agentTypes;
 		},
 	);
 
@@ -557,8 +555,12 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 									</div>
 								</Show>
 								<Show
-									when={!agentTypes.loading}
-									fallback={<p class="muted small">loading agent definitions…</p>}
+									when={!agentTypes.loading && !agentTypes.error}
+									fallback={
+										<p class="muted small">
+											{agentTypes.error ? "failed to load agent definitions" : "loading agent definitions…"}
+										</p>
+									}
 								>
 									<Show
 										when={(agentTypes() ?? []).length > 0}

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -3,17 +3,7 @@
  * shown verbatim) + paired-devices management + version footer.
  */
 
-import {
-	createEffect,
-	createMemo,
-	createResource,
-	createSignal,
-	For,
-	type JSX,
-	onCleanup,
-	onMount,
-	Show,
-} from "solid-js";
+import { createMemo, createResource, createSignal, For, type JSX, onCleanup, onMount, Show } from "solid-js";
 import type { AgentTypeDto, ModelInfoDto, PairingCodeDto, SettingsDto } from "../../shared/protocol.js";
 import { api } from "../api.js";
 import { Modal, relativeTime, Topbar } from "../components/common.js";
@@ -210,101 +200,17 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		return [...roots].sort((a, b) => a.localeCompare(b));
 	});
 
-	// Home-shaped prefixes collapse for display. Chromium's opened select popup
-	// stays control-width and clips long absolute paths (issue 378), so options
-	// render home-relative and the full cwd moves to the select's title tooltip.
-	// With roots from multiple homes, disambiguate as ~user/path.
-	const homePrefixOf = (cwd: string): string | undefined =>
-		cwd.match(/^\/(?:home|Users)\/[^/]+/)?.[0] ?? (cwd === "/root" || cwd.startsWith("/root/") ? "/root" : undefined);
-
-	const homeAliasOf = (home: string): string => (home === "/root" ? "root" : (home.split("/").pop() ?? ""));
-
-	const distinctHomePrefixes = createMemo(() => {
-		const homes = new Set<string>();
-		for (const root of agentProjectRoots()) {
-			const home = homePrefixOf(root);
-			if (home) homes.add(home);
-		}
-		return homes;
-	});
-
-	// Aliases are not unique across home roots: /root vs /home/root and
-	// /home/alice vs /Users/alice all share a final segment. Detect collisions
-	// so displayCwd can namespace-qualify the affected labels.
-	const collidingHomeAliases = createMemo(() => {
-		const counts = new Map<string, number>();
-		for (const home of distinctHomePrefixes()) {
-			const alias = homeAliasOf(home);
-			counts.set(alias, (counts.get(alias) ?? 0) + 1);
-		}
-		return new Set([...counts].filter(([, count]) => count > 1).map(([alias]) => alias));
-	});
-
-	const candidateLabel = (cwd: string): string => {
-		const home = homePrefixOf(cwd);
-		if (!home) return cwd;
-		const rest = cwd.slice(home.length); // "" or "/…"
-		if (distinctHomePrefixes().size <= 1) return `~${rest}`;
-		const alias = homeAliasOf(home);
-		if (home === "/root" || !collidingHomeAliases().has(alias)) return `~${alias}${rest}`;
-		// Namespace-qualify colliding labels: ~home/root/…, ~Users/alice/….
-		return `~${home.split("/")[1]}/${alias}${rest}`;
-	};
-
-	// Labels must be unique — distinct cwds with identical labels would be
-	// indistinguishable in the native popup. Disambiguation covers home-alias
-	// collisions, but crafted names can still duplicate a qualified label (a
-	// user literally named "home": /home/home/alice vs qualified /home/alice).
-	// Any remaining duplicate falls back to the unambiguous full cwd.
-	const displayLabels = createMemo(() => {
-		const labels = new Map<string, string>();
-		for (const root of agentProjectRoots()) labels.set(root, candidateLabel(root));
-		const counts = new Map<string, number>();
-		for (const label of labels.values()) counts.set(label, (counts.get(label) ?? 0) + 1);
-		for (const [root, label] of labels) {
-			if ((counts.get(label) ?? 0) > 1) labels.set(root, root);
-		}
-		return labels;
-	});
-
-	const displayCwd = (cwd: string): string => displayLabels().get(cwd) ?? cwd;
-
-	// Keep the selection reconciled with the fleet: when the selected project
-	// disappears, fall back to global so the select value, title tooltip, and
-	// agentTypes context stay in sync instead of retaining a stale cwd. Empty
-	// snapshots are tolerated — resync windows and out-of-order refreshes can
-	// transiently report no roots, and the select is hidden while roots are
-	// empty anyway, so a retained selection is neither visible nor harmful.
-	// (General refreshFleet response ordering is tracked separately.)
-	createEffect(() => {
-		const selected = agentContextCwd();
-		const roots = agentProjectRoots();
-		if (selected && roots.length > 0 && !roots.includes(selected)) setAgentContextCwd(undefined);
-	});
-
-	// While the fleet reports no roots, the retained selection is recovery
-	// metadata only: request global/home agent definitions instead of rendering
-	// (and allowing edits to) a project context that is not currently reachable.
-	// When roots repopulate with the project, its definitions return with it.
-	// The membership check also prevents a one-flush stale fetch when a
-	// selection disappears — the reconciliation effect clears the signal, but
-	// the resource source memo runs first and must not emit the old cwd.
-	const agentTypesCwd = () => {
-		const roots = agentProjectRoots();
-		if (roots.length === 0) return undefined;
-		const selected = agentContextCwd();
-		return selected && roots.includes(selected) ? selected : undefined;
-	};
-
 	const [agentTypes] = createResource(
-		() => ({ settings: settings(), cwd: agentTypesCwd() }),
+		() => ({ settings: settings(), cwd: agentContextCwd() }),
 		async ({ cwd }) => {
 			if (!settings()) return [];
-			// Failures route through the resource's error state: Solid ignores
-			// superseded fetches entirely (no stale error banners), and the next
-			// successful load clears the error automatically.
-			const { agentTypes } = await api.agentTypes(cwd);
-			return agentTypes;
+			try {
+				const { agentTypes } = await api.agentTypes(cwd);
+				return agentTypes;
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+				return [];
+			}
 		},
 	);
 
@@ -547,127 +453,116 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 												onChange={(e) => setAgentContextCwd(e.currentTarget.value || undefined)}
 											>
 												<option value="">global/home only</option>
-												<For each={agentProjectRoots()}>
-													{(cwd) => <option value={cwd}>{displayCwd(cwd)}</option>}
-												</For>
+												<For each={agentProjectRoots()}>{(cwd) => <option value={cwd}>{cwd}</option>}</For>
 											</select>
 										</span>
 									</div>
 								</Show>
 								<Show
-									when={!agentTypes.loading && !agentTypes.error}
-									fallback={
-										<p class="muted small">
-											{agentTypes.error ? "failed to load agent definitions" : "loading agent definitions…"}
-										</p>
-									}
+									when={(agentTypes() ?? []).length > 0}
+									fallback={<p class="muted small">No agent definitions found.</p>}
 								>
-									<Show
-										when={(agentTypes() ?? []).length > 0}
-										fallback={<p class="muted small">No agent definitions found.</p>}
-									>
-										<For each={agentTypes() ?? []}>
-											{(agent: AgentTypeDto) => {
-												const fallbackList = () => current().agentModels?.[agent.name] ?? [];
-												return (
-													<div class="agent-model-row">
-														<div class="agent-model-summary">
-															<span class="agent-model-name">{agent.name}</span>
-															<span class="agent-model-description">{agent.description}</span>
-														</div>
-														<div class="agent-model-fallbacks">
+									<For each={agentTypes() ?? []}>
+										{(agent: AgentTypeDto) => {
+											const fallbackList = () => current().agentModels?.[agent.name] ?? [];
+											return (
+												<div class="agent-model-row">
+													<div class="agent-model-summary">
+														<span class="agent-model-name">{agent.name}</span>
+														<span class="agent-model-description">{agent.description}</span>
+													</div>
+													<div class="agent-model-fallbacks">
+														<Show
+															when={fallbackList().length > 0}
+															fallback={<span class="muted small">default</span>}
+														>
+															<For each={fallbackList()}>
+																{(entry, index) => (
+																	<span class="agent-model-chip">
+																		{index() + 1}. {entry}
+																	</span>
+																)}
+															</For>
+														</Show>
+													</div>
+													<button
+														type="button"
+														class="btn btn-small agent-model-edit"
+														onClick={() =>
+															setEditingAgent(editingAgent() === agent.name ? undefined : agent.name)
+														}
+													>
+														{editingAgent() === agent.name ? "done" : "edit"}
+													</button>
+													<Show when={editingAgent() === agent.name}>
+														<div class="agent-model-editor">
 															<Show
 																when={fallbackList().length > 0}
-																fallback={<span class="muted small">default</span>}
+																fallback={<p class="muted small">Using the default model.</p>}
 															>
 																<For each={fallbackList()}>
 																	{(entry, index) => (
-																		<span class="agent-model-chip">
-																			{index() + 1}. {entry}
-																		</span>
+																		<div class="agent-model-entry">
+																			<span>{entry}</span>
+																			<div class="agent-model-entry-actions">
+																				<button
+																					type="button"
+																					class="btn btn-small"
+																					disabled={index() === 0}
+																					onClick={() =>
+																						void saveAgentModels(
+																							agent.name,
+																							moveItem(fallbackList(), index(), -1),
+																						)
+																					}
+																				>
+																					↑
+																				</button>
+																				<button
+																					type="button"
+																					class="btn btn-small"
+																					disabled={index() === fallbackList().length - 1}
+																					onClick={() =>
+																						void saveAgentModels(
+																							agent.name,
+																							moveItem(fallbackList(), index(), 1),
+																						)
+																					}
+																				>
+																					↓
+																				</button>
+																				<button
+																					type="button"
+																					class="btn btn-small"
+																					onClick={() =>
+																						void saveAgentModels(
+																							agent.name,
+																							fallbackList().filter((_, i) => i !== index()),
+																						)
+																					}
+																				>
+																					×
+																				</button>
+																			</div>
+																		</div>
 																	)}
 																</For>
 															</Show>
+															<button
+																type="button"
+																class="btn btn-small"
+																onClick={() =>
+																	setModelPickerTarget({ kind: "agent", agentName: agent.name })
+																}
+															>
+																add model…
+															</button>
 														</div>
-														<button
-															type="button"
-															class="btn btn-small agent-model-edit"
-															onClick={() =>
-																setEditingAgent(editingAgent() === agent.name ? undefined : agent.name)
-															}
-														>
-															{editingAgent() === agent.name ? "done" : "edit"}
-														</button>
-														<Show when={editingAgent() === agent.name}>
-															<div class="agent-model-editor">
-																<Show
-																	when={fallbackList().length > 0}
-																	fallback={<p class="muted small">Using the default model.</p>}
-																>
-																	<For each={fallbackList()}>
-																		{(entry, index) => (
-																			<div class="agent-model-entry">
-																				<span>{entry}</span>
-																				<div class="agent-model-entry-actions">
-																					<button
-																						type="button"
-																						class="btn btn-small"
-																						disabled={index() === 0}
-																						onClick={() =>
-																							void saveAgentModels(
-																								agent.name,
-																								moveItem(fallbackList(), index(), -1),
-																							)
-																						}
-																					>
-																						↑
-																					</button>
-																					<button
-																						type="button"
-																						class="btn btn-small"
-																						disabled={index() === fallbackList().length - 1}
-																						onClick={() =>
-																							void saveAgentModels(
-																								agent.name,
-																								moveItem(fallbackList(), index(), 1),
-																							)
-																						}
-																					>
-																						↓
-																					</button>
-																					<button
-																						type="button"
-																						class="btn btn-small"
-																						onClick={() =>
-																							void saveAgentModels(
-																								agent.name,
-																								fallbackList().filter((_, i) => i !== index()),
-																							)
-																						}
-																					>
-																						×
-																					</button>
-																				</div>
-																			</div>
-																		)}
-																	</For>
-																</Show>
-																<button
-																	type="button"
-																	class="btn btn-small"
-																	onClick={() =>
-																		setModelPickerTarget({ kind: "agent", agentName: agent.name })
-																	}
-																>
-																	add model…
-																</button>
-															</div>
-														</Show>
-													</div>
-												);
-											}}
-										</For>
-									</Show>
+													</Show>
+												</div>
+											);
+										}}
+									</For>
 								</Show>
 							</section>
 

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -200,6 +200,30 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 		return [...roots].sort((a, b) => a.localeCompare(b));
 	});
 
+	// Home-shaped prefixes collapse for display. Chromium's opened select popup
+	// stays control-width and clips long absolute paths (issue 378), so options
+	// render home-relative and the full cwd moves to the select's title tooltip.
+	// With roots from multiple homes, disambiguate as ~user/path.
+	const homePrefixOf = (cwd: string): string | undefined =>
+		cwd.match(/^\/(?:home|Users)\/[^/]+/)?.[0] ?? (cwd === "/root" || cwd.startsWith("/root/") ? "/root" : undefined);
+
+	const distinctHomePrefixes = createMemo(() => {
+		const homes = new Set<string>();
+		for (const root of agentProjectRoots()) {
+			const home = homePrefixOf(root);
+			if (home) homes.add(home);
+		}
+		return homes;
+	});
+
+	const displayCwd = (cwd: string): string => {
+		const home = homePrefixOf(cwd);
+		if (!home) return cwd;
+		const rest = cwd.slice(home.length); // "" or "/…"
+		if (distinctHomePrefixes().size <= 1) return `~${rest}`;
+		return `~${home === "/root" ? "root" : (home.split("/").pop() ?? "")}${rest}`;
+	};
+
 	const [agentTypes] = createResource(
 		() => ({ settings: settings(), cwd: agentContextCwd() }),
 		async ({ cwd }) => {
@@ -449,10 +473,13 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 										<span class="setting-control">
 											<select
 												value={agentContextCwd() ?? ""}
+												title={agentContextCwd() ?? "global/home only"}
 												onChange={(e) => setAgentContextCwd(e.currentTarget.value || undefined)}
 											>
 												<option value="">global/home only</option>
-												<For each={agentProjectRoots()}>{(cwd) => <option value={cwd}>{cwd}</option>}</For>
+												<For each={agentProjectRoots()}>
+													{(cwd) => <option value={cwd}>{displayCwd(cwd)}</option>}
+												</For>
 											</select>
 										</span>
 									</div>

--- a/packages/dashboard/src/client/screens/settings.tsx
+++ b/packages/dashboard/src/client/screens/settings.tsx
@@ -286,7 +286,15 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 	// metadata only: request global/home agent definitions instead of rendering
 	// (and allowing edits to) a project context that is not currently reachable.
 	// When roots repopulate with the project, its definitions return with it.
-	const agentTypesCwd = () => (agentProjectRoots().length === 0 ? undefined : agentContextCwd());
+	// The membership check also prevents a one-flush stale fetch when a
+	// selection disappears — the reconciliation effect clears the signal, but
+	// the resource source memo runs first and must not emit the old cwd.
+	const agentTypesCwd = () => {
+		const roots = agentProjectRoots();
+		if (roots.length === 0) return undefined;
+		const selected = agentContextCwd();
+		return selected && roots.includes(selected) ? selected : undefined;
+	};
 
 	const [agentTypes] = createResource(
 		() => ({ settings: settings(), cwd: agentTypesCwd() }),
@@ -549,110 +557,115 @@ export function SettingsScreen(props: { store: AppStore }): JSX.Element {
 									</div>
 								</Show>
 								<Show
-									when={(agentTypes() ?? []).length > 0}
-									fallback={<p class="muted small">No agent definitions found.</p>}
+									when={!agentTypes.loading}
+									fallback={<p class="muted small">loading agent definitions…</p>}
 								>
-									<For each={agentTypes() ?? []}>
-										{(agent: AgentTypeDto) => {
-											const fallbackList = () => current().agentModels?.[agent.name] ?? [];
-											return (
-												<div class="agent-model-row">
-													<div class="agent-model-summary">
-														<span class="agent-model-name">{agent.name}</span>
-														<span class="agent-model-description">{agent.description}</span>
-													</div>
-													<div class="agent-model-fallbacks">
-														<Show
-															when={fallbackList().length > 0}
-															fallback={<span class="muted small">default</span>}
-														>
-															<For each={fallbackList()}>
-																{(entry, index) => (
-																	<span class="agent-model-chip">
-																		{index() + 1}. {entry}
-																	</span>
-																)}
-															</For>
-														</Show>
-													</div>
-													<button
-														type="button"
-														class="btn btn-small agent-model-edit"
-														onClick={() =>
-															setEditingAgent(editingAgent() === agent.name ? undefined : agent.name)
-														}
-													>
-														{editingAgent() === agent.name ? "done" : "edit"}
-													</button>
-													<Show when={editingAgent() === agent.name}>
-														<div class="agent-model-editor">
+									<Show
+										when={(agentTypes() ?? []).length > 0}
+										fallback={<p class="muted small">No agent definitions found.</p>}
+									>
+										<For each={agentTypes() ?? []}>
+											{(agent: AgentTypeDto) => {
+												const fallbackList = () => current().agentModels?.[agent.name] ?? [];
+												return (
+													<div class="agent-model-row">
+														<div class="agent-model-summary">
+															<span class="agent-model-name">{agent.name}</span>
+															<span class="agent-model-description">{agent.description}</span>
+														</div>
+														<div class="agent-model-fallbacks">
 															<Show
 																when={fallbackList().length > 0}
-																fallback={<p class="muted small">Using the default model.</p>}
+																fallback={<span class="muted small">default</span>}
 															>
 																<For each={fallbackList()}>
 																	{(entry, index) => (
-																		<div class="agent-model-entry">
-																			<span>{entry}</span>
-																			<div class="agent-model-entry-actions">
-																				<button
-																					type="button"
-																					class="btn btn-small"
-																					disabled={index() === 0}
-																					onClick={() =>
-																						void saveAgentModels(
-																							agent.name,
-																							moveItem(fallbackList(), index(), -1),
-																						)
-																					}
-																				>
-																					↑
-																				</button>
-																				<button
-																					type="button"
-																					class="btn btn-small"
-																					disabled={index() === fallbackList().length - 1}
-																					onClick={() =>
-																						void saveAgentModels(
-																							agent.name,
-																							moveItem(fallbackList(), index(), 1),
-																						)
-																					}
-																				>
-																					↓
-																				</button>
-																				<button
-																					type="button"
-																					class="btn btn-small"
-																					onClick={() =>
-																						void saveAgentModels(
-																							agent.name,
-																							fallbackList().filter((_, i) => i !== index()),
-																						)
-																					}
-																				>
-																					×
-																				</button>
-																			</div>
-																		</div>
+																		<span class="agent-model-chip">
+																			{index() + 1}. {entry}
+																		</span>
 																	)}
 																</For>
 															</Show>
-															<button
-																type="button"
-																class="btn btn-small"
-																onClick={() =>
-																	setModelPickerTarget({ kind: "agent", agentName: agent.name })
-																}
-															>
-																add model…
-															</button>
 														</div>
-													</Show>
-												</div>
-											);
-										}}
-									</For>
+														<button
+															type="button"
+															class="btn btn-small agent-model-edit"
+															onClick={() =>
+																setEditingAgent(editingAgent() === agent.name ? undefined : agent.name)
+															}
+														>
+															{editingAgent() === agent.name ? "done" : "edit"}
+														</button>
+														<Show when={editingAgent() === agent.name}>
+															<div class="agent-model-editor">
+																<Show
+																	when={fallbackList().length > 0}
+																	fallback={<p class="muted small">Using the default model.</p>}
+																>
+																	<For each={fallbackList()}>
+																		{(entry, index) => (
+																			<div class="agent-model-entry">
+																				<span>{entry}</span>
+																				<div class="agent-model-entry-actions">
+																					<button
+																						type="button"
+																						class="btn btn-small"
+																						disabled={index() === 0}
+																						onClick={() =>
+																							void saveAgentModels(
+																								agent.name,
+																								moveItem(fallbackList(), index(), -1),
+																							)
+																						}
+																					>
+																						↑
+																					</button>
+																					<button
+																						type="button"
+																						class="btn btn-small"
+																						disabled={index() === fallbackList().length - 1}
+																						onClick={() =>
+																							void saveAgentModels(
+																								agent.name,
+																								moveItem(fallbackList(), index(), 1),
+																							)
+																						}
+																					>
+																						↓
+																					</button>
+																					<button
+																						type="button"
+																						class="btn btn-small"
+																						onClick={() =>
+																							void saveAgentModels(
+																								agent.name,
+																								fallbackList().filter((_, i) => i !== index()),
+																							)
+																						}
+																					>
+																						×
+																					</button>
+																				</div>
+																			</div>
+																		)}
+																	</For>
+																</Show>
+																<button
+																	type="button"
+																	class="btn btn-small"
+																	onClick={() =>
+																		setModelPickerTarget({ kind: "agent", agentName: agent.name })
+																	}
+																>
+																	add model…
+																</button>
+															</div>
+														</Show>
+													</div>
+												);
+											}}
+										</For>
+									</Show>
 								</Show>
 							</section>
 

--- a/packages/dashboard/src/client/styles/app.css
+++ b/packages/dashboard/src/client/styles/app.css
@@ -1609,6 +1609,18 @@ details.thinking .thinking-body {
 	color: var(--muted);
 }
 
+.setting-control {
+	min-width: 0;
+	max-width: 100%;
+}
+
+/* The agent context select holds absolute project paths (unbounded intrinsic
+   width). Let the control absorb all flex shrinkage so the label's primary
+   text never wraps; the select clips its value instead. */
+.agent-context-row .setting-label {
+	flex-shrink: 0;
+}
+
 .setting-control select,
 .setting-control input {
 	border: var(--hairline);
@@ -1618,6 +1630,7 @@ details.thinking .thinking-body {
 	font-family: inherit;
 	font-size: var(--fs-secondary);
 	padding: 2px var(--space-2);
+	max-width: 100%;
 }
 
 .checkbox-control {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1550,6 +1550,15 @@ describe("screen smoke tests", () => {
 		return [...el.querySelectorAll(".agent-context-row select option")].map((option) => option.textContent ?? "");
 	};
 
+	// Order-free multi-root assertion: localeCompare collation of mixed-case
+	// prefixes is ICU-dependent, so only membership (plus exact count) is pinned.
+	const expectAgentContextOptions = async (cwds: string[], expected: string[]) => {
+		const options = await agentContextOptionTexts(cwds);
+		expect(options).toHaveLength(expected.length + 1);
+		expect(options[0]).toBe("global/home only");
+		expect(options.slice(1)).toEqual(expect.arrayContaining(expected));
+	};
+
 	it("settings agent context select renders home-relative options with full-path values and tooltip", async () => {
 		vi.mocked(api.fleet).mockResolvedValue({
 			runtimes: [
@@ -1611,19 +1620,58 @@ describe("screen smoke tests", () => {
 
 	it("settings agent context select namespace-qualifies colliding home labels", async () => {
 		// Same-OS collision: /root and /home/root share the alias "root".
-		const rootCollision = await agentContextOptionTexts(["/root/project", "/home/root/project"]);
-		expect(rootCollision).toHaveLength(3);
-		expect(rootCollision.slice(1)).toEqual(expect.arrayContaining(["~root/project", "~home/root/project"]));
+		await expectAgentContextOptions(["/root/project", "/home/root/project"], ["~root/project", "~home/root/project"]);
 
 		// Cross-namespace same-username collision: /home/alice vs /Users/alice.
-		const userCollision = await agentContextOptionTexts(["/home/alice/x", "/Users/alice/x"]);
-		expect(userCollision).toHaveLength(3);
-		expect(userCollision.slice(1)).toEqual(expect.arrayContaining(["~home/alice/x", "~Users/alice/x"]));
+		await expectAgentContextOptions(["/home/alice/x", "/Users/alice/x"], ["~home/alice/x", "~Users/alice/x"]);
 
 		// Distinct usernames across namespaces stay short — no qualification.
-		const noCollision = await agentContextOptionTexts(["/home/alice/x", "/Users/bob/y"]);
-		expect(noCollision).toHaveLength(3);
-		expect(noCollision.slice(1)).toEqual(expect.arrayContaining(["~alice/x", "~bob/y"]));
+		await expectAgentContextOptions(["/home/alice/x", "/Users/bob/y"], ["~alice/x", "~bob/y"]);
+
+		// The special root alias against the generic Users path.
+		await expectAgentContextOptions(["/root/x", "/Users/root/x"], ["~root/x", "~Users/root/x"]);
+
+		// Three-way collision: every label stays unique.
+		await expectAgentContextOptions(
+			["/root/p", "/home/root/p", "/Users/root/p"],
+			["~root/p", "~home/root/p", "~Users/root/p"],
+		);
+
+		// Selective qualification: only colliding aliases qualify; non-colliders stay short.
+		await expectAgentContextOptions(
+			["/home/alice/x", "/Users/alice/x", "/home/bob/y"],
+			["~home/alice/x", "~Users/alice/x", "~bob/y"],
+		);
+	});
+
+	it("settings agent context selection resets to global when its cwd leaves the fleet", async () => {
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		select.value = "/home/test/project-alpha";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(select.getAttribute("title")).toBe("/home/test/project-alpha");
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+
+		// The selected project disappears from the fleet: the select, tooltip,
+		// and agentTypes context must all fall back to global rather than go stale.
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("b", "/home/test/project-beta")],
+			diskSessions: [],
+		});
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(select.value).toBe("");
+		expect(select.getAttribute("title")).toBe("global/home only");
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
 	});
 
 	it("settings rows keep the structure the browser layout harness mirrors", async () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1730,6 +1730,85 @@ describe("screen smoke tests", () => {
 		expect([...el.querySelectorAll(".agent-model-name")].map((node) => node.textContent)).toEqual(["GlobalAgent"]);
 	});
 
+	it("settings shows the loading placeholder until the initial agent definitions load", async () => {
+		let resolveDefinitions: ((value: { agentTypes: { name: string; description: string }[] }) => void) | undefined;
+		vi.mocked(api.agentTypes).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveDefinitions = resolve;
+				}),
+		);
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(el.textContent).toContain("loading agent definitions");
+		expect(el.querySelector(".agent-model-name")).toBeNull();
+
+		resolveDefinitions!({ agentTypes: [{ name: "GlobalAgent", description: "global definition" }] });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).not.toContain("loading agent definitions");
+		expect([...el.querySelectorAll(".agent-model-name")].map((node) => node.textContent)).toEqual(["GlobalAgent"]);
+	});
+
+	it("settings shows the empty fallback when no agent definitions exist", async () => {
+		// Default mock resolves an empty list.
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(el.textContent).toContain("No agent definitions found.");
+		expect(el.querySelector(".agent-model-name")).toBeNull();
+	});
+
+	it("settings ignores superseded agent definition failures and surfaces current ones", async () => {
+		let rejectStaleGlobal: ((err: Error) => void) | undefined;
+		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => {
+			if (cwd === undefined) {
+				return new Promise((_, reject) => {
+					rejectStaleGlobal = reject;
+				});
+			}
+			return { agentTypes: [{ name: "ProjectAgent", description: "project-local definition" }] };
+		});
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/test/project-alpha")],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Select the project: its definitions load while the initial global
+		// fetch is still in flight (superseded).
+		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		select.value = "/home/test/project-alpha";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).toContain("ProjectAgent");
+
+		// The superseded fetch rejects: no error surfaces, current definitions
+		// are undisturbed — failures route through the resource's error state,
+		// which Solid only tracks for the latest request.
+		rejectStaleGlobal!(new Error("stale global failure"));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).not.toContain("failed to load agent definitions");
+		expect(el.querySelector(".settings-error")).toBeNull();
+		expect(el.textContent).toContain("ProjectAgent");
+	});
+
+	it("settings surfaces a failed agent definitions load", async () => {
+		vi.mocked(api.agentTypes).mockRejectedValue(new Error("boom"));
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(el.textContent).toContain("failed to load agent definitions");
+		expect(el.querySelector(".agent-model-name")).toBeNull();
+	});
+
 	it("settings agent context selection survives a transient empty fleet", async () => {
 		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => ({
 			agentTypes: cwd

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1671,6 +1671,9 @@ describe("screen smoke tests", () => {
 
 		// The selected project disappears from the fleet: the select, tooltip,
 		// and agentTypes context must all fall back to global rather than go stale.
+		const alphaCallsBefore = vi
+			.mocked(api.agentTypes)
+			.mock.calls.filter((call) => call[0] === "/home/test/project-alpha").length;
 		vi.mocked(api.fleet).mockResolvedValue({
 			runtimes: [runtimeAt("b", "/home/test/project-beta")],
 			diskSessions: [],
@@ -1680,6 +1683,51 @@ describe("screen smoke tests", () => {
 		expect(select.value).toBe("");
 		expect(select.getAttribute("title")).toBe("global/home only");
 		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
+		// No stale project fetch may fire in the transition flush — the source
+		// membership check prevents it before the reconciliation effect runs.
+		expect(vi.mocked(api.agentTypes).mock.calls.filter((call) => call[0] === "/home/test/project-alpha").length).toBe(
+			alphaCallsBefore,
+		);
+	});
+
+	it("settings agent definitions gate on loading while the context refetches", async () => {
+		let resolveGlobal: ((value: { agentTypes: { name: string; description: string }[] }) => void) | undefined;
+		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => {
+			if (cwd === undefined) {
+				return new Promise((resolve) => {
+					resolveGlobal = resolve;
+				});
+			}
+			return { agentTypes: [{ name: "ProjectAgent", description: "project-local definition" }] };
+		});
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		select.value = "/home/test/project-alpha";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).toContain("ProjectAgent");
+
+		// Roots empty and the global refetch is in flight: the stale project
+		// rows (and their edit controls) must NOT remain on screen — a resource
+		// keeps its previous value while refreshing, so the gate is what hides them.
+		vi.mocked(api.fleet).mockResolvedValue({ runtimes: [], diskSessions: [] });
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).toContain("loading agent definitions");
+		expect(el.querySelector(".agent-model-name")).toBeNull();
+
+		resolveGlobal!({ agentTypes: [{ name: "GlobalAgent", description: "global definition" }] });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.textContent).not.toContain("loading agent definitions");
+		expect([...el.querySelectorAll(".agent-model-name")].map((node) => node.textContent)).toEqual(["GlobalAgent"]);
 	});
 
 	it("settings agent context selection survives a transient empty fleet", async () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1518,54 +1518,28 @@ describe("screen smoke tests", () => {
 		expect(el.textContent).toContain("TUI-only settings");
 	});
 
-	const runtimeAt = (key: string, cwd: string) => ({
-		key,
-		cwd,
-		state: {
-			sessionId: key,
-			thinkingLevel: "off" as const,
-			isStreaming: false,
-			isCompacting: false,
-			steeringMode: "all" as const,
-			followUpMode: "all" as const,
-			autoCompactionEnabled: true,
-			messageCount: 0,
-			pendingMessageCount: 0,
-		},
-		backgroundAgents: [],
-		needsAttention: false,
-		createdAt: new Date().toISOString(),
-		lastActivity: new Date().toISOString(),
-	});
-
-	const agentContextOptionTexts = async (cwds: string[]): Promise<string[]> => {
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: cwds.map((cwd, index) => runtimeAt(`k${index}`, cwd)),
-			diskSessions: [],
+	it("settings agent context select carries full path values with a full-path tooltip", async () => {
+		const runtimeAt = (key: string, cwd: string) => ({
+			key,
+			cwd,
+			state: {
+				sessionId: key,
+				thinkingLevel: "off" as const,
+				isStreaming: false,
+				isCompacting: false,
+				steeringMode: "all" as const,
+				followUpMode: "all" as const,
+				autoCompactionEnabled: true,
+				messageCount: 0,
+				pendingMessageCount: 0,
+			},
+			backgroundAgents: [],
+			needsAttention: false,
+			createdAt: new Date().toISOString(),
+			lastActivity: new Date().toISOString(),
 		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		return [...el.querySelectorAll(".agent-context-row select option")].map((option) => option.textContent ?? "");
-	};
-
-	// Order-free multi-root assertion: localeCompare collation of mixed-case
-	// prefixes is ICU-dependent, so only membership (plus exact count) is pinned.
-	const expectAgentContextOptions = async (cwds: string[], expected: string[]) => {
-		const options = await agentContextOptionTexts(cwds);
-		expect(options).toHaveLength(expected.length + 1);
-		expect(options[0]).toBe("global/home only");
-		expect(options.slice(1)).toEqual(expect.arrayContaining(expected));
-	};
-
-	it("settings agent context select renders home-relative options with full-path values and tooltip", async () => {
 		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [
-				runtimeAt("a", "/home/test/project-beta"),
-				runtimeAt("b", "/home/test/project-alpha"),
-				runtimeAt("c", "/opt/shared"),
-			],
+			runtimes: [runtimeAt("a", "/home/test/project-beta"), runtimeAt("b", "/home/test/project-alpha")],
 			diskSessions: [],
 		});
 		const store = makeStore();
@@ -1573,311 +1547,25 @@ describe("screen smoke tests", () => {
 		await store.refreshFleet();
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
+		// Options display the full absolute cwd (no display transformation) and
+		// the closed control exposes it on hover via the title tooltip.
 		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		expect(select).toBeTruthy();
 		const options = [...select.querySelectorAll("option")];
-		// Sorted by full cwd; display text is home-relative, values stay absolute.
 		expect(options.map((option) => option.textContent)).toEqual([
 			"global/home only",
-			"~/project-alpha",
-			"~/project-beta",
-			"/opt/shared",
+			"/home/test/project-alpha",
+			"/home/test/project-beta",
 		]);
 		expect(options.map((option) => option.value)).toEqual([
 			"",
 			"/home/test/project-alpha",
 			"/home/test/project-beta",
-			"/opt/shared",
 		]);
-		// Tooltip exposes the full path of the current selection.
 		expect(select.getAttribute("title")).toBe("global/home only");
 		select.value = "/home/test/project-alpha";
 		select.dispatchEvent(new Event("change", { bubbles: true }));
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		expect(select.getAttribute("title")).toBe("/home/test/project-alpha");
-	});
-
-	it("settings agent context select disambiguates multiple home prefixes as ~user", async () => {
-		expect(await agentContextOptionTexts(["/home/alice/x", "/home/bob/y"])).toEqual([
-			"global/home only",
-			"~alice/x",
-			"~bob/y",
-		]);
-	});
-
-	it("settings agent context select collapses /root and /Users home prefixes", async () => {
-		// Single-home cases collapse to ~/… exactly like /home does.
-		expect(await agentContextOptionTexts(["/root/project"])).toEqual(["global/home only", "~/project"]);
-		expect(await agentContextOptionTexts(["/root"])).toEqual(["global/home only", "~"]);
-		expect(await agentContextOptionTexts(["/Users/alice/tools"])).toEqual(["global/home only", "~/tools"]);
-		// Mixed home roots disambiguate every root as ~user/… (order assertion-free:
-		// localeCompare collation of mixed-case prefixes is ICU-dependent).
-		const mixed = await agentContextOptionTexts(["/root/a", "/home/bob/b", "/Users/carol/c"]);
-		expect(mixed).toHaveLength(4);
-		expect(mixed[0]).toBe("global/home only");
-		expect(mixed.slice(1)).toEqual(expect.arrayContaining(["~root/a", "~bob/b", "~carol/c"]));
-	});
-
-	it("settings agent context select namespace-qualifies colliding home labels", async () => {
-		// Same-OS collision: /root and /home/root share the alias "root".
-		await expectAgentContextOptions(["/root/project", "/home/root/project"], ["~root/project", "~home/root/project"]);
-
-		// Cross-namespace same-username collision: /home/alice vs /Users/alice.
-		await expectAgentContextOptions(["/home/alice/x", "/Users/alice/x"], ["~home/alice/x", "~Users/alice/x"]);
-
-		// Distinct usernames across namespaces stay short — no qualification.
-		await expectAgentContextOptions(["/home/alice/x", "/Users/bob/y"], ["~alice/x", "~bob/y"]);
-
-		// The special root alias against the generic Users path.
-		await expectAgentContextOptions(["/root/x", "/Users/root/x"], ["~root/x", "~Users/root/x"]);
-
-		// Three-way collision: every label stays unique.
-		await expectAgentContextOptions(
-			["/root/p", "/home/root/p", "/Users/root/p"],
-			["~root/p", "~home/root/p", "~Users/root/p"],
-		);
-
-		// Selective qualification: only colliding aliases qualify; non-colliders stay short.
-		await expectAgentContextOptions(
-			["/home/alice/x", "/Users/alice/x", "/home/bob/y"],
-			["~home/alice/x", "~Users/alice/x", "~bob/y"],
-		);
-
-		// Crafted username matching a namespace segment: /home/home/alice's
-		// natural label would duplicate the qualified /home/alice label, so both
-		// fall back to the unambiguous full cwd. Uninvolved labels stay short.
-		await expectAgentContextOptions(
-			["/home/alice/x", "/Users/alice/x", "/home/home/alice/x"],
-			["~Users/alice/x", "/home/alice/x", "/home/home/alice/x"],
-		);
-	});
-
-	it("settings agent context selection resets to global when its cwd leaves the fleet", async () => {
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
-			diskSessions: [],
-		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		select.value = "/home/test/project-alpha";
-		select.dispatchEvent(new Event("change", { bubbles: true }));
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(select.getAttribute("title")).toBe("/home/test/project-alpha");
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
-
-		// The selected project disappears from the fleet: the select, tooltip,
-		// and agentTypes context must all fall back to global rather than go stale.
-		const alphaCallsBefore = vi
-			.mocked(api.agentTypes)
-			.mock.calls.filter((call) => call[0] === "/home/test/project-alpha").length;
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("b", "/home/test/project-beta")],
-			diskSessions: [],
-		});
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(select.value).toBe("");
-		expect(select.getAttribute("title")).toBe("global/home only");
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
-		// No stale project fetch may fire in the transition flush — the source
-		// membership check prevents it before the reconciliation effect runs.
-		expect(vi.mocked(api.agentTypes).mock.calls.filter((call) => call[0] === "/home/test/project-alpha").length).toBe(
-			alphaCallsBefore,
-		);
-	});
-
-	it("settings agent definitions gate on loading while the context refetches", async () => {
-		let resolveGlobal: ((value: { agentTypes: { name: string; description: string }[] }) => void) | undefined;
-		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => {
-			if (cwd === undefined) {
-				return new Promise((resolve) => {
-					resolveGlobal = resolve;
-				});
-			}
-			return { agentTypes: [{ name: "ProjectAgent", description: "project-local definition" }] };
-		});
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
-			diskSessions: [],
-		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		select.value = "/home/test/project-alpha";
-		select.dispatchEvent(new Event("change", { bubbles: true }));
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).toContain("ProjectAgent");
-
-		// Roots empty and the global refetch is in flight: the stale project
-		// rows (and their edit controls) must NOT remain on screen — a resource
-		// keeps its previous value while refreshing, so the gate is what hides them.
-		vi.mocked(api.fleet).mockResolvedValue({ runtimes: [], diskSessions: [] });
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).toContain("loading agent definitions");
-		expect(el.querySelector(".agent-model-name")).toBeNull();
-
-		resolveGlobal!({ agentTypes: [{ name: "GlobalAgent", description: "global definition" }] });
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).not.toContain("loading agent definitions");
-		expect([...el.querySelectorAll(".agent-model-name")].map((node) => node.textContent)).toEqual(["GlobalAgent"]);
-	});
-
-	it("settings shows the loading placeholder until the initial agent definitions load", async () => {
-		let resolveDefinitions: ((value: { agentTypes: { name: string; description: string }[] }) => void) | undefined;
-		vi.mocked(api.agentTypes).mockImplementation(
-			() =>
-				new Promise((resolve) => {
-					resolveDefinitions = resolve;
-				}),
-		);
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		expect(el.textContent).toContain("loading agent definitions");
-		expect(el.querySelector(".agent-model-name")).toBeNull();
-
-		resolveDefinitions!({ agentTypes: [{ name: "GlobalAgent", description: "global definition" }] });
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).not.toContain("loading agent definitions");
-		expect([...el.querySelectorAll(".agent-model-name")].map((node) => node.textContent)).toEqual(["GlobalAgent"]);
-	});
-
-	it("settings shows the empty fallback when no agent definitions exist", async () => {
-		// Default mock resolves an empty list.
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		expect(el.textContent).toContain("No agent definitions found.");
-		expect(el.querySelector(".agent-model-name")).toBeNull();
-	});
-
-	it("settings ignores superseded agent definition failures and surfaces current ones", async () => {
-		let rejectStaleGlobal: ((err: Error) => void) | undefined;
-		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => {
-			if (cwd === undefined) {
-				return new Promise((_, reject) => {
-					rejectStaleGlobal = reject;
-				});
-			}
-			return { agentTypes: [{ name: "ProjectAgent", description: "project-local definition" }] };
-		});
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project-alpha")],
-			diskSessions: [],
-		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		// Select the project: its definitions load while the initial global
-		// fetch is still in flight (superseded).
-		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		select.value = "/home/test/project-alpha";
-		select.dispatchEvent(new Event("change", { bubbles: true }));
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).toContain("ProjectAgent");
-
-		// The superseded fetch rejects: no error surfaces, current definitions
-		// are undisturbed — failures route through the resource's error state,
-		// which Solid only tracks for the latest request.
-		rejectStaleGlobal!(new Error("stale global failure"));
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.textContent).not.toContain("failed to load agent definitions");
-		expect(el.querySelector(".settings-error")).toBeNull();
-		expect(el.textContent).toContain("ProjectAgent");
-	});
-
-	it("settings surfaces a failed agent definitions load", async () => {
-		vi.mocked(api.agentTypes).mockRejectedValue(new Error("boom"));
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		expect(el.textContent).toContain("failed to load agent definitions");
-		expect(el.querySelector(".agent-model-name")).toBeNull();
-	});
-
-	it("settings agent context selection survives a transient empty fleet", async () => {
-		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => ({
-			agentTypes: cwd
-				? [{ name: "ProjectAgent", description: "project-local definition" }]
-				: [{ name: "GlobalAgent", description: "global definition" }],
-		}));
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
-			diskSessions: [],
-		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		select.value = "/home/test/project-alpha";
-		select.dispatchEvent(new Event("change", { bubbles: true }));
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
-		expect(el.textContent).toContain("ProjectAgent");
-
-		// Transient empty snapshot (resync window / out-of-order refresh): the
-		// select hides and the selection is RETAINED as recovery metadata, but
-		// the rendered definitions fall back to global — a stale project context
-		// must not stay visible or editable while its roots are gone.
-		vi.mocked(api.fleet).mockResolvedValue({ runtimes: [], diskSessions: [] });
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(el.querySelector(".agent-context-row select")).toBeNull();
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
-		expect(el.textContent).toContain("GlobalAgent");
-		expect(el.textContent).not.toContain("ProjectAgent");
-
-		// Fleet repopulates with the project still present: selection and its
-		// project-local definitions return together.
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
-			diskSessions: [],
-		});
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		const restored = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
-		expect(restored.value).toBe("/home/test/project-alpha");
-		expect(restored.getAttribute("title")).toBe("/home/test/project-alpha");
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
-		expect(el.textContent).toContain("ProjectAgent");
-	});
-
-	it("settings rows keep the structure the browser layout harness mirrors", async () => {
-		// settings-layout.browser.test.ts measures a static fixture of this markup.
-		// If any selector asserted here drifts in production, update that harness too.
-		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/test/project")],
-			diskSessions: [],
-		});
-		const store = makeStore();
-		const el = mount(() => <SettingsScreen store={store} />);
-		await store.refreshFleet();
-		await new Promise((resolve) => setTimeout(resolve, 10));
-
-		const row = el.querySelector(".setting-row.agent-context-row")!;
-		expect(row.querySelector(".setting-label .name")).toBeTruthy();
-		expect(row.querySelector(".setting-label .hint")).toBeTruthy();
-		expect(row.querySelector(".setting-control select[title]")).toBeTruthy();
-		// Short-control rows (other selects) and checkbox rows share the same
-		// .setting-row/.setting-control structure the harness exercises.
-		expect(el.querySelectorAll(".setting-row .setting-control select").length).toBeGreaterThan(1);
-		expect(el.querySelector(".setting-control .checkbox-control input[type=checkbox]")).toBeTruthy();
 	});
 
 	it("pairing renders the PIN flow with both security copy blocks", () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1642,6 +1642,14 @@ describe("screen smoke tests", () => {
 			["/home/alice/x", "/Users/alice/x", "/home/bob/y"],
 			["~home/alice/x", "~Users/alice/x", "~bob/y"],
 		);
+
+		// Crafted username matching a namespace segment: /home/home/alice's
+		// natural label would duplicate the qualified /home/alice label, so both
+		// fall back to the unambiguous full cwd. Uninvolved labels stay short.
+		await expectAgentContextOptions(
+			["/home/alice/x", "/Users/alice/x", "/home/home/alice/x"],
+			["~Users/alice/x", "/home/alice/x", "/home/home/alice/x"],
+		);
 	});
 
 	it("settings agent context selection resets to global when its cwd leaves the fleet", async () => {
@@ -1672,6 +1680,42 @@ describe("screen smoke tests", () => {
 		expect(select.value).toBe("");
 		expect(select.getAttribute("title")).toBe("global/home only");
 		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
+	});
+
+	it("settings agent context selection survives a transient empty fleet", async () => {
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		select.value = "/home/test/project-alpha";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+
+		// Transient empty snapshot (resync window / out-of-order refresh): the
+		// select hides with no roots, but the selection must NOT be reset.
+		vi.mocked(api.fleet).mockResolvedValue({ runtimes: [], diskSessions: [] });
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(el.querySelector(".agent-context-row select")).toBeNull();
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+
+		// Fleet repopulates with the project still present: selection intact.
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
+			diskSessions: [],
+		});
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		const restored = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		expect(restored.value).toBe("/home/test/project-alpha");
+		expect(restored.getAttribute("title")).toBe("/home/test/project-alpha");
 	});
 
 	it("settings rows keep the structure the browser layout harness mirrors", async () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1683,6 +1683,11 @@ describe("screen smoke tests", () => {
 	});
 
 	it("settings agent context selection survives a transient empty fleet", async () => {
+		vi.mocked(api.agentTypes).mockImplementation(async (cwd?: string) => ({
+			agentTypes: cwd
+				? [{ name: "ProjectAgent", description: "project-local definition" }]
+				: [{ name: "GlobalAgent", description: "global definition" }],
+		}));
 		vi.mocked(api.fleet).mockResolvedValue({
 			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
 			diskSessions: [],
@@ -1697,16 +1702,22 @@ describe("screen smoke tests", () => {
 		select.dispatchEvent(new Event("change", { bubbles: true }));
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+		expect(el.textContent).toContain("ProjectAgent");
 
 		// Transient empty snapshot (resync window / out-of-order refresh): the
-		// select hides with no roots, but the selection must NOT be reset.
+		// select hides and the selection is RETAINED as recovery metadata, but
+		// the rendered definitions fall back to global — a stale project context
+		// must not stay visible or editable while its roots are gone.
 		vi.mocked(api.fleet).mockResolvedValue({ runtimes: [], diskSessions: [] });
 		await store.refreshFleet();
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		expect(el.querySelector(".agent-context-row select")).toBeNull();
-		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBeUndefined();
+		expect(el.textContent).toContain("GlobalAgent");
+		expect(el.textContent).not.toContain("ProjectAgent");
 
-		// Fleet repopulates with the project still present: selection intact.
+		// Fleet repopulates with the project still present: selection and its
+		// project-local definitions return together.
 		vi.mocked(api.fleet).mockResolvedValue({
 			runtimes: [runtimeAt("a", "/home/test/project-alpha"), runtimeAt("b", "/home/test/project-beta")],
 			diskSessions: [],
@@ -1716,6 +1727,8 @@ describe("screen smoke tests", () => {
 		const restored = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
 		expect(restored.value).toBe("/home/test/project-alpha");
 		expect(restored.getAttribute("title")).toBe("/home/test/project-alpha");
+		expect(vi.mocked(api.agentTypes).mock.lastCall?.[0]).toBe("/home/test/project-alpha");
+		expect(el.textContent).toContain("ProjectAgent");
 	});
 
 	it("settings rows keep the structure the browser layout harness mirrors", async () => {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1518,6 +1518,96 @@ describe("screen smoke tests", () => {
 		expect(el.textContent).toContain("TUI-only settings");
 	});
 
+	it("settings agent context select renders home-relative options with full-path values and tooltip", async () => {
+		const runtimeAt = (key: string, cwd: string) => ({
+			key,
+			cwd,
+			state: {
+				sessionId: key,
+				thinkingLevel: "off" as const,
+				isStreaming: false,
+				isCompacting: false,
+				steeringMode: "all" as const,
+				followUpMode: "all" as const,
+				autoCompactionEnabled: true,
+				messageCount: 0,
+				pendingMessageCount: 0,
+			},
+			backgroundAgents: [],
+			needsAttention: false,
+			createdAt: new Date().toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [
+				runtimeAt("a", "/home/test/project-beta"),
+				runtimeAt("b", "/home/test/project-alpha"),
+				runtimeAt("c", "/opt/shared"),
+			],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const select = el.querySelector<HTMLSelectElement>(".agent-context-row select")!;
+		expect(select).toBeTruthy();
+		const options = [...select.querySelectorAll("option")];
+		// Sorted by full cwd; display text is home-relative, values stay absolute.
+		expect(options.map((option) => option.textContent)).toEqual([
+			"global/home only",
+			"~/project-alpha",
+			"~/project-beta",
+			"/opt/shared",
+		]);
+		expect(options.map((option) => option.value)).toEqual([
+			"",
+			"/home/test/project-alpha",
+			"/home/test/project-beta",
+			"/opt/shared",
+		]);
+		// Tooltip exposes the full path of the current selection.
+		expect(select.getAttribute("title")).toBe("global/home only");
+		select.value = "/home/test/project-alpha";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(select.getAttribute("title")).toBe("/home/test/project-alpha");
+	});
+
+	it("settings agent context select disambiguates multiple home prefixes as ~user", async () => {
+		const runtimeAt = (key: string, cwd: string) => ({
+			key,
+			cwd,
+			state: {
+				sessionId: key,
+				thinkingLevel: "off" as const,
+				isStreaming: false,
+				isCompacting: false,
+				steeringMode: "all" as const,
+				followUpMode: "all" as const,
+				autoCompactionEnabled: true,
+				messageCount: 0,
+				pendingMessageCount: 0,
+			},
+			backgroundAgents: [],
+			needsAttention: false,
+			createdAt: new Date().toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: [runtimeAt("a", "/home/alice/x"), runtimeAt("b", "/home/bob/y")],
+			diskSessions: [],
+		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const options = [...el.querySelectorAll(".agent-context-row select option")];
+		expect(options.map((option) => option.textContent)).toEqual(["global/home only", "~alice/x", "~bob/y"]);
+	});
+
 	it("pairing renders the PIN flow with both security copy blocks", () => {
 		const store = makeStore() as any;
 		const fakeStore = {

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1609,6 +1609,23 @@ describe("screen smoke tests", () => {
 		expect(mixed.slice(1)).toEqual(expect.arrayContaining(["~root/a", "~bob/b", "~carol/c"]));
 	});
 
+	it("settings agent context select namespace-qualifies colliding home labels", async () => {
+		// Same-OS collision: /root and /home/root share the alias "root".
+		const rootCollision = await agentContextOptionTexts(["/root/project", "/home/root/project"]);
+		expect(rootCollision).toHaveLength(3);
+		expect(rootCollision.slice(1)).toEqual(expect.arrayContaining(["~root/project", "~home/root/project"]));
+
+		// Cross-namespace same-username collision: /home/alice vs /Users/alice.
+		const userCollision = await agentContextOptionTexts(["/home/alice/x", "/Users/alice/x"]);
+		expect(userCollision).toHaveLength(3);
+		expect(userCollision.slice(1)).toEqual(expect.arrayContaining(["~home/alice/x", "~Users/alice/x"]));
+
+		// Distinct usernames across namespaces stay short — no qualification.
+		const noCollision = await agentContextOptionTexts(["/home/alice/x", "/Users/bob/y"]);
+		expect(noCollision).toHaveLength(3);
+		expect(noCollision.slice(1)).toEqual(expect.arrayContaining(["~alice/x", "~bob/y"]));
+	});
+
 	it("settings rows keep the structure the browser layout harness mirrors", async () => {
 		// settings-layout.browser.test.ts measures a static fixture of this markup.
 		// If any selector asserted here drifts in production, update that harness too.

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -1518,26 +1518,39 @@ describe("screen smoke tests", () => {
 		expect(el.textContent).toContain("TUI-only settings");
 	});
 
-	it("settings agent context select renders home-relative options with full-path values and tooltip", async () => {
-		const runtimeAt = (key: string, cwd: string) => ({
-			key,
-			cwd,
-			state: {
-				sessionId: key,
-				thinkingLevel: "off" as const,
-				isStreaming: false,
-				isCompacting: false,
-				steeringMode: "all" as const,
-				followUpMode: "all" as const,
-				autoCompactionEnabled: true,
-				messageCount: 0,
-				pendingMessageCount: 0,
-			},
-			backgroundAgents: [],
-			needsAttention: false,
-			createdAt: new Date().toISOString(),
-			lastActivity: new Date().toISOString(),
+	const runtimeAt = (key: string, cwd: string) => ({
+		key,
+		cwd,
+		state: {
+			sessionId: key,
+			thinkingLevel: "off" as const,
+			isStreaming: false,
+			isCompacting: false,
+			steeringMode: "all" as const,
+			followUpMode: "all" as const,
+			autoCompactionEnabled: true,
+			messageCount: 0,
+			pendingMessageCount: 0,
+		},
+		backgroundAgents: [],
+		needsAttention: false,
+		createdAt: new Date().toISOString(),
+		lastActivity: new Date().toISOString(),
+	});
+
+	const agentContextOptionTexts = async (cwds: string[]): Promise<string[]> => {
+		vi.mocked(api.fleet).mockResolvedValue({
+			runtimes: cwds.map((cwd, index) => runtimeAt(`k${index}`, cwd)),
+			diskSessions: [],
 		});
+		const store = makeStore();
+		const el = mount(() => <SettingsScreen store={store} />);
+		await store.refreshFleet();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		return [...el.querySelectorAll(".agent-context-row select option")].map((option) => option.textContent ?? "");
+	};
+
+	it("settings agent context select renders home-relative options with full-path values and tooltip", async () => {
 		vi.mocked(api.fleet).mockResolvedValue({
 			runtimes: [
 				runtimeAt("a", "/home/test/project-beta"),
@@ -1576,27 +1589,31 @@ describe("screen smoke tests", () => {
 	});
 
 	it("settings agent context select disambiguates multiple home prefixes as ~user", async () => {
-		const runtimeAt = (key: string, cwd: string) => ({
-			key,
-			cwd,
-			state: {
-				sessionId: key,
-				thinkingLevel: "off" as const,
-				isStreaming: false,
-				isCompacting: false,
-				steeringMode: "all" as const,
-				followUpMode: "all" as const,
-				autoCompactionEnabled: true,
-				messageCount: 0,
-				pendingMessageCount: 0,
-			},
-			backgroundAgents: [],
-			needsAttention: false,
-			createdAt: new Date().toISOString(),
-			lastActivity: new Date().toISOString(),
-		});
+		expect(await agentContextOptionTexts(["/home/alice/x", "/home/bob/y"])).toEqual([
+			"global/home only",
+			"~alice/x",
+			"~bob/y",
+		]);
+	});
+
+	it("settings agent context select collapses /root and /Users home prefixes", async () => {
+		// Single-home cases collapse to ~/… exactly like /home does.
+		expect(await agentContextOptionTexts(["/root/project"])).toEqual(["global/home only", "~/project"]);
+		expect(await agentContextOptionTexts(["/root"])).toEqual(["global/home only", "~"]);
+		expect(await agentContextOptionTexts(["/Users/alice/tools"])).toEqual(["global/home only", "~/tools"]);
+		// Mixed home roots disambiguate every root as ~user/… (order assertion-free:
+		// localeCompare collation of mixed-case prefixes is ICU-dependent).
+		const mixed = await agentContextOptionTexts(["/root/a", "/home/bob/b", "/Users/carol/c"]);
+		expect(mixed).toHaveLength(4);
+		expect(mixed[0]).toBe("global/home only");
+		expect(mixed.slice(1)).toEqual(expect.arrayContaining(["~root/a", "~bob/b", "~carol/c"]));
+	});
+
+	it("settings rows keep the structure the browser layout harness mirrors", async () => {
+		// settings-layout.browser.test.ts measures a static fixture of this markup.
+		// If any selector asserted here drifts in production, update that harness too.
 		vi.mocked(api.fleet).mockResolvedValue({
-			runtimes: [runtimeAt("a", "/home/alice/x"), runtimeAt("b", "/home/bob/y")],
+			runtimes: [runtimeAt("a", "/home/test/project")],
 			diskSessions: [],
 		});
 		const store = makeStore();
@@ -1604,8 +1621,14 @@ describe("screen smoke tests", () => {
 		await store.refreshFleet();
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		const options = [...el.querySelectorAll(".agent-context-row select option")];
-		expect(options.map((option) => option.textContent)).toEqual(["global/home only", "~alice/x", "~bob/y"]);
+		const row = el.querySelector(".setting-row.agent-context-row")!;
+		expect(row.querySelector(".setting-label .name")).toBeTruthy();
+		expect(row.querySelector(".setting-label .hint")).toBeTruthy();
+		expect(row.querySelector(".setting-control select[title]")).toBeTruthy();
+		// Short-control rows (other selects) and checkbox rows share the same
+		// .setting-row/.setting-control structure the harness exercises.
+		expect(el.querySelectorAll(".setting-row .setting-control select").length).toBeGreaterThan(1);
+		expect(el.querySelector(".setting-control .checkbox-control input[type=checkbox]")).toBeTruthy();
 	});
 
 	it("pairing renders the PIN flow with both security copy blocks", () => {

--- a/packages/dashboard/test/client/settings-layout.browser.test.ts
+++ b/packages/dashboard/test/client/settings-layout.browser.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Real-browser layout regression coverage for the settings "agent definition
+ * context" row (issue 378).
+ *
+ * The row's <select> holds absolute project paths — unbounded-length user
+ * data — and a select's intrinsic width equals its longest option. Without
+ * min-width: 0 on the .setting-control flex item the control cannot shrink
+ * below that min-content width, so it squishes the label on wide screens;
+ * without max-width: 100% it overflows the container in the narrow column
+ * layout. jsdom performs no flex layout or document overflow measurement, so
+ * this loads the production stylesheets in production order and measures the
+ * DOM in real Chromium, mirroring fleet-layout.browser.test.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { type Browser, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const tokensCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/tokens.css", import.meta.url)), "utf8");
+const appCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/app.css", import.meta.url)), "utf8");
+const themesCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/themes.css", import.meta.url)), "utf8");
+
+// ~125 chars: long enough that the select's intrinsic width exceeds the space
+// available beside the label even on a wide viewport.
+const longPath = `/home/acters/${"deeply-nested/project-layer/".repeat(4)}dreb`;
+
+const HARNESS_HTML = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<style>${tokensCss}</style>
+<style>${appCss}</style>
+<style>${themesCss}</style>
+</head>
+<body>
+	<main class="container settings-wrap">
+		<section class="settings-section">
+			<h2>agent models</h2>
+			<div class="setting-row agent-context-row" data-agent-row>
+				<span class="setting-label" data-agent-label>
+					<span class="name">agent definition context</span>
+					<span class="hint">choose a project to include its .dreb/agents definitions</span>
+				</span>
+				<span class="setting-control" data-agent-control>
+					<select data-agent-select>
+						<option value="">global/home only</option>
+						<option value="${longPath}" selected>${longPath}</option>
+					</select>
+				</span>
+			</div>
+			<div class="setting-row" data-short-row>
+				<span class="setting-label">
+					<span class="name">appearance</span>
+					<span class="hint">short control regression guard</span>
+				</span>
+				<span class="setting-control">
+					<select data-short-select>
+						<option selected>system</option>
+						<option>light</option>
+						<option>dark</option>
+					</select>
+				</span>
+			</div>
+		</section>
+	</main>
+</body>
+</html>`;
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+	browser = await chromium.launch();
+	page = await browser.newPage({ viewport: { width: 1024, height: 800 } });
+}, 60_000);
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+beforeEach(async () => {
+	await page.setContent(HARNESS_HTML);
+});
+
+type SettingsMeasurements = {
+	documentFits: boolean;
+	selectWithinRow: boolean;
+	nameOnOneLine: boolean;
+	controlBelowLabel: boolean;
+	shortSelectWithinRow: boolean;
+	shortSelectNotStretched: boolean;
+};
+
+async function measurements(): Promise<SettingsMeasurements> {
+	return page.evaluate(() => {
+		const tolerance = 1;
+		const rectWithin = (child: Element, parent: Element) => {
+			const childRect = child.getBoundingClientRect();
+			const parentRect = parent.getBoundingClientRect();
+			return (
+				childRect.left >= parentRect.left - tolerance &&
+				childRect.right <= parentRect.right + tolerance &&
+				childRect.top >= parentRect.top - tolerance &&
+				childRect.bottom <= parentRect.bottom + tolerance
+			);
+		};
+		const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
+		const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
+		const name = label.querySelector<HTMLElement>(".name")!;
+		const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
+		const select = row.querySelector<HTMLElement>("[data-agent-select]")!;
+		const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
+		const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
+		const nameStyle = getComputedStyle(name);
+		const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
+
+		return {
+			documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
+			selectWithinRow: rectWithin(select, row),
+			// The setting's primary text must not wrap; the hint may wrap (it is
+			// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
+			// the unshrinkable select crushes the label until even the name wraps.
+			nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
+			controlBelowLabel: control.getBoundingClientRect().top > label.getBoundingClientRect().top + tolerance,
+			shortSelectWithinRow: rectWithin(shortSelect, shortRow),
+			shortSelectNotStretched:
+				shortSelect.getBoundingClientRect().width <= shortRow.getBoundingClientRect().width / 2 + tolerance,
+		};
+	});
+}
+
+describe("settings agent-context row layout in a real browser", () => {
+	it.each([760, 1024])("keeps the label readable at %ipx instead of squishing it", async (width) => {
+		await page.setViewportSize({ width, height: 800 });
+		const measured = await measurements();
+
+		expect(measured.documentFits).toBe(true);
+		expect(measured.selectWithinRow).toBe(true);
+		expect(measured.nameOnOneLine).toBe(true);
+	});
+
+	it.each([360, 700])("caps the select to the container at %ipx without horizontal overflow", async (width) => {
+		await page.setViewportSize({ width, height: 800 });
+		const measured = await measurements();
+
+		expect(measured.documentFits).toBe(true);
+		expect(measured.selectWithinRow).toBe(true);
+		// Column layout is active at these widths: the control stacks below the label.
+		expect(measured.controlBelowLabel).toBe(true);
+	});
+
+	it.each([360, 1024])("leaves short controls at their natural size at %ipx", async (width) => {
+		await page.setViewportSize({ width, height: 800 });
+		const measured = await measurements();
+
+		expect(measured.shortSelectWithinRow).toBe(true);
+		expect(measured.shortSelectNotStretched).toBe(true);
+	});
+});

--- a/packages/dashboard/test/client/settings-layout.browser.test.ts
+++ b/packages/dashboard/test/client/settings-layout.browser.test.ts
@@ -10,6 +10,12 @@
  * layout. jsdom performs no flex layout or document overflow measurement, so
  * this loads the production stylesheets in production order and measures the
  * DOM in real Chromium, mirroring fleet-layout.browser.test.ts.
+ *
+ * Note: the native dropdown popup is not part of the DOM and cannot be
+ * measured in Chromium. "Full paths remain readable in the opened dropdown"
+ * is covered at the DOM level by asserting the option elements retain their
+ * complete text; "the closed control clips the value" is covered by comparing
+ * the select's rendered width against its unconstrained intrinsic width.
  */
 
 import { readFileSync } from "node:fs";
@@ -63,6 +69,18 @@ const HARNESS_HTML = `<!DOCTYPE html>
 					</select>
 				</span>
 			</div>
+			<div class="setting-row" data-checkbox-row>
+				<span class="setting-label">
+					<span class="name">always expand thinking</span>
+					<span class="hint">checkbox control regression guard</span>
+				</span>
+				<span class="setting-control">
+					<label class="checkbox-control">
+						<input type="checkbox" checked data-checkbox />
+						<span>open by default</span>
+					</label>
+				</span>
+			</div>
 		</section>
 	</main>
 </body>
@@ -88,13 +106,17 @@ type SettingsMeasurements = {
 	documentFits: boolean;
 	selectWithinRow: boolean;
 	nameOnOneLine: boolean;
+	rowIsHorizontal: boolean;
 	controlBelowLabel: boolean;
-	shortSelectWithinRow: boolean;
-	shortSelectNotStretched: boolean;
+	agentValueClipped: boolean;
+	selectedOptionTextIntact: boolean;
+	shortSelectNaturalSize: boolean;
+	checkboxWithinRow: boolean;
+	checkboxNaturalSize: boolean;
 };
 
 async function measurements(): Promise<SettingsMeasurements> {
-	return page.evaluate(() => {
+	return page.evaluate((expectedLongPath) => {
 		const tolerance = 1;
 		const rectWithin = (child: Element, parent: Element) => {
 			const childRect = child.getBoundingClientRect();
@@ -106,15 +128,33 @@ async function measurements(): Promise<SettingsMeasurements> {
 				childRect.bottom <= parentRect.bottom + tolerance
 			);
 		};
+		// Width the element would take with no max-width constraint — the
+		// baseline for "natural size" and "is the value clipped" checks. The
+		// clone is appended to the SAME PARENT so scoped rules (e.g.
+		// .setting-control select padding/font-size) apply identically.
+		const intrinsicWidth = (element: HTMLElement) => {
+			const clone = element.cloneNode(true) as HTMLElement;
+			clone.style.maxWidth = "none";
+			clone.style.position = "absolute";
+			clone.style.visibility = "hidden";
+			element.parentElement!.appendChild(clone);
+			const width = clone.getBoundingClientRect().width;
+			clone.remove();
+			return width;
+		};
 		const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
 		const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
 		const name = label.querySelector<HTMLElement>(".name")!;
 		const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
-		const select = row.querySelector<HTMLElement>("[data-agent-select]")!;
+		const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
 		const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
 		const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
+		const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
+		const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
 		const nameStyle = getComputedStyle(name);
 		const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
+		const controlRect = control.getBoundingClientRect();
+		const labelRect = label.getBoundingClientRect();
 
 		return {
 			documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
@@ -123,39 +163,66 @@ async function measurements(): Promise<SettingsMeasurements> {
 			// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
 			// the unshrinkable select crushes the label until even the name wraps.
 			nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
-			controlBelowLabel: control.getBoundingClientRect().top > label.getBoundingClientRect().top + tolerance,
-			shortSelectWithinRow: rectWithin(shortSelect, shortRow),
-			shortSelectNotStretched:
-				shortSelect.getBoundingClientRect().width <= shortRow.getBoundingClientRect().width / 2 + tolerance,
+			// Row layout is active above the 700px breakpoint: the control sits
+			// beside the label, not below it.
+			rowIsHorizontal:
+				controlRect.left > labelRect.left &&
+				controlRect.top < labelRect.bottom &&
+				controlRect.bottom > labelRect.top,
+			controlBelowLabel: controlRect.top > labelRect.top + tolerance,
+			// The capped select must visibly clip its value: rendered width is
+			// smaller than the unconstrained intrinsic width. Pre-fix the wide
+			// layout renders the select AT intrinsic width (no clipping, label
+			// squished instead).
+			agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
+			// DOM-level guarantee behind "full paths remain readable in the opened
+			// dropdown": the option data is never truncated, only visually clipped.
+			selectedOptionTextIntact: select.options[select.selectedIndex].text === expectedLongPath,
+			// Natural size = rendered width matches the unconstrained baseline:
+			// neither stretched nor clipped by the new constraints.
+			shortSelectNaturalSize: Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
+			checkboxWithinRow: rectWithin(checkbox, checkboxRow),
+			checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
 		};
-	});
+	}, longPath);
+}
+
+async function measurementsAt(width: number): Promise<SettingsMeasurements> {
+	await page.setViewportSize({ width, height: 800 });
+	return measurements();
 }
 
 describe("settings agent-context row layout in a real browser", () => {
-	it.each([760, 1024])("keeps the label readable at %ipx instead of squishing it", async (width) => {
-		await page.setViewportSize({ width, height: 800 });
-		const measured = await measurements();
+	// 701px is the first viewport where the desktop row layout applies; 1024px
+	// exercises the same layout with slack. (.settings-wrap caps at 720px, so
+	// intermediate widths add no new geometry.)
+	it.each([701, 1024])("keeps the label readable and the row horizontal at %ipx", async (width) => {
+		const measured = await measurementsAt(width);
 
 		expect(measured.documentFits).toBe(true);
 		expect(measured.selectWithinRow).toBe(true);
 		expect(measured.nameOnOneLine).toBe(true);
+		expect(measured.rowIsHorizontal).toBe(true);
+		expect(measured.agentValueClipped).toBe(true);
+		expect(measured.selectedOptionTextIntact).toBe(true);
 	});
 
 	it.each([360, 700])("caps the select to the container at %ipx without horizontal overflow", async (width) => {
-		await page.setViewportSize({ width, height: 800 });
-		const measured = await measurements();
+		const measured = await measurementsAt(width);
 
 		expect(measured.documentFits).toBe(true);
 		expect(measured.selectWithinRow).toBe(true);
 		// Column layout is active at these widths: the control stacks below the label.
 		expect(measured.controlBelowLabel).toBe(true);
+		expect(measured.agentValueClipped).toBe(true);
+		expect(measured.selectedOptionTextIntact).toBe(true);
 	});
 
-	it.each([360, 1024])("leaves short controls at their natural size at %ipx", async (width) => {
-		await page.setViewportSize({ width, height: 800 });
-		const measured = await measurements();
+	it.each([360, 1024])("leaves short controls and checkboxes at their natural size at %ipx", async (width) => {
+		const measured = await measurementsAt(width);
 
-		expect(measured.shortSelectWithinRow).toBe(true);
-		expect(measured.shortSelectNotStretched).toBe(true);
+		expect(measured.shortSelectNaturalSize).toBe(true);
+		expect(measured.checkboxWithinRow).toBe(true);
+		expect(measured.checkboxNaturalSize).toBe(true);
 	});
 });

--- a/packages/dashboard/test/client/settings-layout.browser.test.ts
+++ b/packages/dashboard/test/client/settings-layout.browser.test.ts
@@ -11,15 +11,9 @@
  * this loads the production stylesheets in production order and measures the
  * DOM in real Chromium, mirroring fleet-layout.browser.test.ts.
  *
- * Scope: this test is LAYOUT-ONLY. The harness mirrors the production markup
- * from settings.tsx (home-relative option text, title tooltip) as a static
- * fixture; it intentionally does not assert option semantics. The production
- * markup contract (classes/structure/title binding this fixture depends on)
- * and all option/tooltip semantics are covered in screens.test.tsx (jsdom) —
- * drift there fails loudly. Chromium's opened select popup is a native window
- * outside the DOM and cannot be measured; it also stays control-width and
- * clips long options on Linux, which is why production shortens the display
- * text in the first place.
+ * Scope: LAYOUT-ONLY. The harness mirrors the production markup from
+ * settings.tsx (full-path option text, title tooltip on the select) as a
+ * static fixture; option semantics are covered in screens.test.tsx (jsdom).
  */
 
 import { readFileSync } from "node:fs";
@@ -32,11 +26,8 @@ const appCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/app.c
 const themesCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/themes.css", import.meta.url)), "utf8");
 
 // ~125 chars: long enough that the select's intrinsic width exceeds the space
-// available beside the label even on a wide viewport. Options render
-// home-relative in production (Chromium's opened popup stays control-width
-// and clips); the full path lives in the option value and the select's title.
+// available beside the label even on a wide viewport.
 const longPath = `/home/acters/${"deeply-nested/project-layer/".repeat(4)}dreb`;
-const longPathDisplay = `~/${"deeply-nested/project-layer/".repeat(4)}dreb`;
 
 const HARNESS_HTML = `<!DOCTYPE html>
 <html>
@@ -59,7 +50,7 @@ const HARNESS_HTML = `<!DOCTYPE html>
 				<span class="setting-control" data-agent-control>
 					<select data-agent-select title="${longPath}">
 						<option value="">global/home only</option>
-						<option value="${longPath}" selected>${longPathDisplay}</option>
+						<option value="${longPath}" selected>${longPath}</option>
 					</select>
 				</span>
 			</div>
@@ -74,18 +65,6 @@ const HARNESS_HTML = `<!DOCTYPE html>
 						<option>light</option>
 						<option>dark</option>
 					</select>
-				</span>
-			</div>
-			<div class="setting-row" data-checkbox-row>
-				<span class="setting-label">
-					<span class="name">always expand thinking</span>
-					<span class="hint">checkbox control regression guard</span>
-				</span>
-				<span class="setting-control">
-					<label class="checkbox-control">
-						<input type="checkbox" checked data-checkbox />
-						<span>open by default</span>
-					</label>
 				</span>
 			</div>
 		</section>
@@ -116,9 +95,8 @@ type SettingsMeasurements = {
 	rowIsHorizontal: boolean;
 	controlBelowLabel: boolean;
 	agentValueClipped: boolean;
+	shortSelectWithinRow: boolean;
 	shortSelectNaturalSize: boolean;
-	checkboxWithinRow: boolean;
-	checkboxNaturalSize: boolean;
 };
 
 async function measurements(): Promise<SettingsMeasurements> {
@@ -155,8 +133,6 @@ async function measurements(): Promise<SettingsMeasurements> {
 		const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
 		const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
 		const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
-		const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
-		const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
 		const nameStyle = getComputedStyle(name);
 		const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
 		const controlRect = control.getBoundingClientRect();
@@ -181,11 +157,10 @@ async function measurements(): Promise<SettingsMeasurements> {
 			// layout renders the select AT intrinsic width (no clipping, label
 			// squished instead).
 			agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
+			shortSelectWithinRow: rectWithin(shortSelect, shortRow),
 			// Natural size = rendered width matches the unconstrained baseline:
 			// neither stretched nor clipped by the new constraints.
 			shortSelectNaturalSize: Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
-			checkboxWithinRow: rectWithin(checkbox, checkboxRow),
-			checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
 		};
 	});
 }
@@ -219,11 +194,10 @@ describe("settings agent-context row layout in a real browser", () => {
 		expect(measured.agentValueClipped).toBe(true);
 	});
 
-	it.each([360, 1024])("leaves short controls and checkboxes at their natural size at %ipx", async (width) => {
+	it.each([360, 1024])("leaves short controls at their natural size at %ipx", async (width) => {
 		const measured = await measurementsAt(width);
 
+		expect(measured.shortSelectWithinRow).toBe(true);
 		expect(measured.shortSelectNaturalSize).toBe(true);
-		expect(measured.checkboxWithinRow).toBe(true);
-		expect(measured.checkboxNaturalSize).toBe(true);
 	});
 });

--- a/packages/dashboard/test/client/settings-layout.browser.test.ts
+++ b/packages/dashboard/test/client/settings-layout.browser.test.ts
@@ -11,13 +11,15 @@
  * this loads the production stylesheets in production order and measures the
  * DOM in real Chromium, mirroring fleet-layout.browser.test.ts.
  *
- * Note: Chromium's opened select popup stays control-width and clips long
- * options (Linux/Aura) — it is also a native window outside the DOM, so it
- * cannot be measured. Production therefore renders options home-relative and
- * puts the full cwd in the select's title tooltip (see settings.tsx); this
- * harness mirrors that markup and asserts the clipped rendering plus the
- * preserved full-path value/tooltip at the DOM level. The home-relative
- * formatting logic itself is covered in screens.test.tsx (jsdom).
+ * Scope: this test is LAYOUT-ONLY. The harness mirrors the production markup
+ * from settings.tsx (home-relative option text, title tooltip) as a static
+ * fixture; it intentionally does not assert option semantics. The production
+ * markup contract (classes/structure/title binding this fixture depends on)
+ * and all option/tooltip semantics are covered in screens.test.tsx (jsdom) —
+ * drift there fails loudly. Chromium's opened select popup is a native window
+ * outside the DOM and cannot be measured; it also stays control-width and
+ * clips long options on Linux, which is why production shortens the display
+ * text in the first place.
  */
 
 import { readFileSync } from "node:fs";
@@ -114,90 +116,78 @@ type SettingsMeasurements = {
 	rowIsHorizontal: boolean;
 	controlBelowLabel: boolean;
 	agentValueClipped: boolean;
-	selectedOptionPreserved: boolean;
 	shortSelectNaturalSize: boolean;
 	checkboxWithinRow: boolean;
 	checkboxNaturalSize: boolean;
 };
 
 async function measurements(): Promise<SettingsMeasurements> {
-	return page.evaluate(
-		({ expectedLongPath, expectedDisplay }) => {
-			const tolerance = 1;
-			const rectWithin = (child: Element, parent: Element) => {
-				const childRect = child.getBoundingClientRect();
-				const parentRect = parent.getBoundingClientRect();
-				return (
-					childRect.left >= parentRect.left - tolerance &&
-					childRect.right <= parentRect.right + tolerance &&
-					childRect.top >= parentRect.top - tolerance &&
-					childRect.bottom <= parentRect.bottom + tolerance
-				);
-			};
-			// Width the element would take with no max-width constraint — the
-			// baseline for "natural size" and "is the value clipped" checks. The
-			// clone is appended to the SAME PARENT so scoped rules (e.g.
-			// .setting-control select padding/font-size) apply identically.
-			const intrinsicWidth = (element: HTMLElement) => {
-				const clone = element.cloneNode(true) as HTMLElement;
-				clone.style.maxWidth = "none";
-				clone.style.position = "absolute";
-				clone.style.visibility = "hidden";
-				element.parentElement!.appendChild(clone);
-				const width = clone.getBoundingClientRect().width;
-				clone.remove();
-				return width;
-			};
-			const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
-			const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
-			const name = label.querySelector<HTMLElement>(".name")!;
-			const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
-			const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
-			const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
-			const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
-			const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
-			const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
-			const nameStyle = getComputedStyle(name);
-			const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
-			const controlRect = control.getBoundingClientRect();
-			const labelRect = label.getBoundingClientRect();
+	return page.evaluate(() => {
+		const tolerance = 1;
+		const rectWithin = (child: Element, parent: Element) => {
+			const childRect = child.getBoundingClientRect();
+			const parentRect = parent.getBoundingClientRect();
+			return (
+				childRect.left >= parentRect.left - tolerance &&
+				childRect.right <= parentRect.right + tolerance &&
+				childRect.top >= parentRect.top - tolerance &&
+				childRect.bottom <= parentRect.bottom + tolerance
+			);
+		};
+		// Width the element would take with no max-width constraint — the
+		// baseline for "natural size" and "is the value clipped" checks. The
+		// clone is appended to the SAME PARENT so scoped rules (e.g.
+		// .setting-control select padding/font-size) apply identically.
+		const intrinsicWidth = (element: HTMLElement) => {
+			const clone = element.cloneNode(true) as HTMLElement;
+			clone.style.maxWidth = "none";
+			clone.style.position = "absolute";
+			clone.style.visibility = "hidden";
+			element.parentElement!.appendChild(clone);
+			const width = clone.getBoundingClientRect().width;
+			clone.remove();
+			return width;
+		};
+		const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
+		const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
+		const name = label.querySelector<HTMLElement>(".name")!;
+		const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
+		const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
+		const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
+		const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
+		const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
+		const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
+		const nameStyle = getComputedStyle(name);
+		const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
+		const controlRect = control.getBoundingClientRect();
+		const labelRect = label.getBoundingClientRect();
 
-			return {
-				documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
-				selectWithinRow: rectWithin(select, row),
-				// The setting's primary text must not wrap; the hint may wrap (it is
-				// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
-				// the unshrinkable select crushes the label until even the name wraps.
-				nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
-				// Row layout is active above the 700px breakpoint: the control sits
-				// beside the label, not below it.
-				rowIsHorizontal:
-					controlRect.left > labelRect.left &&
-					controlRect.top < labelRect.bottom &&
-					controlRect.bottom > labelRect.top,
-				controlBelowLabel: controlRect.top > labelRect.top + tolerance,
-				// The capped select must visibly clip its value: rendered width is
-				// smaller than the unconstrained intrinsic width. Pre-fix the wide
-				// layout renders the select AT intrinsic width (no clipping, label
-				// squished instead).
-				agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
-				// DOM-level guarantee behind full-path availability: the option data
-				// is never truncated (value + tooltip hold the full cwd), only the
-				// display text is shortened to the home-relative form.
-				selectedOptionPreserved:
-					select.options[select.selectedIndex].text === expectedDisplay &&
-					select.value === expectedLongPath &&
-					select.title === expectedLongPath,
-				// Natural size = rendered width matches the unconstrained baseline:
-				// neither stretched nor clipped by the new constraints.
-				shortSelectNaturalSize:
-					Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
-				checkboxWithinRow: rectWithin(checkbox, checkboxRow),
-				checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
-			};
-		},
-		{ expectedLongPath: longPath, expectedDisplay: longPathDisplay },
-	);
+		return {
+			documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
+			selectWithinRow: rectWithin(select, row),
+			// The setting's primary text must not wrap; the hint may wrap (it is
+			// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
+			// the unshrinkable select crushes the label until even the name wraps.
+			nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
+			// Row layout is active above the 700px breakpoint: the control sits
+			// beside the label, not below it.
+			rowIsHorizontal:
+				controlRect.left > labelRect.left &&
+				controlRect.top < labelRect.bottom &&
+				controlRect.bottom > labelRect.top,
+			controlBelowLabel: controlRect.top > labelRect.top + tolerance,
+			// The capped select must visibly clip its value: rendered width is
+			// smaller than the unconstrained intrinsic width. Pre-fix the wide
+			// layout renders the select AT intrinsic width (no clipping, label
+			// squished instead).
+			agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
+			// Natural size = rendered width matches the unconstrained baseline:
+			// neither stretched nor clipped by the new constraints.
+			shortSelectNaturalSize: Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
+			checkboxWithinRow: rectWithin(checkbox, checkboxRow),
+			checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
+		};
+	});
 }
 
 async function measurementsAt(width: number): Promise<SettingsMeasurements> {
@@ -217,7 +207,6 @@ describe("settings agent-context row layout in a real browser", () => {
 		expect(measured.nameOnOneLine).toBe(true);
 		expect(measured.rowIsHorizontal).toBe(true);
 		expect(measured.agentValueClipped).toBe(true);
-		expect(measured.selectedOptionPreserved).toBe(true);
 	});
 
 	it.each([360, 700])("caps the select to the container at %ipx without horizontal overflow", async (width) => {
@@ -228,7 +217,6 @@ describe("settings agent-context row layout in a real browser", () => {
 		// Column layout is active at these widths: the control stacks below the label.
 		expect(measured.controlBelowLabel).toBe(true);
 		expect(measured.agentValueClipped).toBe(true);
-		expect(measured.selectedOptionPreserved).toBe(true);
 	});
 
 	it.each([360, 1024])("leaves short controls and checkboxes at their natural size at %ipx", async (width) => {

--- a/packages/dashboard/test/client/settings-layout.browser.test.ts
+++ b/packages/dashboard/test/client/settings-layout.browser.test.ts
@@ -11,11 +11,13 @@
  * this loads the production stylesheets in production order and measures the
  * DOM in real Chromium, mirroring fleet-layout.browser.test.ts.
  *
- * Note: the native dropdown popup is not part of the DOM and cannot be
- * measured in Chromium. "Full paths remain readable in the opened dropdown"
- * is covered at the DOM level by asserting the option elements retain their
- * complete text; "the closed control clips the value" is covered by comparing
- * the select's rendered width against its unconstrained intrinsic width.
+ * Note: Chromium's opened select popup stays control-width and clips long
+ * options (Linux/Aura) — it is also a native window outside the DOM, so it
+ * cannot be measured. Production therefore renders options home-relative and
+ * puts the full cwd in the select's title tooltip (see settings.tsx); this
+ * harness mirrors that markup and asserts the clipped rendering plus the
+ * preserved full-path value/tooltip at the DOM level. The home-relative
+ * formatting logic itself is covered in screens.test.tsx (jsdom).
  */
 
 import { readFileSync } from "node:fs";
@@ -28,8 +30,11 @@ const appCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/app.c
 const themesCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/themes.css", import.meta.url)), "utf8");
 
 // ~125 chars: long enough that the select's intrinsic width exceeds the space
-// available beside the label even on a wide viewport.
+// available beside the label even on a wide viewport. Options render
+// home-relative in production (Chromium's opened popup stays control-width
+// and clips); the full path lives in the option value and the select's title.
 const longPath = `/home/acters/${"deeply-nested/project-layer/".repeat(4)}dreb`;
+const longPathDisplay = `~/${"deeply-nested/project-layer/".repeat(4)}dreb`;
 
 const HARNESS_HTML = `<!DOCTYPE html>
 <html>
@@ -50,9 +55,9 @@ const HARNESS_HTML = `<!DOCTYPE html>
 					<span class="hint">choose a project to include its .dreb/agents definitions</span>
 				</span>
 				<span class="setting-control" data-agent-control>
-					<select data-agent-select>
+					<select data-agent-select title="${longPath}">
 						<option value="">global/home only</option>
-						<option value="${longPath}" selected>${longPath}</option>
+						<option value="${longPath}" selected>${longPathDisplay}</option>
 					</select>
 				</span>
 			</div>
@@ -109,82 +114,90 @@ type SettingsMeasurements = {
 	rowIsHorizontal: boolean;
 	controlBelowLabel: boolean;
 	agentValueClipped: boolean;
-	selectedOptionTextIntact: boolean;
+	selectedOptionPreserved: boolean;
 	shortSelectNaturalSize: boolean;
 	checkboxWithinRow: boolean;
 	checkboxNaturalSize: boolean;
 };
 
 async function measurements(): Promise<SettingsMeasurements> {
-	return page.evaluate((expectedLongPath) => {
-		const tolerance = 1;
-		const rectWithin = (child: Element, parent: Element) => {
-			const childRect = child.getBoundingClientRect();
-			const parentRect = parent.getBoundingClientRect();
-			return (
-				childRect.left >= parentRect.left - tolerance &&
-				childRect.right <= parentRect.right + tolerance &&
-				childRect.top >= parentRect.top - tolerance &&
-				childRect.bottom <= parentRect.bottom + tolerance
-			);
-		};
-		// Width the element would take with no max-width constraint — the
-		// baseline for "natural size" and "is the value clipped" checks. The
-		// clone is appended to the SAME PARENT so scoped rules (e.g.
-		// .setting-control select padding/font-size) apply identically.
-		const intrinsicWidth = (element: HTMLElement) => {
-			const clone = element.cloneNode(true) as HTMLElement;
-			clone.style.maxWidth = "none";
-			clone.style.position = "absolute";
-			clone.style.visibility = "hidden";
-			element.parentElement!.appendChild(clone);
-			const width = clone.getBoundingClientRect().width;
-			clone.remove();
-			return width;
-		};
-		const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
-		const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
-		const name = label.querySelector<HTMLElement>(".name")!;
-		const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
-		const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
-		const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
-		const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
-		const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
-		const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
-		const nameStyle = getComputedStyle(name);
-		const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
-		const controlRect = control.getBoundingClientRect();
-		const labelRect = label.getBoundingClientRect();
+	return page.evaluate(
+		({ expectedLongPath, expectedDisplay }) => {
+			const tolerance = 1;
+			const rectWithin = (child: Element, parent: Element) => {
+				const childRect = child.getBoundingClientRect();
+				const parentRect = parent.getBoundingClientRect();
+				return (
+					childRect.left >= parentRect.left - tolerance &&
+					childRect.right <= parentRect.right + tolerance &&
+					childRect.top >= parentRect.top - tolerance &&
+					childRect.bottom <= parentRect.bottom + tolerance
+				);
+			};
+			// Width the element would take with no max-width constraint — the
+			// baseline for "natural size" and "is the value clipped" checks. The
+			// clone is appended to the SAME PARENT so scoped rules (e.g.
+			// .setting-control select padding/font-size) apply identically.
+			const intrinsicWidth = (element: HTMLElement) => {
+				const clone = element.cloneNode(true) as HTMLElement;
+				clone.style.maxWidth = "none";
+				clone.style.position = "absolute";
+				clone.style.visibility = "hidden";
+				element.parentElement!.appendChild(clone);
+				const width = clone.getBoundingClientRect().width;
+				clone.remove();
+				return width;
+			};
+			const row = document.querySelector<HTMLElement>("[data-agent-row]")!;
+			const label = row.querySelector<HTMLElement>("[data-agent-label]")!;
+			const name = label.querySelector<HTMLElement>(".name")!;
+			const control = row.querySelector<HTMLElement>("[data-agent-control]")!;
+			const select = row.querySelector<HTMLSelectElement>("[data-agent-select]")!;
+			const shortRow = document.querySelector<HTMLElement>("[data-short-row]")!;
+			const shortSelect = shortRow.querySelector<HTMLElement>("[data-short-select]")!;
+			const checkboxRow = document.querySelector<HTMLElement>("[data-checkbox-row]")!;
+			const checkbox = checkboxRow.querySelector<HTMLElement>("[data-checkbox]")!;
+			const nameStyle = getComputedStyle(name);
+			const nameLineHeight = Number.parseFloat(nameStyle.lineHeight);
+			const controlRect = control.getBoundingClientRect();
+			const labelRect = label.getBoundingClientRect();
 
-		return {
-			documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
-			selectWithinRow: rectWithin(select, row),
-			// The setting's primary text must not wrap; the hint may wrap (it is
-			// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
-			// the unshrinkable select crushes the label until even the name wraps.
-			nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
-			// Row layout is active above the 700px breakpoint: the control sits
-			// beside the label, not below it.
-			rowIsHorizontal:
-				controlRect.left > labelRect.left &&
-				controlRect.top < labelRect.bottom &&
-				controlRect.bottom > labelRect.top,
-			controlBelowLabel: controlRect.top > labelRect.top + tolerance,
-			// The capped select must visibly clip its value: rendered width is
-			// smaller than the unconstrained intrinsic width. Pre-fix the wide
-			// layout renders the select AT intrinsic width (no clipping, label
-			// squished instead).
-			agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
-			// DOM-level guarantee behind "full paths remain readable in the opened
-			// dropdown": the option data is never truncated, only visually clipped.
-			selectedOptionTextIntact: select.options[select.selectedIndex].text === expectedLongPath,
-			// Natural size = rendered width matches the unconstrained baseline:
-			// neither stretched nor clipped by the new constraints.
-			shortSelectNaturalSize: Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
-			checkboxWithinRow: rectWithin(checkbox, checkboxRow),
-			checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
-		};
-	}, longPath);
+			return {
+				documentFits: document.documentElement.scrollWidth <= window.innerWidth + tolerance,
+				selectWithinRow: rectWithin(select, row),
+				// The setting's primary text must not wrap; the hint may wrap (it is
+				// secondary and wraps in narrow layouts elsewhere by design). Pre-fix
+				// the unshrinkable select crushes the label until even the name wraps.
+				nameOnOneLine: name.getBoundingClientRect().height <= nameLineHeight + tolerance,
+				// Row layout is active above the 700px breakpoint: the control sits
+				// beside the label, not below it.
+				rowIsHorizontal:
+					controlRect.left > labelRect.left &&
+					controlRect.top < labelRect.bottom &&
+					controlRect.bottom > labelRect.top,
+				controlBelowLabel: controlRect.top > labelRect.top + tolerance,
+				// The capped select must visibly clip its value: rendered width is
+				// smaller than the unconstrained intrinsic width. Pre-fix the wide
+				// layout renders the select AT intrinsic width (no clipping, label
+				// squished instead).
+				agentValueClipped: intrinsicWidth(select) - select.getBoundingClientRect().width > 2,
+				// DOM-level guarantee behind full-path availability: the option data
+				// is never truncated (value + tooltip hold the full cwd), only the
+				// display text is shortened to the home-relative form.
+				selectedOptionPreserved:
+					select.options[select.selectedIndex].text === expectedDisplay &&
+					select.value === expectedLongPath &&
+					select.title === expectedLongPath,
+				// Natural size = rendered width matches the unconstrained baseline:
+				// neither stretched nor clipped by the new constraints.
+				shortSelectNaturalSize:
+					Math.abs(shortSelect.getBoundingClientRect().width - intrinsicWidth(shortSelect)) <= 2,
+				checkboxWithinRow: rectWithin(checkbox, checkboxRow),
+				checkboxNaturalSize: Math.abs(checkbox.getBoundingClientRect().width - intrinsicWidth(checkbox)) <= 2,
+			};
+		},
+		{ expectedLongPath: longPath, expectedDisplay: longPathDisplay },
+	);
 }
 
 async function measurementsAt(width: number): Promise<SettingsMeasurements> {
@@ -204,7 +217,7 @@ describe("settings agent-context row layout in a real browser", () => {
 		expect(measured.nameOnOneLine).toBe(true);
 		expect(measured.rowIsHorizontal).toBe(true);
 		expect(measured.agentValueClipped).toBe(true);
-		expect(measured.selectedOptionTextIntact).toBe(true);
+		expect(measured.selectedOptionPreserved).toBe(true);
 	});
 
 	it.each([360, 700])("caps the select to the container at %ipx without horizontal overflow", async (width) => {
@@ -215,7 +228,7 @@ describe("settings agent-context row layout in a real browser", () => {
 		// Column layout is active at these widths: the control stacks below the label.
 		expect(measured.controlBelowLabel).toBe(true);
 		expect(measured.agentValueClipped).toBe(true);
-		expect(measured.selectedOptionTextIntact).toBe(true);
+		expect(measured.selectedOptionPreserved).toBe(true);
 	});
 
 	it.each([360, 1024])("leaves short controls and checkboxes at their natural size at %ipx", async (width) => {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.43.1",
+  "version": "2.43.0",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.43.0",
+  "version": "2.43.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.43.0",
+  "version": "2.43.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.43.1",
+	"version": "2.43.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.43.0",
+	"version": "2.43.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.43.0",
+	"version": "2.43.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #378

The agent definition context select in dashboard Settings held absolute project paths, whose intrinsic width (longest option) squishes the label on wide screens and overflows the container in the narrow column layout. This constrains the control without touching its behavior:

- `app.css`: `.setting-control { min-width: 0; max-width: 100% }`, `max-width: 100%` on `.setting-control select/input`, and `.agent-context-row .setting-label { flex-shrink: 0 }` so the control (which clips gracefully) absorbs shrinkage instead of the label.
- `settings.tsx`: one line — a full-path `title` tooltip on the select, so a clipped value is identifiable on hover.
- Tests: a real-Chromium layout regression test (jsdom cannot measure flex layout) covering wide (701/1024px) and narrow (360/700px) viewports, value clipping, and a short-control regression guard; plus one concise jsdom test for option values and the tooltip.

**Scope note:** this branch previously explored a home-relative display formatter and fleet/resource-state reconciliation; both were removed as out of scope per the maintainer's scope review. Fleet refresh ordering is tracked in issue 380; a word-wrapping path picker is proposed in issue 381.

---
*Reduced to layout scope per maintainer review.*
