### PR TITLE
Fix ask_user schema compatibility with llama.cpp

### DIFF
--- a/packages/coding-agent/src/core/tools/ask-user.ts
+++ b/packages/coding-agent/src/core/tools/ask-user.ts
@@ -45,7 +45,7 @@ const askUserSchema = Type.Object({
 		}),
 	),
 	options: Type.Optional(
-		Type.Array(Type.String({ minLength: 1, pattern: "\\S" }), {
+		Type.Array(Type.String({ minLength: 1, pattern: "^.*[^ \\t\\r\\n].*$" }), {
 			minItems: 2,
 			maxItems: 4,
 			description: "2-4 nonblank suggested answers the user can pick from.",

--- a/packages/coding-agent/test/tools/ask-user.test.ts
+++ b/packages/coding-agent/test/tools/ask-user.test.ts
@@ -47,10 +47,12 @@ describe("ask_user tool", () => {
 		const props = (def.parameters as any).properties;
 		expect(props.options.minItems).toBe(2);
 		expect(props.options.maxItems).toBe(4);
+		expect(props.options.items.pattern).toBe("^.*[^ \\t\\r\\n].*$");
 		expect(props.question.type).toBe("string");
 		expect(Value.Check(def.parameters, { question: "Pick", options: ["A", "B"] })).toBe(true);
 		expect(Value.Check(def.parameters, { question: "Pick", options: ["", "B"] })).toBe(false);
 		expect(Value.Check(def.parameters, { question: "Pick", options: ["   ", "B"] })).toBe(false);
+		expect(Value.Check(def.parameters, { question: "Pick", options: ["\t\r", "B"] })).toBe(false);
 	});
 
 	it("returns a graceful non-blocking result when no UI is available", async () => {


### PR DESCRIPTION
## Summary

- anchor the `ask_user` option pattern as required by llama.cpp's JSON Schema converter
- replace unsupported `\S` syntax with a compatible negated whitespace character class
- retain rejection of empty and whitespace-only options

## Failure mode

llama.cpp rejected every request before inference because all tool schemas are included in the prompt, even when `ask_user` is not used:

```text
Unable to generate parser for this template. Automatic parser generation failed: JSON schema conversion failed:
Pattern must start with '^' and end with '$'
```

After anchoring alone, llama.cpp still rejected `\S` while parsing the generated grammar. The updated pattern was verified against the live local Qwen endpoint.

## Validation

- `npx biome check --error-on-warnings .`
- `npx tsgo --noEmit`
- `bash test.sh --no-live-api` — 5,355 passed, 709 skipped
- live llama.cpp/Qwen request with the corrected tool schema
