### PR TITLE
Bound dashboard streaming payloads for fast local models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.55.2",
+			"version": "2.55.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/server/event-hub.ts
+++ b/packages/dashboard/src/server/event-hub.ts
@@ -73,8 +73,13 @@ export function projectDashboardEvent(event: Record<string, unknown>): Record<st
 			return omit(event, "messages");
 		case "turn_end":
 			return omit(event, "message", "toolResults");
-		case "message_update":
-			return omit(event, "message");
+		case "message_update": {
+			const projected = omit(event, "message");
+			const streamEvent = event.assistantMessageEvent;
+			return streamEvent && typeof streamEvent === "object" && !Array.isArray(streamEvent)
+				? { ...projected, assistantMessageEvent: omit(streamEvent as Record<string, unknown>, "partial") }
+				: projected;
+		}
 		case "tool_execution_update":
 			return omit(event, "args");
 		case "stream_retry":

--- a/packages/dashboard/test/event-hub.test.ts
+++ b/packages/dashboard/test/event-hub.test.ts
@@ -258,42 +258,141 @@ describe("EventHub", () => {
 	});
 
 	it("projects only reducer-unused cumulative fields and preserves reducer behavior", () => {
+		const textMessage = (text: string) => ({
+			role: "assistant",
+			model: "fast-local",
+			content: [{ type: "text", text }],
+		});
+		const thinkingMessage = (thinking: string) => ({
+			role: "assistant",
+			model: "fast-local",
+			content: [{ type: "thinking", thinking }],
+		});
+		const directDelta = {
+			type: "message_update",
+			message: textMessage("hello"),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "hello",
+				partial: textMessage("hello"),
+				futureField: "kept",
+			},
+			transportField: "kept",
+		};
+		const directEnd = {
+			type: "message_update",
+			message: textMessage("hello"),
+			assistantMessageEvent: {
+				type: "text_end",
+				contentIndex: 0,
+				content: "hello",
+				partial: textMessage("hello"),
+			},
+		};
+		const childDelta = {
+			type: "background_agent_event",
+			agentId: "child",
+			event: {
+				type: "message_update",
+				message: thinkingMessage("reasoning"),
+				assistantMessageEvent: {
+					type: "thinking_delta",
+					contentIndex: 0,
+					delta: "reasoning",
+					partial: thinkingMessage("reasoning"),
+				},
+			},
+		};
+		const agentEnd = { type: "agent_end", messages: [{ huge: "x".repeat(200) }] };
+		const toolUpdate = {
+			type: "tool_execution_update",
+			toolCallId: "tool",
+			toolName: "bash",
+			args: { huge: "x".repeat(200) },
+			partialResult: "ok",
+		};
+		const turnEnd = {
+			type: "turn_end",
+			message: { huge: "x".repeat(200) },
+			toolResults: [{ huge: "x".repeat(200) }],
+		};
+		const streamRetry = {
+			type: "stream_retry",
+			attempt: 1,
+			maxAttempts: 2,
+			error: "kept",
+			discardedPartial: { huge: "x".repeat(200) },
+		};
+		const lengthRetry = {
+			type: "length_retry",
+			attempt: 1,
+			maxAttempts: 2,
+			previousMaxTokens: 100,
+			nextMaxTokens: 200,
+			discardedPartial: { huge: "x".repeat(200) },
+		};
+		const childEnd = {
+			type: "background_agent_event",
+			agentId: "child",
+			event: { type: "agent_end", messages: [{ huge: "x".repeat(200) }] },
+		};
+		const unknown = { type: "unknown_extension_event", cumulative: "kept" };
 		const events = [
-			{ type: "agent_end", messages: [{ huge: "x".repeat(200) }] },
+			{ type: "message_start", message: textMessage("") },
 			{
 				type: "message_update",
-				message: { content: "x".repeat(200) },
-				assistantMessageEvent: { type: "text_start" },
+				message: textMessage(""),
+				assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: textMessage("") },
 			},
+			directDelta,
+			directEnd,
+			{ type: "message_end", message: textMessage("hello") },
 			{
-				type: "tool_execution_update",
-				toolCallId: "tool",
-				toolName: "bash",
-				args: { huge: "x".repeat(200) },
-				partialResult: "ok",
-			},
-			{ type: "turn_end", message: { huge: "x".repeat(200) }, toolResults: [{ huge: "x".repeat(200) }] },
-			{
-				type: "stream_retry",
-				attempt: 1,
-				maxAttempts: 2,
-				error: "kept",
-				discardedPartial: { huge: "x".repeat(200) },
-			},
-			{
-				type: "length_retry",
-				attempt: 1,
-				maxAttempts: 2,
-				previousMaxTokens: 100,
-				nextMaxTokens: 200,
-				discardedPartial: { huge: "x".repeat(200) },
+				type: "background_agent_event",
+				agentId: "child",
+				event: { type: "message_start", message: thinkingMessage("") },
 			},
 			{
 				type: "background_agent_event",
 				agentId: "child",
-				event: { type: "agent_end", messages: [{ huge: "x".repeat(200) }] },
+				event: {
+					type: "message_update",
+					message: thinkingMessage(""),
+					assistantMessageEvent: {
+						type: "thinking_start",
+						contentIndex: 0,
+						partial: thinkingMessage(""),
+					},
+				},
 			},
-			{ type: "unknown_extension_event", cumulative: "kept" },
+			childDelta,
+			{
+				type: "background_agent_event",
+				agentId: "child",
+				event: {
+					type: "message_update",
+					message: thinkingMessage("reasoning"),
+					assistantMessageEvent: {
+						type: "thinking_end",
+						contentIndex: 0,
+						content: "reasoning",
+						partial: thinkingMessage("reasoning"),
+					},
+				},
+			},
+			{
+				type: "background_agent_event",
+				agentId: "child",
+				event: { type: "message_end", message: thinkingMessage("reasoning") },
+			},
+			agentEnd,
+			toolUpdate,
+			turnEnd,
+			streamRetry,
+			lengthRetry,
+			childEnd,
+			unknown,
 		] as Record<string, unknown>[];
 		const full = createSessionViewState("k");
 		const projected = createSessionViewState("k");
@@ -301,16 +400,127 @@ describe("EventHub", () => {
 			applySessionEvent(full, event);
 			applySessionEvent(projected, projectDashboardEvent(event));
 		}
+
 		expect(projected).toEqual(full);
-		expect(projectDashboardEvent(events[0]!)).not.toHaveProperty("messages");
-		expect(projectDashboardEvent(events[1]!)).not.toHaveProperty("message");
-		expect(projectDashboardEvent(events[2]!)).not.toHaveProperty("args");
-		expect(projectDashboardEvent(events[2]!)).toMatchObject({ toolName: "bash" });
-		expect(projectDashboardEvent(events[4]!)).not.toHaveProperty("discardedPartial");
-		expect(projectDashboardEvent(events[5]!)).not.toHaveProperty("discardedPartial");
-		expect(projectDashboardEvent(events[6]!)).toMatchObject({ event: { type: "agent_end" } });
-		expect((projectDashboardEvent(events[6]!).event as Record<string, unknown>).messages).toBeUndefined();
-		expect(projectDashboardEvent(events[7]!)).toBe(events[7]);
+		expect(projected.entries).toMatchObject([
+			{ kind: "assistant", streaming: false, blocks: [{ kind: "text", text: "hello" }] },
+		]);
+		expect(projected.subagents.child?.entries).toMatchObject([
+			{ kind: "assistant", streaming: false, blocks: [{ kind: "thinking", text: "reasoning" }] },
+		]);
+		const projectedDirect = projectDashboardEvent(directDelta);
+		expect(projectedDirect).not.toHaveProperty("message");
+		expect(projectedDirect).toMatchObject({
+			transportField: "kept",
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "hello",
+				futureField: "kept",
+			},
+		});
+		expect(projectedDirect.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectDashboardEvent(directEnd)).toMatchObject({
+			assistantMessageEvent: { type: "text_end", contentIndex: 0, content: "hello" },
+		});
+		expect(directDelta).toHaveProperty("message");
+		expect(directDelta.assistantMessageEvent).toHaveProperty("partial");
+
+		const projectedChild = projectDashboardEvent(childDelta).event as Record<string, unknown>;
+		expect(projectedChild).not.toHaveProperty("message");
+		expect(projectedChild.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectedChild).toMatchObject({
+			assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "reasoning" },
+		});
+		expect(projectDashboardEvent(agentEnd)).not.toHaveProperty("messages");
+		expect(projectDashboardEvent(toolUpdate)).not.toHaveProperty("args");
+		expect(projectDashboardEvent(toolUpdate)).toMatchObject({ toolName: "bash" });
+		expect(projectDashboardEvent(turnEnd)).not.toHaveProperty("message");
+		expect(projectDashboardEvent(turnEnd)).not.toHaveProperty("toolResults");
+		expect(projectDashboardEvent(streamRetry)).not.toHaveProperty("discardedPartial");
+		expect(projectDashboardEvent(lengthRetry)).not.toHaveProperty("discardedPartial");
+		expect(projectDashboardEvent(childEnd)).toMatchObject({ event: { type: "agent_end" } });
+		expect((projectDashboardEvent(childEnd).event as Record<string, unknown>).messages).toBeUndefined();
+		expect(projectDashboardEvent(unknown)).toBe(unknown);
+	});
+
+	it("keeps a long cumulative stream bounded, replayable, and transcript-exact", () => {
+		const deltaCount = 2_000;
+		const delta = "token ";
+		const byteBudget = 512 * 1024;
+		const eventBytes = 512;
+		const hub = new EventHub({
+			bufferSize: deltaCount + 2,
+			bufferBytes: byteBudget,
+			replayBytes: byteBudget,
+			eventBytes,
+		});
+		const live = collectClient();
+		hub.attach(live.client);
+		const message = (text: string) => ({
+			role: "assistant",
+			model: "fast-local",
+			content: [{ type: "text", text }],
+		});
+
+		hub.publish("runtime", { type: "message_start", message: message("") });
+		hub.publish("runtime", {
+			type: "message_update",
+			message: message(""),
+			assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: message("") },
+		});
+		let expectedText = "";
+		let lastRawEvent: Record<string, unknown> | undefined;
+		for (let index = 0; index < deltaCount; index += 1) {
+			expectedText += delta;
+			const partial = message(expectedText);
+			lastRawEvent = {
+				type: "message_update",
+				message: partial,
+				assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta, partial },
+			};
+			hub.publish("runtime", lastRawEvent);
+		}
+
+		expect(lastRawEvent).toBeDefined();
+		expect(
+			Buffer.byteLength(formatSseFrame({ seq: deltaCount + 2, key: "runtime", event: lastRawEvent! })),
+		).toBeGreaterThan(eventBytes);
+		expect(hub.clientCount).toBe(1);
+		expect(hub.historyCount).toBe(deltaCount + 2);
+		expect(hub.historyBytes).toBeLessThan(byteBudget);
+		const liveEnvelopes = live.envelopes();
+		expect(liveEnvelopes).toHaveLength(deltaCount + 2);
+		expect(liveEnvelopes.some((envelope) => envelope.event.type === "dashboard_resync")).toBe(false);
+		const deltaFrameBytes = live.chunks
+			.filter((chunk) => chunk.includes('"type":"text_delta"'))
+			.map((chunk) => Buffer.byteLength(chunk));
+		expect(deltaFrameBytes).toHaveLength(deltaCount);
+		expect(Math.max(...deltaFrameBytes)).toBeLessThan(eventBytes);
+		expect(Math.max(...deltaFrameBytes) - Math.min(...deltaFrameBytes)).toBeLessThan(16);
+		expect(live.chunks.reduce((bytes, chunk) => bytes + Buffer.byteLength(chunk), 0)).toBe(hub.historyBytes);
+
+		const replayed = collectClient();
+		const replayDiagnostic = vi.fn();
+		hub.attach(replayed.client, 0, replayDiagnostic);
+		expect(replayDiagnostic).toHaveBeenCalledWith({
+			kind: "replay",
+			count: deltaCount + 2,
+			bytes: hub.historyBytes,
+			fromSeq: 1,
+			toSeq: deltaCount + 2,
+		});
+		expect(replayed.envelopes()).toHaveLength(deltaCount + 2);
+		expect(replayed.envelopes().some((envelope) => envelope.event.type === "dashboard_resync")).toBe(false);
+
+		const liveState = createSessionViewState("runtime");
+		const replayedState = createSessionViewState("runtime");
+		for (const envelope of liveEnvelopes) applySessionEvent(liveState, envelope.event);
+		for (const envelope of replayed.envelopes()) applySessionEvent(replayedState, envelope.event);
+		expect(replayedState).toEqual(liveState);
+		expect(liveState.entries).toMatchObject([
+			{ kind: "assistant", streaming: true, blocks: [{ kind: "text", text: expectedText }] },
+		]);
 	});
 
 	it("preserves assistant stop reason and provider error text on projected message_end", () => {

--- a/packages/dashboard/test/event-hub.test.ts
+++ b/packages/dashboard/test/event-hub.test.ts
@@ -523,6 +523,187 @@ describe("EventHub", () => {
 		]);
 	});
 
+	it("projects toolcall stream deltas and preserves final toolCall through bounded transport", () => {
+		const toolMessage = (args: Record<string, unknown>) => ({
+			role: "assistant",
+			model: "fast-local",
+			content: [{ type: "toolCall", id: "tc1", name: "bash", arguments: args }],
+		});
+		const toolCall = { type: "toolCall", id: "tc1", name: "bash", arguments: { cmd: "ls" } };
+		const start = {
+			type: "message_update",
+			message: toolMessage({}),
+			assistantMessageEvent: { type: "toolcall_start", contentIndex: 2, partial: toolMessage({}) },
+		};
+		const delta = {
+			type: "message_update",
+			message: toolMessage({ cmd: 'ls /tmp"' }),
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 2,
+				delta: 'ls /tmp"',
+				partial: toolMessage({ cmd: 'ls /tmp"' }),
+				futureField: "kept",
+			},
+			transportField: "kept",
+		};
+		const end = {
+			type: "message_update",
+			message: toolMessage({ cmd: "ls /tmp" }),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 2,
+				toolCall,
+				partial: toolMessage({ cmd: "ls /tmp" }),
+			},
+		};
+		const childEnd = {
+			type: "background_agent_event",
+			agentId: "child",
+			event: {
+				type: "message_update",
+				message: toolMessage({ cmd: "ls /tmp" }),
+				assistantMessageEvent: { type: "toolcall_end", contentIndex: 0, toolCall, partial: toolMessage({}) },
+			},
+		};
+
+		const events = [start, delta, end, childEnd] as Record<string, unknown>[];
+		const full = createSessionViewState("k");
+		const projected = createSessionViewState("k");
+		for (const event of events) {
+			applySessionEvent(full, event);
+			applySessionEvent(projected, projectDashboardEvent(event));
+		}
+		expect(projected).toEqual(full);
+
+		const projectedStart = projectDashboardEvent(start);
+		expect(projectedStart).not.toHaveProperty("message");
+		expect(projectedStart.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectedStart).toMatchObject({ assistantMessageEvent: { type: "toolcall_start", contentIndex: 2 } });
+
+		const projectedDelta = projectDashboardEvent(delta);
+		expect(projectedDelta).not.toHaveProperty("message");
+		expect(projectedDelta.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectedDelta).toMatchObject({
+			transportField: "kept",
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 2,
+				delta: 'ls /tmp"',
+				futureField: "kept",
+			},
+		});
+
+		const projectedEnd = projectDashboardEvent(end);
+		expect(projectedEnd).not.toHaveProperty("message");
+		expect(projectedEnd.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectedEnd.assistantMessageEvent).toMatchObject({
+			type: "toolcall_end",
+			contentIndex: 2,
+			toolCall,
+		});
+
+		const projectedChild = projectDashboardEvent(childEnd).event as Record<string, unknown>;
+		expect(projectedChild).not.toHaveProperty("message");
+		expect(projectedChild.assistantMessageEvent).not.toHaveProperty("partial");
+		expect(projectedChild.assistantMessageEvent).toMatchObject({ type: "toolcall_end", toolCall });
+
+		expect(start).toHaveProperty("message");
+		expect(start.assistantMessageEvent).toHaveProperty("partial");
+		expect(delta).toHaveProperty("message");
+		expect(delta.assistantMessageEvent).toHaveProperty("partial");
+		expect(end).toHaveProperty("message");
+		expect(end.assistantMessageEvent).toHaveProperty("partial");
+		expect(childEnd.event).toHaveProperty("message");
+		expect((childEnd.event as Record<string, unknown>).assistantMessageEvent).toHaveProperty("partial");
+
+		const deltaCount = 2_000;
+		const byteBudget = 512 * 1024;
+		const eventBytes = 512;
+		const hub = new EventHub({
+			bufferSize: deltaCount + 3,
+			bufferBytes: byteBudget,
+			replayBytes: byteBudget,
+			eventBytes,
+		});
+		const live = collectClient();
+		hub.attach(live.client);
+
+		hub.publish("runtime", { type: "message_start", message: toolMessage({}) });
+		hub.publish("runtime", {
+			type: "message_update",
+			message: toolMessage({}),
+			assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, partial: toolMessage({}) },
+		});
+		let expectedArgs = "";
+		let lastRawEvent: Record<string, unknown> | undefined;
+		for (let index = 0; index < deltaCount; index += 1) {
+			expectedArgs += `arg${index} `;
+			const partial = toolMessage({ cmd: expectedArgs });
+			lastRawEvent = {
+				type: "message_update",
+				message: partial,
+				assistantMessageEvent: {
+					type: "toolcall_delta",
+					contentIndex: 0,
+					delta: `arg${index} `,
+					partial,
+				},
+			};
+			hub.publish("runtime", lastRawEvent);
+		}
+		hub.publish("runtime", {
+			type: "message_update",
+			message: toolMessage({ cmd: expectedArgs }),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall,
+				partial: toolMessage({ cmd: expectedArgs }),
+			},
+		});
+
+		expect(lastRawEvent).toBeDefined();
+		expect(
+			Buffer.byteLength(formatSseFrame({ seq: deltaCount + 2, key: "runtime", event: lastRawEvent! })),
+		).toBeGreaterThan(eventBytes);
+		expect(hub.clientCount).toBe(1);
+		expect(hub.historyCount).toBe(deltaCount + 3);
+		expect(hub.historyBytes).toBeLessThan(byteBudget);
+		const liveEnvelopes = live.envelopes();
+		expect(liveEnvelopes).toHaveLength(deltaCount + 3);
+		expect(liveEnvelopes.some((envelope) => envelope.event.type === "dashboard_resync")).toBe(false);
+		expect(liveEnvelopes.at(-1)?.event).toMatchObject({
+			type: "message_update",
+			assistantMessageEvent: { type: "toolcall_end", toolCall },
+		});
+		const deltaFrameBytes = live.chunks
+			.filter((chunk) => chunk.includes('"type":"toolcall_delta"'))
+			.map((chunk) => Buffer.byteLength(chunk));
+		expect(deltaFrameBytes).toHaveLength(deltaCount);
+		expect(Math.max(...deltaFrameBytes)).toBeLessThan(eventBytes);
+		expect(Math.max(...deltaFrameBytes) - Math.min(...deltaFrameBytes)).toBeLessThan(16);
+
+		const replayed = collectClient();
+		const replayDiagnostic = vi.fn();
+		hub.attach(replayed.client, 0, replayDiagnostic);
+		expect(replayDiagnostic).toHaveBeenCalledWith({
+			kind: "replay",
+			count: deltaCount + 3,
+			bytes: hub.historyBytes,
+			fromSeq: 1,
+			toSeq: deltaCount + 3,
+		});
+		expect(replayed.envelopes()).toHaveLength(deltaCount + 3);
+		expect(replayed.envelopes().some((envelope) => envelope.event.type === "dashboard_resync")).toBe(false);
+
+		const liveState = createSessionViewState("runtime");
+		const replayedState = createSessionViewState("runtime");
+		for (const envelope of liveEnvelopes) applySessionEvent(liveState, envelope.event);
+		for (const envelope of replayed.envelopes()) applySessionEvent(replayedState, envelope.event);
+		expect(replayedState).toEqual(liveState);
+	});
+
 	it("preserves assistant stop reason and provider error text on projected message_end", () => {
 		const event = {
 			type: "message_end",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.55.2",
+  "version": "2.55.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.55.2",
+	"version": "2.55.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #445

Bound the dashboard's high-rate streaming transport by removing reducer-unused cumulative state before SSE sizing, retention, and fanout, while preserving exact live and recovery behavior.

Implementation plan posted as a comment below.
