### PR TITLE
Add link to mach10 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Every change should move clearly through GitHub:
 4. Validate the complete change and review your own diff.
 5. Open a standalone PR that resolves one clear issue, includes the necessary tests and documentation, and is ready for maintainer review.
 
-AI-assisted contributions must use a GitHub-aware development workflow such as [mach6](packages/coding-agent/docs/mach6.md), mach10, or an equivalent process that records the issue, plan, implementation, validation, and self-review on GitHub. The specific tool is not important; a traceable and reviewable result is.
+AI-assisted contributions must use a GitHub-aware development workflow such as [mach6](packages/coding-agent/docs/mach6.md), [mach10](github.com/LeanAndMean/mach10), or an equivalent process that records the issue, plan, implementation, validation, and self-review on GitHub. The specific tool is not important; a traceable and reviewable result is.
 
 For bugs, provide a minimal reproduction, test case, or sanitized log when possible. Fix the observed problem first rather than redesigning adjacent systems without evidence or maintainer agreement.
 


### PR DESCRIPTION
Updated the reference to mach10 in the AI-assisted contributions section to include a link.