### PR TITLE
Preserve compatible thinking traces across model switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ dreb supports both subscription and API-key providers, with model metadata updat
 
 Custom model configuration can override built-in provider base URLs, merge custom models into built-in providers, set compatibility flags for OpenAI-compatible servers, resolve API keys from shell commands or environment variables, and register providers dynamically from extensions.
 
+When switching models, dreb replays exact-model signed, encrypted, or redacted reasoning state unchanged. Portable structured reasoning is limited to models on the same provider using the OpenAI Chat Completions API when the destination accepts the source's recognized plain field (`reasoning_content`, `reasoning`, or `reasoning_text`); other readable reasoning is carried as labelled plaintext, while opaque redacted or encrypted-only state is not sent to incompatible targets. Provider identity and signature compatibility matter for custom models as well. Switching changes only the outbound request, so returning to the original model can replay its original state unless history has been compacted or pruned.
+
 Provider-specific docs include Kimi vision notes that distinguish the Kimi Code OAuth endpoint, the Kimi API-key coding provider, first-party Kimi CLI media handling, and Moonshot Open Platform vision support.
 
 ### Workflows and customization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11400,7 +11400,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11449,7 +11449,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11482,7 +11482,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.43.2",
+			"version": "2.43.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "22.x"
   },
   "packageManager": "npm@11.5.1",
-  "version": "2.43.2",
+  "version": "2.43.3",
   "dependencies": {
     "@dreb/coding-agent": "*",
     "@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -830,16 +830,27 @@ await streamAnthropic(claude, context, options);
 
 ## Cross-Provider Handoffs
 
-The library supports seamless handoffs between different LLM providers within the same conversation. This allows you to switch models mid-conversation while preserving context, including thinking blocks, tool calls, and tool results.
+The library can prepare one conversation for another model without changing the stored `Context`. User messages, visible assistant text, tool calls, and tool results remain available, while model-bound tool signatures and IDs are normalized for the destination. Provider-specific reasoning state is handled conservatively.
 
-### How It Works
+### Reasoning State Compatibility
 
-When messages from one provider are sent to a different provider, the library automatically transforms them for compatibility:
+- **Exact model:** signed, encrypted, and redacted reasoning state is replayed unchanged.
+- **Compatible model switch:** structured reasoning is preserved only when source and target share a provider, both use `openai-completions`, the destination accepts structured reasoning, and the source uses a recognized plain field: `reasoning_content`, `reasoning`, or `reasoning_text`.
+- **Other readable reasoning:** it is retained as labelled plaintext inside `<reformatted-pre-switch-reasoning>` markers, with incompatible protocol metadata stripped.
+- **Opaque state:** redacted or encrypted-only reasoning is omitted for incompatible targets.
 
-- **User and tool result messages** are passed through unchanged
-- **Assistant messages from the same provider/API** are preserved as-is
-- **Assistant messages from different providers** have their thinking blocks converted to text with `<thinking>` tags
-- **Tool calls and regular text** are preserved unchanged
+Compatibility depends on provider, API, and signature behavior. This includes custom models: two models at the same endpoint are not compatible merely because their IDs or URLs match; they must share the configured provider identity as well.
+
+The transformation applies only to the outbound request. It does not mutate `Context.messages`, so a later switch back to the original model can replay its original reasoning state unless that history has been compacted or pruned by the caller.
+
+### Examples
+
+| Source and target | Outbound reasoning state |
+|---|---|
+| The same model | Original signed, encrypted, or redacted state is replayed unchanged. |
+| Two models under the same custom provider, both using `openai-completions`, where the destination accepts the source's `reasoning_content`, `reasoning`, or `reasoning_text` field | Recognized plain structured reasoning is preserved. |
+| Different providers or APIs with readable reasoning | Reasoning is sent as labelled plaintext in `<reformatted-pre-switch-reasoning>` markers. |
+| An incompatible target with redacted or encrypted-only reasoning | Opaque reasoning state is omitted. |
 
 ### Example: Multi-Provider Conversation
 
@@ -858,31 +869,16 @@ const claudeResponse = await complete(claude, context, {
 });
 context.messages.push(claudeResponse);
 
-// Switch to GPT-5 - it will see Claude's thinking as <thinking> tagged text
+// Switch to GPT-5. Readable Claude reasoning is reformatted for this outbound request.
 const gpt5 = getModel('openai', 'gpt-5-mini');
 context.messages.push({ role: 'user', content: 'Is that calculation correct?' });
 const gptResponse = await complete(gpt5, context);
 context.messages.push(gptResponse);
 
-// Switch to Gemini
-const gemini = getModel('google', 'gemini-2.5-flash');
+// Switching back to Claude can use the original Claude state in context.
 context.messages.push({ role: 'user', content: 'What was the original question?' });
-const geminiResponse = await complete(gemini, context);
+const finalClaudeResponse = await complete(claude, context);
 ```
-
-### Provider Compatibility
-
-All providers can handle messages from other providers, including:
-- Text content
-- Tool calls and tool results (including images in tool results)
-- Thinking/reasoning blocks (transformed to tagged text for cross-provider compatibility)
-- Aborted messages with partial content
-
-This enables flexible workflows where you can:
-- Start with a fast model for initial responses
-- Switch to a more capable model for complex reasoning
-- Use specialized models for specific tasks
-- Maintain conversation continuity across provider outages
 
 ## Context Serialization
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -538,6 +538,7 @@ export function convertMessages(
 		model,
 		(id) => normalizeToolCallId(id),
 		(thinking, target, source) =>
+			target.reasoning &&
 			!compat.requiresThinkingAsText &&
 			source.provider === target.provider &&
 			source.api === "openai-completions" &&

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -33,6 +33,8 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
+const STRUCTURED_REASONING_FIELDS = new Set(["reasoning_content", "reasoning", "reasoning_text"]);
+
 /**
  * Check if conversation messages contain tool calls or tool results.
  * This is needed because Anthropic (via proxy) requires the tools param
@@ -183,9 +185,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					// or reasoning (other openai compatible endpoints)
 					// Use the first non-empty reasoning field to avoid duplication
 					// (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
-					const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
 					let foundReasoningField: string | null = null;
-					for (const field of reasoningFields) {
+					for (const field of STRUCTURED_REASONING_FIELDS) {
 						if (
 							(choice.delta as any)[field] !== null &&
 							(choice.delta as any)[field] !== undefined &&
@@ -532,7 +533,17 @@ export function convertMessages(
 		return id;
 	};
 
-	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
+	const transformedMessages = transformMessages(
+		context.messages,
+		model,
+		(id) => normalizeToolCallId(id),
+		(thinking, target, source) =>
+			!compat.requiresThinkingAsText &&
+			source.provider === target.provider &&
+			source.api === "openai-completions" &&
+			target.api === "openai-completions" &&
+			STRUCTURED_REASONING_FIELDS.has(thinking.thinkingSignature ?? ""),
+	);
 
 	if (context.systemPrompt) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
@@ -627,9 +638,10 @@ export function convertMessages(
 						assistantMsg.content = [{ type: "text", text: thinkingText }];
 					}
 				} else {
-					// Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)
+					// OpenAI-compatible reasoning signatures are field names. Whitelist them
+					// before using one as a dynamic outbound property.
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
-					if (signature && signature.length > 0) {
+					if (signature && STRUCTURED_REASONING_FIELDS.has(signature)) {
 						(assistantMsg as any)[signature] = sanitizeSurrogates(
 							nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n"),
 						);

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -1,4 +1,11 @@
-import type { Api, AssistantMessage, Message, Model, ToolCall, ToolResultMessage } from "../types.js";
+import type { Api, AssistantMessage, Message, Model, ThinkingContent, ToolCall, ToolResultMessage } from "../types.js";
+
+/** Decide whether a readable foreign thinking block can use the target's structured format. */
+export type PreserveCrossModelThinking<TApi extends Api> = (
+	thinking: ThinkingContent,
+	target: Model<TApi>,
+	source: AssistantMessage,
+) => boolean;
 
 /**
  * Normalize tool call ID for cross-provider compatibility.
@@ -9,6 +16,7 @@ export function transformMessages<TApi extends Api>(
 	messages: Message[],
 	model: Model<TApi>,
 	normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
+	preserveCrossModelThinking?: PreserveCrossModelThinking<TApi>,
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
@@ -37,7 +45,7 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.api === model.api &&
 				assistantMsg.model === model.id;
 
-			const transformedContent = assistantMsg.content.flatMap((block) => {
+			const transformedContent = assistantMsg.content.flatMap((block, index) => {
 				if (block.type === "thinking") {
 					// Redacted thinking is opaque encrypted content, only valid for the same model.
 					// Drop it for cross-model to avoid API errors.
@@ -45,14 +53,29 @@ export function transformMessages<TApi extends Api>(
 						return isSameModel ? block : [];
 					}
 					// For same model: keep thinking blocks with signatures (needed for replay)
-					// even if the thinking text is empty (OpenAI encrypted reasoning)
+					// even if the thinking text is empty (OpenAI encrypted reasoning).
 					if (isSameModel && block.thinkingSignature) return block;
-					// Skip empty thinking blocks, convert others to plain text
+					// Empty foreign thinking has no readable representation. This includes
+					// encrypted reasoning carried only by a signature.
 					if (!block.thinking || block.thinking.trim() === "") return [];
 					if (isSameModel) return block;
+					// Cross-model structural replay is destination-controlled. The caller
+					// must explicitly opt in rather than trusting an arbitrary signature.
+					if (preserveCrossModelThinking?.(block, model, assistantMsg)) return block;
+
+					const hasVisibleTextBefore = assistantMsg.content
+						.slice(0, index)
+						.some((content) => content.type === "text" && content.text.trim().length > 0);
+					const hasVisibleTextAfter = assistantMsg.content
+						.slice(index + 1)
+						.some((content) => content.type === "text" && content.text.trim().length > 0);
+					const separatorBefore = hasVisibleTextBefore ? "\n\n" : "";
+					const separatorAfter = hasVisibleTextAfter ? "\n\n" : "";
 					return {
 						type: "text" as const,
-						text: block.thinking,
+						text:
+							`${separatorBefore}<reformatted-pre-switch-reasoning>\n${block.thinking}\n` +
+							`</reformatted-pre-switch-reasoning>${separatorAfter}`,
 					};
 				}
 

--- a/packages/ai/test/openai-completions-kimi.test.ts
+++ b/packages/ai/test/openai-completions-kimi.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { streamSimple } from "../src/stream.js";
-import type { Model } from "../src/types.js";
+import type { AssistantMessage, Model } from "../src/types.js";
 
 const mockState = vi.hoisted(() => ({
 	lastParams: undefined as unknown,
+	chunks: undefined as unknown[] | undefined,
 }));
 
 vi.mock("openai", () => {
@@ -14,15 +15,19 @@ vi.mock("openai", () => {
 					mockState.lastParams = params;
 					return {
 						async *[Symbol.asyncIterator]() {
-							yield {
-								choices: [{ delta: {}, finish_reason: "stop" }],
-								usage: {
-									prompt_tokens: 1,
-									completion_tokens: 1,
-									prompt_tokens_details: { cached_tokens: 0 },
-									completion_tokens_details: { reasoning_tokens: 0 },
+							for (const chunk of mockState.chunks ?? [
+								{
+									choices: [{ delta: {}, finish_reason: "stop" }],
+									usage: {
+										prompt_tokens: 1,
+										completion_tokens: 1,
+										prompt_tokens_details: { cached_tokens: 0 },
+										completion_tokens_details: { reasoning_tokens: 0 },
+									},
 								},
-							};
+							]) {
+								yield chunk;
+							}
 						},
 					};
 				},
@@ -47,9 +52,34 @@ const KIMI_MODEL: Model<"openai-completions"> = {
 	compat: { thinkingFormat: "kimi" },
 };
 
+function assistantHistory(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "kimi-coding-oauth",
+		model: "kimi-for-coding",
+		content: [
+			{ type: "thinking", thinking: "historical plan", thinkingSignature: "reasoning_content" },
+			{ type: "text", text: "historical answer" },
+		],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+		...overrides,
+	};
+}
+
 describe("openai-completions kimi thinkingFormat", () => {
 	beforeEach(() => {
 		mockState.lastParams = undefined;
+		mockState.chunks = undefined;
 	});
 
 	it("sets thinking effort using the Kimi Code request shape", async () => {
@@ -255,5 +285,141 @@ describe("openai-completions kimi thinkingFormat", () => {
 		expect(params.reasoning_effort).toBeUndefined();
 		// prompt_cache_key is set inside the kimi branch which requires model.reasoning
 		expect(params.prompt_cache_key).toBeUndefined();
+	});
+
+	it.each(["reasoning_content", "reasoning", "reasoning_text"])(
+		"replays compatible Kimi %s structurally across Kimi models",
+		async (reasoningField) => {
+			const k3: Model<"openai-completions"> = {
+				...KIMI_MODEL,
+				provider: "kimi-coding-oauth",
+				id: "k3",
+			};
+			await streamSimple(
+				k3,
+				{
+					messages: [
+						{ role: "user", content: "hello", timestamp: 0 },
+						assistantHistory({
+							content: [
+								{ type: "thinking", thinking: "historical plan", thinkingSignature: reasoningField },
+								{ type: "text", text: "historical answer" },
+							],
+						}),
+					],
+				},
+				{ apiKey: "test" },
+			).result();
+
+			const params = mockState.lastParams as {
+				messages: Array<Record<string, unknown> & { role: string; content?: string | null }>;
+			};
+			const historical = params.messages.find((message) => message.role === "assistant");
+			expect(historical).toMatchObject({
+				role: "assistant",
+				content: "historical answer",
+				[reasoningField]: "historical plan",
+			});
+			expect(historical?.content).not.toContain("historical plan");
+		},
+	);
+
+	it("uses the labeled fallback when the destination requires thinking as text", async () => {
+		const k3: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			provider: "kimi-coding-oauth",
+			id: "k3",
+			compat: { thinkingFormat: "kimi", requiresThinkingAsText: true },
+		};
+		await streamSimple(
+			k3,
+			{
+				messages: [assistantHistory()],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as {
+			messages: Array<Record<string, unknown> & { role: string; content?: string | null }>;
+		};
+		const historical = params.messages.find((message) => message.role === "assistant");
+		expect(historical?.content).toBe(
+			"<reformatted-pre-switch-reasoning>\nhistorical plan\n" +
+				"</reformatted-pre-switch-reasoning>\n\nhistorical answer",
+		);
+		expect(historical).not.toHaveProperty("reasoning_content");
+	});
+
+	it("uses only labeled plaintext for incompatible Responses reasoning", async () => {
+		const k3: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			provider: "kimi-coding-oauth",
+			id: "k3",
+		};
+		await streamSimple(
+			k3,
+			{
+				messages: [
+					{ role: "user", content: "hello", timestamp: 0 },
+					assistantHistory({
+						api: "openai-codex-responses",
+						provider: "openai-codex",
+						model: "gpt-5.6-sol",
+						content: [
+							{
+								type: "thinking",
+								thinking: "readable summary",
+								thinkingSignature: JSON.stringify({ type: "reasoning", encrypted_content: "opaque" }),
+							},
+							{ type: "text", text: "historical answer" },
+						],
+					}),
+				],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as {
+			messages: Array<Record<string, unknown> & { role: string; content?: string | null }>;
+		};
+		const historical = params.messages.find((message) => message.role === "assistant");
+		expect(historical?.content).toBe(
+			"<reformatted-pre-switch-reasoning>\nreadable summary\n" +
+				"</reformatted-pre-switch-reasoning>\n\nhistorical answer",
+		);
+		expect(historical).not.toHaveProperty("reasoning_content");
+		expect(historical).not.toHaveProperty("reasoning");
+		expect(historical).not.toHaveProperty("reasoning_text");
+		expect(historical).not.toHaveProperty("reasoning_details");
+	});
+
+	it("parses reasoning_content deltas into thinking before visible text", async () => {
+		mockState.chunks = [
+			{
+				id: "response-1",
+				choices: [{ delta: { reasoning_content: "plan" }, finish_reason: null }],
+			},
+			{
+				id: "response-1",
+				choices: [{ delta: { content: "answer" }, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 1,
+					completion_tokens: 2,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+				},
+			},
+		];
+
+		const result = await streamSimple(
+			KIMI_MODEL,
+			{ messages: [{ role: "user", content: "Hi", timestamp: 0 }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "plan", thinkingSignature: "reasoning_content" },
+			{ type: "text", text: "answer" },
+		]);
 	});
 });

--- a/packages/ai/test/openai-completions-kimi.test.ts
+++ b/packages/ai/test/openai-completions-kimi.test.ts
@@ -324,6 +324,35 @@ describe("openai-completions kimi thinkingFormat", () => {
 		},
 	);
 
+	it("uses the labeled fallback when the compatible destination does not support reasoning", async () => {
+		const k3: Model<"openai-completions"> = {
+			...KIMI_MODEL,
+			provider: "kimi-coding-oauth",
+			id: "k3",
+			reasoning: false,
+		};
+		await streamSimple(
+			k3,
+			{
+				messages: [assistantHistory()],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as {
+			messages: Array<Record<string, unknown> & { role: string; content?: string | null }>;
+		};
+		const historical = params.messages.find((message) => message.role === "assistant");
+		expect(historical?.content).toBe(
+			"<reformatted-pre-switch-reasoning>\nhistorical plan\n" +
+				"</reformatted-pre-switch-reasoning>\n\nhistorical answer",
+		);
+		expect(historical).not.toHaveProperty("reasoning_content");
+		expect(historical).not.toHaveProperty("reasoning");
+		expect(historical).not.toHaveProperty("reasoning_text");
+		expect(historical).not.toHaveProperty("reasoning_details");
+	});
+
 	it("uses the labeled fallback when the destination requires thinking as text", async () => {
 		const k3: Model<"openai-completions"> = {
 			...KIMI_MODEL,

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -60,11 +60,19 @@ describe("OpenAI to Anthropic session migration for Copilot Claude", () => {
 		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
 		const assistantMsg = result.find((m) => m.role === "assistant") as AssistantMessage;
 
-		// Thinking block should be converted to text since models differ
+		// Thinking block should become explicitly labeled text since models differ.
 		const textBlocks = assistantMsg.content.filter((b) => b.type === "text");
 		const thinkingBlocks = assistantMsg.content.filter((b) => b.type === "thinking");
 		expect(thinkingBlocks).toHaveLength(0);
-		expect(textBlocks.length).toBeGreaterThanOrEqual(2);
+		expect(textBlocks).toEqual([
+			{
+				type: "text",
+				text:
+					"<reformatted-pre-switch-reasoning>\nLet me think about this...\n" +
+					"</reformatted-pre-switch-reasoning>\n\n",
+			},
+			{ type: "text", text: "Hi there!" },
+		]);
 	});
 
 	it("removes thoughtSignature from tool calls when migrating between models", () => {

--- a/packages/ai/test/transform-messages-thinking-handoff.test.ts
+++ b/packages/ai/test/transform-messages-thinking-handoff.test.ts
@@ -108,6 +108,26 @@ describe("transformMessages thinking handoff", () => {
 		]);
 	});
 
+	it("separates visible text before foreign thinking without adding a trailing separator", () => {
+		const target = model("openai-completions", "kimi-coding-oauth", "k3");
+		const message = assistant(
+			[
+				{ type: "text", text: "visible answer" },
+				{ type: "thinking", thinking: "foreign reasoning", thinkingSignature: "reasoning_content" },
+			],
+			{ provider: "other-provider", model: "other-model" },
+		);
+
+		const result = transformMessages([message], target, undefined, preserveCompatibleThinking);
+		expect((result[0] as AssistantMessage).content).toEqual([
+			{ type: "text", text: "visible answer" },
+			{
+				type: "text",
+				text: "\n\n<reformatted-pre-switch-reasoning>\nforeign reasoning\n</reformatted-pre-switch-reasoning>",
+			},
+		]);
+	});
+
 	it("wraps unknown readable signatures and omits redacted or empty foreign thinking", () => {
 		const target = model("openai-completions", "kimi-coding-oauth", "k3");
 		const message = assistant([

--- a/packages/ai/test/transform-messages-thinking-handoff.test.ts
+++ b/packages/ai/test/transform-messages-thinking-handoff.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "../src/providers/transform-messages.js";
+import type { Api, AssistantMessage, Message, Model, ThinkingContent } from "../src/types.js";
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const structuredReasoningFields = new Set(["reasoning_content", "reasoning", "reasoning_text"]);
+
+function model<TApi extends Api>(api: TApi, provider = "kimi-coding-oauth", id = "k3"): Model<TApi> {
+	return {
+		api,
+		provider,
+		id,
+		name: id,
+		baseUrl: "https://example.test/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16000,
+	};
+}
+
+function assistant(
+	content: AssistantMessage["content"],
+	overrides: Partial<Pick<AssistantMessage, "api" | "provider" | "model">> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "kimi-coding-oauth",
+		model: "kimi-for-coding",
+		usage,
+		stopReason: "stop",
+		timestamp: 1,
+		...overrides,
+	};
+}
+
+function preserveCompatibleThinking<TApi extends Api>(
+	thinking: ThinkingContent,
+	target: Model<TApi>,
+	source: AssistantMessage,
+): boolean {
+	return (
+		source.provider === target.provider &&
+		source.api === "openai-completions" &&
+		target.api === "openai-completions" &&
+		structuredReasoningFields.has(thinking.thinkingSignature ?? "")
+	);
+}
+
+describe("transformMessages thinking handoff", () => {
+	it("replays exact-model plain, signed, redacted, and empty encrypted thinking unchanged", () => {
+		const target = model("openai-completions", "kimi-coding-oauth", "kimi-for-coding");
+		const message = assistant([
+			{ type: "thinking", thinking: "plain reasoning" },
+			{ type: "thinking", thinking: "signed reasoning", thinkingSignature: "signed-state" },
+			{ type: "thinking", thinking: "", thinkingSignature: "encrypted-state", redacted: true },
+			{ type: "thinking", thinking: "", thinkingSignature: "reasoning_content" },
+		]);
+
+		const result = transformMessages([message], target, undefined, preserveCompatibleThinking);
+		expect((result[0] as AssistantMessage).content).toEqual(message.content);
+	});
+
+	it.each(["reasoning_content", "reasoning", "reasoning_text"])(
+		"preserves %s structurally for a compatible OpenAI-completions destination",
+		(thinkingSignature) => {
+			const target = model("openai-completions", "kimi-coding-oauth", "k3");
+			const message = assistant([
+				{ type: "thinking", thinking: "portable reasoning", thinkingSignature },
+				{ type: "text", text: "visible answer" },
+			]);
+
+			const result = transformMessages([message], target, undefined, preserveCompatibleThinking);
+			expect((result[0] as AssistantMessage).content).toEqual(message.content);
+		},
+	);
+
+	it.each([
+		[model("openai-completions", "other-provider", "other-model"), {}],
+		[model("openai-completions", "kimi-coding-oauth", "k3"), { api: "openai-responses" as const }],
+	])("uses the labeled fallback across provider or API boundaries", (target, sourceOverride) => {
+		const message = assistant(
+			[
+				{ type: "thinking", thinking: "foreign reasoning", thinkingSignature: "reasoning_content" },
+				{ type: "text", text: "visible answer" },
+			],
+			sourceOverride,
+		);
+
+		const result = transformMessages([message], target, undefined, preserveCompatibleThinking);
+		expect((result[0] as AssistantMessage).content).toEqual([
+			{
+				type: "text",
+				text: "<reformatted-pre-switch-reasoning>\nforeign reasoning\n" + "</reformatted-pre-switch-reasoning>\n\n",
+			},
+			{ type: "text", text: "visible answer" },
+		]);
+	});
+
+	it("wraps unknown readable signatures and omits redacted or empty foreign thinking", () => {
+		const target = model("openai-completions", "kimi-coding-oauth", "k3");
+		const message = assistant([
+			{ type: "thinking", thinking: "unknown but readable", thinkingSignature: "private_reasoning" },
+			{ type: "thinking", thinking: "secret", thinkingSignature: "reasoning_content", redacted: true },
+			{ type: "thinking", thinking: "", thinkingSignature: "reasoning_content" },
+		]);
+
+		const result = transformMessages([message], target, undefined, preserveCompatibleThinking);
+		expect((result[0] as AssistantMessage).content).toEqual([
+			{
+				type: "text",
+				text: "<reformatted-pre-switch-reasoning>\nunknown but readable\n" + "</reformatted-pre-switch-reasoning>",
+			},
+		]);
+	});
+
+	it("does not mutate history and restores original protocol state when returning to the source", () => {
+		const source = model("openai-codex-responses", "openai-codex", "gpt-5.6-sol");
+		const target = model("openai-completions", "kimi-coding-oauth", "k3");
+		const encryptedSignature = JSON.stringify({
+			type: "reasoning",
+			id: "rs_original",
+			encrypted_content: "opaque",
+		});
+		const messages: Message[] = [
+			{ role: "user", content: "hello", timestamp: 0 },
+			assistant(
+				[
+					{ type: "thinking", thinking: "readable summary", thinkingSignature: encryptedSignature },
+					{ type: "text", text: "visible answer" },
+				],
+				{ api: "openai-codex-responses", provider: "openai-codex", model: "gpt-5.6-sol" },
+			),
+		];
+		const original = JSON.parse(JSON.stringify(messages)) as Message[];
+
+		const handedOff = transformMessages(messages, target, undefined, preserveCompatibleThinking);
+		expect((handedOff[1] as AssistantMessage).content).toEqual([
+			{
+				type: "text",
+				text: "<reformatted-pre-switch-reasoning>\nreadable summary\n</reformatted-pre-switch-reasoning>\n\n",
+			},
+			{ type: "text", text: "visible answer" },
+		]);
+		expect(messages).toEqual(original);
+
+		const returned = transformMessages(messages, source, undefined, preserveCompatibleThinking);
+		expect(returned).toEqual(original);
+	});
+});

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -129,6 +129,8 @@ See [docs/providers.md](docs/providers.md) for detailed setup instructions, incl
 
 **Custom providers & models:** Add providers via `~/.dreb/agent/models.json` if they speak a supported API (OpenAI, Anthropic, Google). For custom APIs or OAuth, use extensions. See [docs/models.md](docs/models.md) and [docs/custom-provider.md](docs/custom-provider.md).
 
+**Reasoning across model switches:** Exact-model signed, encrypted, or redacted reasoning state is replayed unchanged. Structured reasoning is portable only between models that share a provider and the `openai-completions` API when the destination accepts the source's recognized plain field (`reasoning_content`, `reasoning`, or `reasoning_text`). Other readable reasoning is retained as labelled plaintext in `<reformatted-pre-switch-reasoning>` markers with incompatible protocol metadata removed; opaque redacted or encrypted-only state is omitted for incompatible targets. This outbound conversion does not change session history, so switching back can replay the original state unless it was compacted or pruned. Custom models must also share provider identity and compatible API/signature behavior.
+
 ---
 
 ## Interactive Mode

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -11,6 +11,7 @@ Add custom providers and models (Ollama, vLLM, LM Studio, proxies) via `~/.dreb/
 - [Model Configuration](#model-configuration)
 - [Overriding Built-in Providers](#overriding-built-in-providers)
 - [Per-model Overrides](#per-model-overrides)
+- [Reasoning Across Model Switches](#reasoning-across-model-switches)
 - [OpenAI Compatibility](#openai-compatibility)
 
 ## Minimal Example
@@ -235,6 +236,12 @@ Behavior notes:
 - Unknown model IDs are ignored.
 - You can combine provider-level `baseUrl`/`headers` with `modelOverrides`.
 - If `models` is also defined for a provider, custom models are merged after built-in overrides. A custom model with the same `id` replaces the overridden built-in model entry.
+
+## Reasoning Across Model Switches
+
+A custom model's `provider` identity is part of reasoning-state compatibility; matching endpoint URLs or model IDs alone is not enough. Exact-model signed, encrypted, or redacted reasoning state is replayed unchanged. Between different models, structured reasoning is preserved only when both models use the same provider and `openai-completions` API, the destination accepts structured reasoning, and the source uses a recognized plain field: `reasoning_content`, `reasoning`, or `reasoning_text`.
+
+For other targets, readable reasoning is retained as labelled plaintext inside `<reformatted-pre-switch-reasoning>` markers after incompatible protocol metadata is stripped. Redacted or encrypted-only opaque state is omitted. This conversion happens only for the outbound request and does not alter session history, so returning to the original model can replay its original state unless history has been compacted or pruned. Portability also depends on compatible provider signatures.
 
 ## OpenAI Compatibility
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.43.2",
+  "version": "2.43.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.43.2",
+	"version": "2.43.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #374

Preserve compatible structured reasoning across model switches and clearly label readable reasoning reformatted for incompatible destinations.

Implementation plan posted as a comment below.
