### PR TITLE
Bound dashboard fleet and session inventory payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.55.3",
+			"version": "2.55.4",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/dashboard.md
+++ b/packages/coding-agent/docs/dashboard.md
@@ -220,9 +220,13 @@ debounce from its in-memory state, so an update performs neither child RPC calls
 nor a disk inventory scan.
 
 Live runtime state and on-disk session inventory have separate refresh paths.
-After creating, resuming, stopping, or deleting a session, the client narrowly
-refreshes the disk list through `GET /api/sessions` rather than reloading the
-whole fleet. While the Fleet screen is visible, it polls each live runtime's
+Before fleet, inventory, or resync serialization, the server explicitly projects
+each on-disk session to the declared browser DTO and bounds its first-message
+preview to 256 Unicode characters. Internal parent paths and complete searchable
+transcript text never cross this browser boundary. After creating, resuming,
+stopping, or deleting a session, the client narrowly refreshes the disk list
+through `GET /api/sessions` rather than reloading the whole fleet. While the
+Fleet screen is visible, it polls each live runtime's
 stats no more often than every 30 seconds. That poll is single-flight, retains a
 card's last good stats if an update fails, and surfaces failures in the Fleet UI.
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -153,9 +153,13 @@ live runtime cards are updated by global, event-derived `fleet_snapshot` SSE
 frames, debounced by 200 ms. Those frames are built from the pool's in-memory
 runtime state, so they do not trigger child RPC calls or a disk inventory scan.
 
-Disk inventory is separate from live-runtime state. The client narrowly refreshes
-it with `GET /api/sessions` after create, resume, stop, or delete, rather than
-reloading the whole fleet. While the Fleet screen is visible, it refreshes
+Disk inventory is separate from live-runtime state. Before fleet, inventory, or
+resync serialization, the server projects each on-disk session to the declared
+browser DTO and bounds its first-message preview to 256 Unicode characters;
+internal parent paths and complete searchable transcript text never cross this
+boundary. The client narrowly refreshes inventory with `GET /api/sessions` after
+create, resume, stop, or delete, rather than reloading the whole fleet. While the
+Fleet screen is visible, it refreshes
 per-runtime stats no more often than every 30 seconds; the refresh is
 single-flight, preserves each card's last good values, and exposes refresh
 failures in the UI.

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/server/server.ts
+++ b/packages/dashboard/src/server/server.ts
@@ -25,7 +25,11 @@ import type {
 	SessionInfoDto,
 	SessionInventoryDto,
 } from "../shared/protocol.js";
-import { MAX_CLIENT_DIAGNOSTIC_BYTES, MAX_PROMPT_BODY_BYTES } from "../shared/protocol.js";
+import {
+	MAX_CLIENT_DIAGNOSTIC_BYTES,
+	MAX_PROMPT_BODY_BYTES,
+	MAX_SESSION_PREVIEW_CHARACTERS,
+} from "../shared/protocol.js";
 import type { AuthDecision, DashboardAuth } from "./auth.js";
 import {
 	DASHBOARD_IMAGE_ID_PATTERN,
@@ -46,13 +50,24 @@ export type DashboardServerApp = express.Express & {
 	closeDashboard(): Promise<void>;
 };
 
+export interface DashboardSessionInfoSource {
+	path: string;
+	id: string;
+	cwd: string;
+	name?: string;
+	created: Date;
+	modified: Date;
+	messageCount: number;
+	firstMessage: string;
+}
+
 export interface DashboardServerOptions {
 	auth: DashboardAuth;
 	pool: RuntimePool;
 	/** Directory of built client assets; omit to skip static serving (tests). */
 	staticDir?: string;
 	/** Session listing (cross-project) — injected so tests can stub it. */
-	listAllSessions: () => Promise<unknown[]>;
+	listAllSessions: () => Promise<DashboardSessionInfoSource[]>;
 	deleteSession: (path: string) => Promise<unknown>;
 	logger?: (line: string) => void;
 	/** Build version of the running server process (for the settings footer / stale-server detection). */
@@ -73,6 +88,30 @@ const DEVICE_COOKIE = "dreb_dashboard_device";
 export const MAX_SSE_BUFFERED_BYTES = 4 * 1024 * 1024;
 export const CLIENT_DIAGNOSTIC_RATE_LIMIT_MS = 30_000;
 const CLIENT_DIAGNOSTIC_CONNECTION_TTL_MS = 10 * 60_000;
+
+function boundedSessionPreview(text: string): string {
+	let preview = "";
+	let characters = 0;
+	for (const character of text) {
+		if (characters === MAX_SESSION_PREVIEW_CHARACTERS) break;
+		preview += character;
+		characters++;
+	}
+	return preview;
+}
+
+function toSessionInfoDto(session: DashboardSessionInfoSource): SessionInfoDto {
+	return {
+		path: session.path,
+		id: session.id,
+		cwd: session.cwd,
+		name: session.name,
+		created: session.created.toISOString(),
+		modified: session.modified.toISOString(),
+		messageCount: session.messageCount,
+		firstMessage: boundedSessionPreview(session.firstMessage),
+	};
+}
 
 function isClientDiagnostic(value: unknown): value is ClientConnectionDiagnosticDto {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -439,7 +478,7 @@ export function createDashboardServer(options: DashboardServerOptions): Dashboar
 
 	// -- fleet -----------------------------------------------------------------
 	const listDiskSessions = async (): Promise<SessionInfoDto[]> =>
-		((await options.listAllSessions()) as SessionInfoDto[]).filter((session) => existsSync(session.cwd));
+		(await options.listAllSessions()).filter((session) => existsSync(session.cwd)).map(toSessionInfoDto);
 
 	const currentCwdInventory = async (): Promise<string[]> => [
 		...pool.list().map((handle) => handle.cwd),

--- a/packages/dashboard/src/shared/protocol.ts
+++ b/packages/dashboard/src/shared/protocol.ts
@@ -7,7 +7,10 @@
  * compatibility at the mapping sites.
  */
 
-/** Session metadata (mirrors RpcSessionInfo). */
+/** Maximum Unicode code points carried for an on-disk session's first-message preview. */
+export const MAX_SESSION_PREVIEW_CHARACTERS = 256;
+
+/** Session metadata (mirrors RpcSessionInfo, with a bounded first-message preview). */
 export interface SessionInfoDto {
 	path: string;
 	id: string;

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -7,7 +7,13 @@ import { DashboardAuth, MemoryPairingStorage, type TailscaleIdentity } from "../
 import { DashboardImageService } from "../src/server/dashboard-images.js";
 import { EventHub, formatSseFrame } from "../src/server/event-hub.js";
 import { RuntimePool } from "../src/server/runtime-pool.js";
-import { createDashboardServer, MAX_SSE_BUFFERED_BYTES, parseDeviceCookie } from "../src/server/server.js";
+import {
+	createDashboardServer,
+	type DashboardSessionInfoSource,
+	MAX_SSE_BUFFERED_BYTES,
+	parseDeviceCookie,
+} from "../src/server/server.js";
+import { MAX_SESSION_PREVIEW_CHARACTERS } from "../src/shared/protocol.js";
 import { makeFakeClient } from "./runtime-pool.test.js";
 
 const servers: Server[] = [];
@@ -22,7 +28,7 @@ afterEach(async () => {
 
 interface TestServerOptions {
 	auth?: DashboardAuth;
-	listAllSessions?: () => Promise<unknown[]>;
+	listAllSessions?: () => Promise<DashboardSessionInfoSource[]>;
 	deleteSession?: (path: string) => Promise<unknown>;
 	staticDir?: string;
 	onRestart?: () => void;
@@ -38,6 +44,20 @@ async function createTempProject(): Promise<string> {
 	const dir = await mkdtemp(join(tmpdir(), "dreb-dash-server-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+function diskSession(cwd: string, overrides: Partial<DashboardSessionInfoSource> = {}): DashboardSessionInfoSource {
+	return {
+		path: "/sessions/one.jsonl",
+		id: "one",
+		cwd,
+		name: "Session one",
+		created: new Date("2026-01-02T03:04:05.000Z"),
+		modified: new Date("2026-02-03T04:05:06.000Z"),
+		messageCount: 7,
+		firstMessage: "First message",
+		...overrides,
+	};
 }
 
 async function waitUntil(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
@@ -344,18 +364,120 @@ describe("dashboard server — pairing code", () => {
 describe("dashboard server — fleet and runtimes", () => {
 	it("GET /api/fleet returns runtimes and disk sessions", async () => {
 		const dir = await createTempProject();
-		const disk = [{ path: "/s/one.jsonl", id: "one", cwd: dir }];
+		const disk = [diskSession(dir, { path: "/s/one.jsonl" })];
 		const { base } = await startServer({ listAllSessions: async () => disk });
 		const res = await fetch(`${base}/api/fleet`);
 		const body = (await res.json()) as { runtimes: unknown[]; diskSessions: unknown[] };
 		expect(body.runtimes).toEqual([]);
-		expect(body.diskSessions).toEqual(disk);
+		expect(body.diskSessions).toEqual([
+			{
+				path: "/s/one.jsonl",
+				id: "one",
+				cwd: dir,
+				name: "Session one",
+				created: "2026-01-02T03:04:05.000Z",
+				modified: "2026-02-03T04:05:06.000Z",
+				messageCount: 7,
+				firstMessage: "First message",
+			},
+		]);
+	});
+
+	it("projects bounded disk-session DTOs for fleet, inventory, and resync responses", async () => {
+		const dir = await createTempProject();
+		const preview = `${"a".repeat(MAX_SESSION_PREVIEW_CHARACTERS - 1)}😀trailing text`;
+		const internalSession = {
+			...diskSession(dir, { firstMessage: preview }),
+			parentSessionPath: "/sessions/private-parent.jsonl",
+			allMessagesText: "private complete searchable transcript",
+			futureInternalField: "must not cross the wire",
+		};
+		const { base } = await startServer({ listAllSessions: async () => [internalSession] });
+
+		const fleet = (await fetch(`${base}/api/fleet`).then((response) => response.json())) as {
+			diskSessions: Array<Record<string, unknown>>;
+		};
+		const inventory = (await fetch(`${base}/api/sessions`).then((response) => response.json())) as {
+			sessions: Array<Record<string, unknown>>;
+		};
+		const resync = (await fetch(`${base}/api/resync`).then((response) => response.json())) as {
+			fleet: { diskSessions: Array<Record<string, unknown>> };
+		};
+
+		for (const session of [fleet.diskSessions[0], inventory.sessions[0], resync.fleet.diskSessions[0]]) {
+			expect(Object.keys(session ?? {}).sort()).toEqual([
+				"created",
+				"cwd",
+				"firstMessage",
+				"id",
+				"messageCount",
+				"modified",
+				"name",
+				"path",
+			]);
+			expect(session).toEqual({
+				path: internalSession.path,
+				id: internalSession.id,
+				cwd: internalSession.cwd,
+				name: internalSession.name,
+				created: internalSession.created.toISOString(),
+				modified: internalSession.modified.toISOString(),
+				messageCount: internalSession.messageCount,
+				firstMessage: `${"a".repeat(MAX_SESSION_PREVIEW_CHARACTERS - 1)}😀`,
+			});
+			expect(Array.from(String(session?.firstMessage))).toHaveLength(MAX_SESSION_PREVIEW_CHARACTERS);
+		}
+		expect(JSON.stringify({ fleet, inventory, resync })).not.toContain("private complete searchable transcript");
+		expect(JSON.stringify({ fleet, inventory, resync })).not.toContain("private-parent");
+		expect(JSON.stringify({ fleet, inventory, resync })).not.toContain("futureInternalField");
+	});
+
+	it("preserves session previews below and at the character limit", async () => {
+		const dir = await createTempProject();
+		const below = "b".repeat(MAX_SESSION_PREVIEW_CHARACTERS - 1);
+		const atLimit = "😀".repeat(MAX_SESSION_PREVIEW_CHARACTERS);
+		const { base } = await startServer({
+			listAllSessions: async () => [
+				diskSession(dir, { id: "below", path: "/sessions/below.jsonl", firstMessage: below }),
+				diskSession(dir, { id: "at-limit", path: "/sessions/at-limit.jsonl", firstMessage: atLimit }),
+			],
+		});
+
+		const body = (await fetch(`${base}/api/sessions`).then((response) => response.json())) as {
+			sessions: Array<{ firstMessage: string }>;
+		};
+		expect(body.sessions.map((session) => session.firstMessage)).toEqual([below, atLimit]);
+	});
+
+	it("bounds fleet growth by session count and preview size instead of searchable transcript size", async () => {
+		const dir = await createTempProject();
+		const sessionCount = 40;
+		const transcriptMarker = "complete-transcript-marker";
+		const sessions = Array.from({ length: sessionCount }, (_, index) => ({
+			...diskSession(dir, {
+				path: `/sessions/${index}.jsonl`,
+				id: `session-${index}`,
+				firstMessage: "😀".repeat(MAX_SESSION_PREVIEW_CHARACTERS * 10),
+			}),
+			allMessagesText: `${transcriptMarker}${"x".repeat(100_000)}`,
+		}));
+		const { base } = await startServer({ listAllSessions: async () => sessions });
+
+		const body = await fetch(`${base}/api/fleet`).then((response) => response.text());
+		const fleet = JSON.parse(body) as { diskSessions: Array<{ firstMessage: string }> };
+
+		expect(fleet.diskSessions).toHaveLength(sessionCount);
+		expect(body).not.toContain(transcriptMarker);
+		expect(Buffer.byteLength(body)).toBeLessThan(sessionCount * (MAX_SESSION_PREVIEW_CHARACTERS * 4 + 512));
+		for (const session of fleet.diskSessions) {
+			expect(Array.from(session.firstMessage)).toHaveLength(MAX_SESSION_PREVIEW_CHARACTERS);
+		}
 	});
 
 	it("logs payload-free structured diagnostics for GET /api/fleet", async () => {
 		const dir = await createTempProject();
 		const secret = "private-cwd-session-prompt-content";
-		const disk = [{ path: `/sessions/${secret}.jsonl`, id: secret, cwd: dir, name: secret }];
+		const disk = [diskSession(dir, { path: `/sessions/${secret}.jsonl`, id: secret, name: secret })];
 		const logs: string[] = [];
 		const { base } = await startServer({ listAllSessions: async () => disk, logger: (line) => logs.push(line) });
 
@@ -471,23 +593,25 @@ describe("dashboard server — fleet and runtimes", () => {
 	it("GET /api/fleet hides disk sessions whose cwd no longer exists", async () => {
 		const liveCwd = await createTempProject();
 		const missingCwd = join(tmpdir(), `dreb-dash-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-		const liveSession = { path: "/s/live.jsonl", id: "live", cwd: liveCwd };
-		const missingSession = { path: "/s/missing.jsonl", id: "missing", cwd: missingCwd };
+		const liveSession = diskSession(liveCwd, { path: "/s/live.jsonl", id: "live" });
+		const missingSession = diskSession(missingCwd, { path: "/s/missing.jsonl", id: "missing" });
 		const { base } = await startServer({ listAllSessions: async () => [liveSession, missingSession] });
 
 		const res = await fetch(`${base}/api/fleet`);
 		const body = (await res.json()) as { runtimes: unknown[]; diskSessions: Array<{ id: string; cwd: string }> };
 
 		expect(res.status).toBe(200);
-		expect(body.diskSessions).toEqual([liveSession]);
-		expect(body.diskSessions).not.toContainEqual(missingSession);
+		expect(body.diskSessions).toEqual([
+			expect.objectContaining({ path: liveSession.path, id: liveSession.id, cwd: liveSession.cwd }),
+		]);
+		expect(body.diskSessions).not.toContainEqual(expect.objectContaining({ id: missingSession.id }));
 	});
 
 	it("GET /api/sessions returns only existing disk sessions without describing runtimes", async () => {
 		const liveCwd = await createTempProject();
 		const missingCwd = join(tmpdir(), `dreb-dash-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-		const liveSession = { path: "/s/live.jsonl", id: "live", cwd: liveCwd };
-		const missingSession = { path: "/s/missing.jsonl", id: "missing", cwd: missingCwd };
+		const liveSession = diskSession(liveCwd, { path: "/s/live.jsonl", id: "live" });
+		const missingSession = diskSession(missingCwd, { path: "/s/missing.jsonl", id: "missing" });
 		const listAllSessions = vi.fn(async () => [liveSession, missingSession]);
 		const { base, clients, pool } = await startServer({ listAllSessions });
 		await pool.create(liveCwd);
@@ -497,7 +621,15 @@ describe("dashboard server — fleet and runtimes", () => {
 		const body = (await res.json()) as { sessions: Array<{ id: string; cwd: string }> };
 
 		expect(res.status).toBe(200);
-		expect(body).toEqual({ sessions: [liveSession] });
+		expect(body.sessions).toEqual([
+			expect.objectContaining({
+				path: liveSession.path,
+				id: liveSession.id,
+				cwd: liveSession.cwd,
+				created: liveSession.created.toISOString(),
+				modified: liveSession.modified.toISOString(),
+			}),
+		]);
 		expect(listAllSessions).toHaveBeenCalledTimes(1);
 		expect(describe).not.toHaveBeenCalled();
 		expect(clients[0].getState).not.toHaveBeenCalled();

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.55.3",
+  "version": "2.55.4",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.55.3",
+	"version": "2.55.4",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #450

Bound the dashboard's fleet and session inventory wire payloads so internal session-search text cannot reach browser responses and first-message previews remain size-limited.

Implementation plan posted as a comment below.
