### PR TITLE
Bound dashboard runtime events before RPC serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.55.4",
+			"version": "2.55.5",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -1794,6 +1794,12 @@ Example streaming a text response:
 {"type":"message_update","message":{...},"assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"Hello world","partial":{...}}}
 ```
 
+#### Dashboard-mode wire projection (`--ui dashboard`)
+
+When the RPC server is launched with `--ui dashboard`, `message_update` events are projected **before serialization**: the cumulative top-level `message` field and the nested `assistantMessageEvent.partial` field are omitted from every frame. Both fields grow with the response, so carrying them on every delta makes the JSONL stream quadratic in response length; the dashboard reducer consumes only the delta fields (`type`, `contentIndex`, `delta`, `content`, `toolCall`), which are preserved unchanged.
+
+The projection applies recursively to `message_update` events nested inside `background_agent_event` payloads. It does **not** apply to command responses — `get_dashboard_snapshot` still returns complete messages — and `message_end` always carries the full final message as the authoritative transcript record. RPC servers launched without `--ui dashboard` emit the full unprojected protocol shown above.
+
 ### tool_execution_start / tool_execution_update / tool_execution_end
 
 Emitted when a tool begins, streams progress, and completes execution.
@@ -1961,7 +1967,7 @@ Chain completions omit ambiguous scalar model/thinking fields and instead includ
 }
 ```
 
-`background_agent_event` relays every JSONL event the child process emits (the same event union documented here, plus the initial session header), verbatim, tagged with the child's `agentId`. This is the live-transcript transport for observers like the dashboard — no session-file tailing needed. Streaming children emit `message_update` deltas at high frequency; consumers that fan events out further (e.g. over a network) should batch or throttle:
+`background_agent_event` relays every JSONL event the child process emits (the same event union documented here, plus the initial session header), verbatim, tagged with the child's `agentId`. This is the live-transcript transport for observers like the dashboard — no session-file tailing needed. Streaming children emit `message_update` deltas at high frequency; consumers that fan events out further (e.g. over a network) should batch or throttle. Under `--ui dashboard`, the [wire projection](#dashboard-mode-wire-projection---ui-dashboard) described above applies recursively to nested `message_update` events, so relayed frames omit the cumulative `message` and `partial` fields just like top-level ones:
 
 ```json
 {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1464,6 +1464,14 @@ export class AgentSession {
 		return this.sessionManager.getSessionName();
 	}
 
+	/**
+	 * UI surface this session was launched for (e.g. "tui", "rpc", "dashboard",
+	 * "agent", "cli"), from the --ui flag or the mode-based default.
+	 */
+	get uiType(): string | undefined {
+		return this._uiType;
+	}
+
 	/** Scoped models for cycling (from --models flag) */
 	get scopedModels(): ReadonlyArray<{ model: Model<any>; thinkingLevel?: ThinkingLevel }> {
 		return this._scopedModels;

--- a/packages/coding-agent/src/core/output-guard.ts
+++ b/packages/coding-agent/src/core/output-guard.ts
@@ -59,7 +59,7 @@ export function isStdoutTakenOver(): boolean {
 // so we fail loudly instead of growing memory without bound.
 // ---------------------------------------------------------------------------
 
-/** Maximum bytes allowed to queue behind a backpressured stdout before aborting. */
+/** Maximum aggregate bytes allowed for ordinary queued writes before aborting. */
 export const MAX_QUEUED_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB
 
 const FATAL_DIAGNOSTIC_FLUSH_TIMEOUT_MS = 1_000;
@@ -108,7 +108,12 @@ function flushStdoutQueue(): void {
 
 function enqueueStdout(text: string): void {
 	const bytes = Buffer.byteLength(text);
-	if (stdoutQueuedBytes + bytes > MAX_QUEUED_STDOUT_BYTES) {
+	// Bound accumulated ordinary backlog, but allow one legitimate protocol frame
+	// larger than the cap (for example, a complete dashboard snapshot). Once that
+	// oversized frame is queued, any subsequent write still fails the cap check.
+	const exceedsAggregateCap = stdoutQueuedBytes + bytes > MAX_QUEUED_STDOUT_BYTES;
+	const isSingleOversizedFrame = bytes > MAX_QUEUED_STDOUT_BYTES && stdoutQueuedBytes <= MAX_QUEUED_STDOUT_BYTES;
+	if (exceedsAggregateCap && !isSingleOversizedFrame) {
 		const diagnostic =
 			`Fatal: stdout write queue exceeded ${MAX_QUEUED_STDOUT_BYTES} bytes while the stream was ` +
 			"backpressured. The consumer of this process's stdout is not reading; refusing " +

--- a/packages/coding-agent/src/core/output-guard.ts
+++ b/packages/coding-agent/src/core/output-guard.ts
@@ -62,6 +62,8 @@ export function isStdoutTakenOver(): boolean {
 /** Maximum bytes allowed to queue behind a backpressured stdout before aborting. */
 export const MAX_QUEUED_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB
 
+const FATAL_DIAGNOSTIC_FLUSH_TIMEOUT_MS = 1_000;
+
 const stdoutQueue: string[] = [];
 let stdoutQueuedBytes = 0;
 let stdoutBackpressured = false;
@@ -107,12 +109,21 @@ function flushStdoutQueue(): void {
 function enqueueStdout(text: string): void {
 	const bytes = Buffer.byteLength(text);
 	if (stdoutQueuedBytes + bytes > MAX_QUEUED_STDOUT_BYTES) {
-		process.stderr.write(
+		const diagnostic =
 			`Fatal: stdout write queue exceeded ${MAX_QUEUED_STDOUT_BYTES} bytes while the stream was ` +
-				"backpressured. The consumer of this process's stdout is not reading; refusing " +
-				"unbounded memory growth. Aborting.\n",
-		);
-		process.exit(1);
+			"backpressured. The consumer of this process's stdout is not reading; refusing " +
+			"unbounded memory growth. Aborting.\n";
+		let exiting = false;
+		const exit = (): void => {
+			if (exiting) return;
+			exiting = true;
+			clearTimeout(forceExit);
+			process.exit(1);
+		};
+		const forceExit = setTimeout(exit, FATAL_DIAGNOSTIC_FLUSH_TIMEOUT_MS);
+		forceExit.unref();
+		process.stderr.write(diagnostic, exit);
+		return;
 	}
 	stdoutQueue.push(text);
 	stdoutQueuedBytes += bytes;

--- a/packages/coding-agent/src/core/output-guard.ts
+++ b/packages/coding-agent/src/core/output-guard.ts
@@ -46,15 +46,98 @@ export function isStdoutTakenOver(): boolean {
 	return stdoutTakeoverState !== undefined;
 }
 
-export function writeRawStdout(text: string): void {
+// ---------------------------------------------------------------------------
+// Backpressure-aware bounded write queue
+//
+// stream.write() returns false when the stream's internal buffer is full
+// (backpressure). Ignoring that signal during high-rate event streaming lets
+// output queue up unboundedly inside the process, which is what produced the
+// multi-thousand-event end-of-response bursts in issue 448. While the stream
+// is backpressured we queue subsequent writes and flush them in order on
+// "drain". The queue is byte-capped: a consumer that stalls beyond the cap
+// means this process's primary output channel is dead or hopelessly behind,
+// so we fail loudly instead of growing memory without bound.
+// ---------------------------------------------------------------------------
+
+/** Maximum bytes allowed to queue behind a backpressured stdout before aborting. */
+export const MAX_QUEUED_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB
+
+const stdoutQueue: string[] = [];
+let stdoutQueuedBytes = 0;
+let stdoutBackpressured = false;
+let stdoutDrainListening = false;
+let stdoutDrainWaiters: Array<() => void> = [];
+
+function writeToStdout(text: string): boolean {
 	if (stdoutTakeoverState) {
-		stdoutTakeoverState.rawStdoutWrite(text);
+		return stdoutTakeoverState.rawStdoutWrite(text);
+	}
+	return process.stdout.write(text);
+}
+
+function requestDrainFlush(): void {
+	if (stdoutDrainListening) return;
+	stdoutDrainListening = true;
+	process.stdout.once("drain", () => {
+		stdoutDrainListening = false;
+		flushStdoutQueue();
+	});
+}
+
+function flushStdoutQueue(): void {
+	stdoutBackpressured = false;
+	while (stdoutQueue.length > 0) {
+		const next = stdoutQueue.shift() as string;
+		stdoutQueuedBytes -= Buffer.byteLength(next);
+		// A false return means the stream accepted the chunk but its buffer is
+		// full again — stop writing and wait for the next drain.
+		if (!writeToStdout(next)) {
+			stdoutBackpressured = true;
+			requestDrainFlush();
+			return;
+		}
+	}
+	if (stdoutDrainWaiters.length > 0) {
+		const waiters = stdoutDrainWaiters;
+		stdoutDrainWaiters = [];
+		for (const resolve of waiters) resolve();
+	}
+}
+
+function enqueueStdout(text: string): void {
+	const bytes = Buffer.byteLength(text);
+	if (stdoutQueuedBytes + bytes > MAX_QUEUED_STDOUT_BYTES) {
+		process.stderr.write(
+			`Fatal: stdout write queue exceeded ${MAX_QUEUED_STDOUT_BYTES} bytes while the stream was ` +
+				"backpressured. The consumer of this process's stdout is not reading; refusing " +
+				"unbounded memory growth. Aborting.\n",
+		);
+		process.exit(1);
+	}
+	stdoutQueue.push(text);
+	stdoutQueuedBytes += bytes;
+}
+
+export function writeRawStdout(text: string): void {
+	// Queue behind any backpressured/queued writes to preserve ordering.
+	if (stdoutBackpressured || stdoutQueue.length > 0) {
+		enqueueStdout(text);
 		return;
 	}
-	process.stdout.write(text);
+	if (!writeToStdout(text)) {
+		stdoutBackpressured = true;
+		requestDrainFlush();
+	}
 }
 
 export async function flushRawStdout(): Promise<void> {
+	// Wait for any queued output to drain so flushes observe true end-of-stream.
+	if (stdoutBackpressured || stdoutQueue.length > 0) {
+		await new Promise<void>((resolve) => {
+			stdoutDrainWaiters.push(resolve);
+		});
+	}
+
 	if (stdoutTakeoverState) {
 		await new Promise<void>((resolve, reject) => {
 			stdoutTakeoverState?.rawStdoutWrite("", (err) => {

--- a/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
@@ -1,0 +1,55 @@
+/**
+ * Dashboard-mode RPC event projection.
+ *
+ * `message_update` events carry two cumulative copies of the growing assistant
+ * message: the top-level `message` field and `assistantMessageEvent.partial`.
+ * Serializing both for every token makes the child->parent JSONL pipe quadratic
+ * in response length and floods the stdout queue (see issue 448).
+ *
+ * The dashboard never reads those fields: its browser reducer consumes only
+ * the delta fields (`delta`, `content`, `toolCall`, `contentIndex`), and its
+ * authoritative transcript comes from `message_end` plus `get_dashboard_snapshot`
+ * RPC responses. The dashboard's own EventHub already strips the same fields at
+ * the browser SSE boundary (projectDashboardEvent); this module applies the same
+ * removal one boundary earlier, before JSONL serialization in runRpcMode.
+ *
+ * Only the quadratic `message_update` fields are removed here. Broader bounding
+ * (agent_end messages, tool_execution_update args, retry discardedPartial,
+ * images) remains the EventHub's browser-facing concern.
+ */
+
+function omit(event: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
+	const copy = { ...event };
+	for (const key of keys) delete copy[key];
+	return copy;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Project a single agent session event for dashboard-mode RPC transport.
+ *
+ * Unknown event types are returned exactly as received (same reference) so
+ * extensions and future event types remain forward-safe. Projected events are
+ * shallow copies — the input event is never mutated, because other session
+ * subscribers (and the session's own state) share the same object.
+ */
+export function projectDashboardRpcEvent(event: Record<string, unknown>): Record<string, unknown> {
+	switch (event.type) {
+		case "message_update": {
+			const projected = omit(event, "message");
+			const streamEvent = event.assistantMessageEvent;
+			return isPlainObject(streamEvent)
+				? { ...projected, assistantMessageEvent: omit(streamEvent, "partial") }
+				: projected;
+		}
+		case "background_agent_event": {
+			const child = event.event;
+			return isPlainObject(child) ? { ...event, event: projectDashboardRpcEvent(child) } : event;
+		}
+		default:
+			return event;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -58,6 +58,7 @@ import {
 } from "../../core/tools/subagent.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+import { projectDashboardRpcEvent } from "./rpc-event-projection.js";
 import type {
 	RpcAgentTypeInfo,
 	RpcBackgroundAgentInfo,
@@ -1806,6 +1807,15 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				})
 			: undefined;
 
+	// Dashboard-launched runtimes (--ui dashboard) get message_update events
+	// projected before serialization: the cumulative `message` and
+	// `assistantMessageEvent.partial` fields are quadratic in response length on
+	// the JSONL pipe, and no dashboard consumer reads them (deltas, message_end,
+	// and get_dashboard_snapshot responses carry the authoritative data). Generic
+	// RPC consumers keep the full protocol unchanged. Only the event stream is
+	// projected — command responses (output() calls below) always stay complete.
+	const projectEvents = session.uiType === "dashboard";
+
 	// Output all agent events as JSON
 	session.subscribe((event) => {
 		if (tabTitleGenerator && !session.sessionName) {
@@ -1819,7 +1829,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				tabTitleGenerator.onMessageEnd(event.message);
 			}
 		}
-		output(event);
+		output(projectEvents ? projectDashboardRpcEvent(event as unknown as Record<string, unknown>) : event);
 	});
 
 	// Handle a single command

--- a/packages/coding-agent/test/output-guard.test.ts
+++ b/packages/coding-agent/test/output-guard.test.ts
@@ -42,6 +42,7 @@ describe("output-guard", () => {
 		restoreStdout();
 		process.stdout.write = originalStdoutWrite;
 		process.stderr.write = originalStderrWrite;
+		vi.restoreAllMocks();
 	});
 
 	it("isStdoutTakenOver returns false initially", () => {
@@ -120,6 +121,21 @@ describe("output-guard", () => {
 		expect(chunks).toEqual(["first", "second", "third", "fourth"]);
 	});
 
+	it("queues and drains through the raw stdout writer while taken over", () => {
+		let writable = false;
+		const rawStdoutChunks = fakeStdoutWrite(() => writable);
+		takeOverStdout();
+
+		writeRawStdout("first");
+		writeRawStdout("second");
+		writeRawStdout("third");
+		expect(rawStdoutChunks).toEqual(["first"]);
+
+		writable = true;
+		process.stdout.emit("drain");
+		expect(rawStdoutChunks).toEqual(["first", "second", "third"]);
+	});
+
 	it("does not duplicate the chunk whose write returned false", () => {
 		let writable = true;
 		const chunks = fakeStdoutWrite(() => writable);
@@ -152,24 +168,59 @@ describe("output-guard", () => {
 		expect(chunks).toEqual(["one", "two", "three"]);
 	});
 
-	it("keeps queueing bounded: exceeding the byte cap fails loudly", () => {
+	it("keeps takeover queueing bounded and flushes the fatal diagnostic before exit", () => {
 		const stderrChunks: string[] = [];
-		process.stderr.write = ((chunk: string | Uint8Array) => {
+		let stderrCallback: ((error?: Error | null) => void) | undefined;
+		process.stderr.write = ((
+			chunk: string | Uint8Array,
+			encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+			callback?: (error?: Error | null) => void,
+		) => {
 			stderrChunks.push(String(chunk));
-			return true;
+			stderrCallback = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+			return false;
 		}) as typeof process.stderr.write;
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
 			throw new Error("process.exit");
 		}) as never);
 
-		fakeStdoutWrite(() => false); // permanently backpressured
+		let writable = false;
+		fakeStdoutWrite(() => writable);
+		takeOverStdout();
 		writeRawStdout("trigger"); // accepted, signals backpressure
 		writeRawStdout("small"); // queued
 
 		const oversized = "x".repeat(MAX_QUEUED_STDOUT_BYTES);
-		expect(() => writeRawStdout(oversized)).toThrow("process.exit");
-		expect(exitSpy).toHaveBeenCalledWith(1);
+		writeRawStdout(oversized);
+		expect(exitSpy).not.toHaveBeenCalled();
 		expect(stderrChunks.join("")).toContain("stdout write queue exceeded");
+		expect(stderrCallback).toBeTypeOf("function");
+		expect(() => stderrCallback?.()).toThrow("process.exit");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+
+		writable = true;
+		process.stdout.emit("drain");
+	});
+
+	it("forces a bounded exit when the fatal stderr diagnostic never flushes", () => {
+		vi.useFakeTimers();
+		try {
+			process.stderr.write = (() => false) as typeof process.stderr.write;
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+
+			fakeStdoutWrite(() => false);
+			writeRawStdout("trigger");
+			writeRawStdout("small");
+			writeRawStdout("x".repeat(MAX_QUEUED_STDOUT_BYTES));
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(() => vi.advanceTimersByTime(1_000)).toThrow("process.exit");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("flushRawStdout resolves immediately when nothing is queued", async () => {

--- a/packages/coding-agent/test/output-guard.test.ts
+++ b/packages/coding-agent/test/output-guard.test.ts
@@ -188,6 +188,38 @@ describe("output-guard", () => {
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 
+	it("rejects a write queued behind one allowed oversized frame", () => {
+		const stderrChunks: string[] = [];
+		let stderrCallback: ((error?: Error | null) => void) | undefined;
+		process.stderr.write = ((
+			chunk: string | Uint8Array,
+			encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+			callback?: (error?: Error | null) => void,
+		) => {
+			stderrChunks.push(String(chunk));
+			stderrCallback = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+			return false;
+		}) as typeof process.stderr.write;
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as never);
+
+		let writable = false;
+		fakeStdoutWrite(() => writable);
+		writeRawStdout("trigger"); // accepted, signals backpressure
+		writeRawStdout("x".repeat(MAX_QUEUED_STDOUT_BYTES + 1)); // one oversized frame is allowed
+		writeRawStdout("next"); // accumulated backlog beyond that frame must fail loudly
+
+		expect(exitSpy).not.toHaveBeenCalled();
+		expect(stderrChunks.join("")).toContain("stdout write queue exceeded");
+		expect(stderrCallback).toBeTypeOf("function");
+		expect(() => stderrCallback?.()).toThrow("process.exit");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+
+		writable = true;
+		process.stdout.emit("drain");
+	});
+
 	it("keeps takeover queueing bounded and flushes the fatal diagnostic before exit", () => {
 		const stderrChunks: string[] = [];
 		let stderrCallback: ((error?: Error | null) => void) | undefined;

--- a/packages/coding-agent/test/output-guard.test.ts
+++ b/packages/coding-agent/test/output-guard.test.ts
@@ -168,6 +168,26 @@ describe("output-guard", () => {
 		expect(chunks).toEqual(["one", "two", "three"]);
 	});
 
+	it("allows one oversized protocol frame to drain without treating it as accumulated backlog", () => {
+		let writable = false;
+		const chunks = fakeStdoutWrite(() => writable);
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as never);
+
+		writeRawStdout("trigger"); // accepted, signals backpressure
+		const oversized = "x".repeat(MAX_QUEUED_STDOUT_BYTES + 1);
+		writeRawStdout(oversized);
+
+		expect(chunks).toEqual(["trigger"]);
+		expect(exitSpy).not.toHaveBeenCalled();
+
+		writable = true;
+		process.stdout.emit("drain");
+		expect(chunks).toEqual(["trigger", oversized]);
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
 	it("keeps takeover queueing bounded and flushes the fatal diagnostic before exit", () => {
 		const stderrChunks: string[] = [];
 		let stderrCallback: ((error?: Error | null) => void) | undefined;

--- a/packages/coding-agent/test/output-guard.test.ts
+++ b/packages/coding-agent/test/output-guard.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	flushRawStdout,
+	isStdoutTakenOver,
+	MAX_QUEUED_STDOUT_BYTES,
+	restoreStdout,
+	takeOverStdout,
+	writeRawStdout,
+} from "../src/core/output-guard.js";
+
+/** Install a fake process.stdout.write; returns captured chunks and a backpressure switch. */
+function fakeStdoutWrite(impl?: (chunk: string) => boolean) {
+	const chunks: string[] = [];
+	const fake = ((chunk: string | Uint8Array, encodingOrCallback?: unknown, callback?: unknown) => {
+		chunks.push(String(chunk));
+		const cb = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+		if (typeof cb === "function") (cb as (error?: Error | null) => void)();
+		return impl ? impl(String(chunk)) : true;
+	}) as typeof process.stdout.write;
+	process.stdout.write = fake;
+	return chunks;
+}
+
+/** Flush any queued module state left over from a test. */
+function flushModuleQueue(): void {
+	fakeStdoutWrite();
+	process.stdout.emit("drain");
+}
+
+describe("output-guard", () => {
+	let originalStdoutWrite: typeof process.stdout.write;
+	let originalStderrWrite: typeof process.stderr.write;
+
+	beforeEach(() => {
+		originalStdoutWrite = process.stdout.write;
+		originalStderrWrite = process.stderr.write;
+		restoreStdout();
+	});
+
+	afterEach(() => {
+		flushModuleQueue();
+		restoreStdout();
+		process.stdout.write = originalStdoutWrite;
+		process.stderr.write = originalStderrWrite;
+	});
+
+	it("isStdoutTakenOver returns false initially", () => {
+		expect(isStdoutTakenOver()).toBe(false);
+	});
+
+	it("takeOverStdout routes intercepted stdout writes to stderr", () => {
+		const stderrChunks: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrChunks.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+
+		takeOverStdout();
+		expect(isStdoutTakenOver()).toBe(true);
+
+		process.stdout.write("intercepted");
+		expect(stderrChunks).toEqual(["intercepted"]);
+	});
+
+	it("takeOverStdout is idempotent and restoreStdout reverts", () => {
+		takeOverStdout();
+		takeOverStdout();
+		expect(isStdoutTakenOver()).toBe(true);
+
+		restoreStdout();
+		expect(isStdoutTakenOver()).toBe(false);
+
+		const chunks = fakeStdoutWrite();
+		process.stdout.write("direct");
+		expect(chunks).toEqual(["direct"]);
+	});
+
+	it("writeRawStdout writes directly when the stream is not backpressured", () => {
+		const chunks = fakeStdoutWrite();
+		writeRawStdout("one");
+		writeRawStdout("two");
+		expect(chunks).toEqual(["one", "two"]);
+	});
+
+	it("writeRawStdout bypasses stdout interception while taken over", () => {
+		const rawStdoutChunks = fakeStdoutWrite();
+		const stderrChunks: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrChunks.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+
+		takeOverStdout();
+
+		process.stdout.write("intercepted");
+		writeRawStdout("protocol");
+
+		expect(stderrChunks).toEqual(["intercepted"]);
+		expect(rawStdoutChunks).toEqual(["protocol"]);
+	});
+
+	it("queues writes while backpressured and flushes them in order on drain", () => {
+		let writable = false;
+		const chunks = fakeStdoutWrite(() => writable);
+
+		writeRawStdout("first"); // accepted, returns false -> backpressured
+		expect(chunks).toEqual(["first"]);
+
+		writeRawStdout("second");
+		writeRawStdout("third");
+		// Queued behind the backpressure, not written yet.
+		expect(chunks).toEqual(["first"]);
+
+		writable = true;
+		process.stdout.emit("drain");
+		expect(chunks).toEqual(["first", "second", "third"]);
+
+		// Stream healthy again: writes go direct.
+		writeRawStdout("fourth");
+		expect(chunks).toEqual(["first", "second", "third", "fourth"]);
+	});
+
+	it("does not duplicate the chunk whose write returned false", () => {
+		let writable = true;
+		const chunks = fakeStdoutWrite(() => writable);
+
+		writeRawStdout("a");
+		writable = false;
+		writeRawStdout("b"); // accepted by the stream, signals backpressure
+		writeRawStdout("c"); // queued
+		expect(chunks).toEqual(["a", "b"]);
+
+		writable = true;
+		process.stdout.emit("drain");
+		expect(chunks).toEqual(["a", "b", "c"]);
+	});
+
+	it("stops flushing when the stream fills again and resumes on the next drain", () => {
+		let writable = false;
+		const chunks = fakeStdoutWrite(() => writable);
+
+		writeRawStdout("one");
+		writeRawStdout("two");
+		writeRawStdout("three");
+
+		// First drain: the stream accepts one queued chunk then fills again.
+		process.stdout.emit("drain");
+		expect(chunks).toEqual(["one", "two"]);
+
+		writable = true;
+		process.stdout.emit("drain");
+		expect(chunks).toEqual(["one", "two", "three"]);
+	});
+
+	it("keeps queueing bounded: exceeding the byte cap fails loudly", () => {
+		const stderrChunks: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrChunks.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as never);
+
+		fakeStdoutWrite(() => false); // permanently backpressured
+		writeRawStdout("trigger"); // accepted, signals backpressure
+		writeRawStdout("small"); // queued
+
+		const oversized = "x".repeat(MAX_QUEUED_STDOUT_BYTES);
+		expect(() => writeRawStdout(oversized)).toThrow("process.exit");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(stderrChunks.join("")).toContain("stdout write queue exceeded");
+	});
+
+	it("flushRawStdout resolves immediately when nothing is queued", async () => {
+		fakeStdoutWrite();
+		await flushRawStdout();
+	});
+
+	it("flushRawStdout waits for queued output to drain", async () => {
+		let writable = false;
+		const chunks = fakeStdoutWrite(() => writable);
+
+		writeRawStdout("first");
+		writeRawStdout("queued");
+
+		let flushed = false;
+		const pending = flushRawStdout().then(() => {
+			flushed = true;
+		});
+
+		// Still backpressured: the flush must not complete.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(flushed).toBe(false);
+
+		writable = true;
+		process.stdout.emit("drain");
+		await pending;
+		expect(flushed).toBe(true);
+		expect(chunks.slice(0, 2)).toEqual(["first", "queued"]);
+	});
+});

--- a/packages/coding-agent/test/rpc-event-projection.test.ts
+++ b/packages/coding-agent/test/rpc-event-projection.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { projectDashboardRpcEvent } from "../src/modes/rpc/rpc-event-projection.js";
+
+function growingAssistantMessage(textLength: number) {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "x".repeat(textLength) }],
+		api: "anthropic-messages",
+		provider: "faux",
+		model: "faux-1",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 123,
+	};
+}
+
+function makeMessageUpdate(textLength: number) {
+	const partial = growingAssistantMessage(textLength);
+	return {
+		type: "message_update",
+		message: { ...partial },
+		assistantMessageEvent: {
+			type: "text_delta",
+			contentIndex: 0,
+			delta: "xyz",
+			partial,
+		},
+	};
+}
+
+describe("projectDashboardRpcEvent", () => {
+	it("strips the cumulative top-level message and nested partial from message_update", () => {
+		const projected = projectDashboardRpcEvent(makeMessageUpdate(5000));
+
+		expect(projected.type).toBe("message_update");
+		expect(projected.message).toBeUndefined();
+		const streamEvent = projected.assistantMessageEvent as Record<string, unknown>;
+		expect(streamEvent.partial).toBeUndefined();
+	});
+
+	it("preserves the delta fields the dashboard reducer reads", () => {
+		const projected = projectDashboardRpcEvent(makeMessageUpdate(100));
+		const streamEvent = projected.assistantMessageEvent as Record<string, unknown>;
+
+		expect(streamEvent.type).toBe("text_delta");
+		expect(streamEvent.contentIndex).toBe(0);
+		expect(streamEvent.delta).toBe("xyz");
+	});
+
+	it("preserves toolCall and content on their terminal stream events", () => {
+		const toolCall = { id: "tc1", name: "bash", arguments: { command: "ls" } };
+		const projected = projectDashboardRpcEvent({
+			type: "message_update",
+			message: growingAssistantMessage(10),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall,
+				partial: growingAssistantMessage(10),
+			},
+		});
+		const streamEvent = projected.assistantMessageEvent as Record<string, unknown>;
+
+		expect(streamEvent.toolCall).toEqual(toolCall);
+		expect(streamEvent.partial).toBeUndefined();
+
+		const textEnd = projectDashboardRpcEvent({
+			type: "message_update",
+			message: growingAssistantMessage(10),
+			assistantMessageEvent: {
+				type: "text_end",
+				contentIndex: 0,
+				content: "final text",
+				partial: growingAssistantMessage(10),
+			},
+		});
+		expect((textEnd.assistantMessageEvent as Record<string, unknown>).content).toBe("final text");
+	});
+
+	it("does not mutate the input event", () => {
+		const event = makeMessageUpdate(50);
+		projectDashboardRpcEvent(event);
+
+		expect(event.message).toBeDefined();
+		expect(event.assistantMessageEvent.partial).toBeDefined();
+		expect(event.assistantMessageEvent.partial.content[0].text).toHaveLength(50);
+	});
+
+	it("handles a message_update without a nested stream event object", () => {
+		const projected = projectDashboardRpcEvent({
+			type: "message_update",
+			message: growingAssistantMessage(10),
+			assistantMessageEvent: null,
+		});
+
+		expect(projected.message).toBeUndefined();
+		expect(projected.assistantMessageEvent).toBeNull();
+	});
+
+	it("recurses into background_agent_event payloads", () => {
+		const child = makeMessageUpdate(5000);
+		const projected = projectDashboardRpcEvent({
+			type: "background_agent_event",
+			agentId: "agent-1",
+			event: child,
+		});
+
+		expect(projected.type).toBe("background_agent_event");
+		expect(projected.agentId).toBe("agent-1");
+		const projectedChild = projected.event as Record<string, unknown>;
+		expect(projectedChild.type).toBe("message_update");
+		expect(projectedChild.message).toBeUndefined();
+		expect((projectedChild.assistantMessageEvent as Record<string, unknown>).partial).toBeUndefined();
+		expect((projectedChild.assistantMessageEvent as Record<string, unknown>).delta).toBe("xyz");
+
+		// The relayed child event must not be mutated — other subscribers share it.
+		expect(child.message).toBeDefined();
+		expect(child.assistantMessageEvent.partial).toBeDefined();
+	});
+
+	it("passes background_agent_event through untouched when the payload is not an object", () => {
+		const event = { type: "background_agent_event", agentId: "agent-1", event: "not-an-object" };
+		expect(projectDashboardRpcEvent(event)).toBe(event);
+	});
+
+	it("returns unknown event types by reference so they stay forward-safe", () => {
+		const event = { type: "message_end", message: growingAssistantMessage(10) };
+		expect(projectDashboardRpcEvent(event)).toBe(event);
+
+		const extensionEvent = { type: "some_future_extension_event", payload: { a: 1 } };
+		expect(projectDashboardRpcEvent(extensionEvent)).toBe(extensionEvent);
+	});
+
+	it("keeps projected frames small regardless of cumulative message size", () => {
+		for (const size of [100, 1_000, 10_000, 100_000]) {
+			const projected = projectDashboardRpcEvent(makeMessageUpdate(size));
+			expect(JSON.stringify(projected).length).toBeLessThan(300);
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
+++ b/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for issue 448: dashboard-mode RPC events must be projected
+ * before JSONL serialization so high-rate message_update streams stay bounded
+ * on the child->dashboard stdout pipe.
+ *
+ * Drives runRpcMode against the faux streaming harness with long text
+ * responses and inspects the raw serialized frames captured at writeRawStdout.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as outputGuard from "../src/core/output-guard.js";
+import * as jsonl from "../src/modes/rpc/jsonl.js";
+import { runRpcMode } from "../src/modes/rpc/rpc-mode.js";
+import { createHarness, type Harness } from "./test-harness.js";
+
+interface RpcCapture {
+	/** Raw JSONL lines exactly as passed to writeRawStdout. */
+	lines: string[];
+	/** Parsed frames, parallel to lines. */
+	frames: Array<Record<string, unknown>>;
+	/** Inject a JSONL command line into the RPC server's stdin reader. */
+	sendCommand: (command: Record<string, unknown>) => void;
+	/** Remove the stdin listeners this runRpcMode invocation registered. */
+	detach: () => void;
+}
+
+async function startRpcMode(harness: Harness): Promise<RpcCapture> {
+	const lines: string[] = [];
+	const frames: Array<Record<string, unknown>> = [];
+	let handleInputLine: ((line: string) => void) | undefined;
+	const existingEndListeners = new Set(process.stdin.listeners("end"));
+	const existingErrorListeners = new Set(process.stdin.listeners("error"));
+
+	vi.spyOn(outputGuard, "takeOverStdout").mockImplementation(() => {});
+	vi.spyOn(outputGuard, "writeRawStdout").mockImplementation((line) => {
+		lines.push(line);
+		frames.push(JSON.parse(line) as Record<string, unknown>);
+	});
+	vi.spyOn(jsonl, "attachJsonlLineReader").mockImplementation((_stream, onLine) => {
+		handleInputLine = onLine;
+		return () => {};
+	});
+
+	void runRpcMode(harness.session);
+	await vi.waitFor(() => expect(handleInputLine).toBeDefined());
+
+	return {
+		lines,
+		frames,
+		sendCommand: (command) => handleInputLine!(JSON.stringify(command)),
+		detach: () => {
+			for (const listener of process.stdin.listeners("end")) {
+				if (!existingEndListeners.has(listener)) process.stdin.off("end", listener as (...args: unknown[]) => void);
+			}
+			for (const listener of process.stdin.listeners("error")) {
+				if (!existingErrorListeners.has(listener)) {
+					process.stdin.off("error", listener as (...args: unknown[]) => void);
+				}
+			}
+		},
+	};
+}
+
+function messageUpdateFrames(capture: RpcCapture): Array<Record<string, unknown>> {
+	return capture.frames.filter((f) => f.type === "message_update");
+}
+
+function serializedMessageUpdateBytes(capture: RpcCapture): number {
+	let total = 0;
+	for (const line of capture.lines) {
+		// Cheap pre-filter on the raw line avoids re-parsing everything.
+		if (line.includes('"message_update"')) total += line.length;
+	}
+	return total;
+}
+
+/** Run one streaming turn of the given text size and return the capture. */
+async function streamTextOfSize(size: number): Promise<{ capture: RpcCapture; harness: Harness }> {
+	const harness = createHarness({ responses: ["x".repeat(size)], uiType: "dashboard" });
+	const capture = await startRpcMode(harness);
+	await harness.session.prompt("hi");
+	return { capture, harness };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("runRpcMode dashboard event projection (issue 448)", () => {
+	it("projects cumulative fields out of every message_update frame before serialization", async () => {
+		const { capture, harness } = await streamTextOfSize(8_000);
+		try {
+			const updates = messageUpdateFrames(capture);
+			// 8,000 chars at 3-5 chars per delta => thousands of updates.
+			expect(updates.length).toBeGreaterThan(1_500);
+
+			for (const frame of updates) {
+				expect(frame.message).toBeUndefined();
+				const streamEvent = frame.assistantMessageEvent as Record<string, unknown>;
+				expect(streamEvent.partial).toBeUndefined();
+			}
+
+			// Deltas survive and reconstruct the full text.
+			const reconstructed = updates
+				.map((f) => f.assistantMessageEvent as Record<string, unknown>)
+				.filter((e) => e.type === "text_delta")
+				.map((e) => e.delta as string)
+				.join("");
+			expect(reconstructed).toHaveLength(8_000);
+
+			// Every delta frame is small and bounded — no growth with stream position.
+			const deltaLines = capture.lines.filter((l) => l.includes('"message_update"') && l.includes('"text_delta"'));
+			for (const line of deltaLines) {
+				expect(line.length).toBeLessThan(512);
+			}
+
+			// The authoritative final message still arrives complete on message_end.
+			const messageEnd = capture.frames.find(
+				(f) => f.type === "message_end" && (f.message as { role?: string })?.role === "assistant",
+			);
+			expect(messageEnd).toBeDefined();
+			const endMessage = messageEnd?.message as { content?: Array<{ text?: string }> };
+			expect(endMessage.content?.[0]?.text).toHaveLength(8_000);
+		} finally {
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+
+	it("keeps aggregate message_update bytes near-linear in response length", async () => {
+		const small = await streamTextOfSize(8_000);
+		let smallBytes: number;
+		try {
+			smallBytes = serializedMessageUpdateBytes(small.capture);
+		} finally {
+			small.capture.detach();
+			small.harness.cleanup();
+		}
+
+		const large = await streamTextOfSize(16_000);
+		let largeBytes: number;
+		try {
+			largeBytes = serializedMessageUpdateBytes(large.capture);
+		} finally {
+			large.capture.detach();
+			large.harness.cleanup();
+		}
+
+		// Linear growth doubles the bytes when the response doubles; quadratic
+		// cumulative serialization would quadruple them (the unprojected shape
+		// carries two full copies of the growing message per frame).
+		expect(largeBytes / smallBytes).toBeLessThan(2.5);
+
+		// Absolute sanity bound: projected total stays a small multiple of the
+		// response size; the unprojected 16 KB response would be ~64 MB.
+		expect(largeBytes).toBeLessThan(16_000 * 64);
+	});
+
+	it("does not project get_dashboard_snapshot responses", async () => {
+		const { capture, harness } = await streamTextOfSize(1_000);
+		try {
+			const baseline = capture.frames.length;
+			capture.sendCommand({ type: "get_dashboard_snapshot" });
+			await vi.waitFor(() => {
+				expect(
+					capture.frames.some(
+						(f) => f.type === "response" && f.command === "get_dashboard_snapshot" && f.success === true,
+					),
+				).toBe(true);
+			});
+
+			const response = capture.frames.find(
+				(f) => f.type === "response" && f.command === "get_dashboard_snapshot" && f.success === true,
+			);
+			const data = response?.data as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+			const assistant = data.messages?.find((m) => m.content?.[0]?.text && m.content[0].text.length === 1_000);
+			expect(assistant).toBeDefined();
+
+			// The barrier event accompanying the snapshot is also present.
+			expect(capture.frames.slice(baseline).some((f) => f.type === "dashboard_snapshot_barrier")).toBe(true);
+		} finally {
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+
+	it("leaves the generic RPC protocol untouched when uiType is not dashboard", async () => {
+		const harness = createHarness({ responses: ["x".repeat(4_000)] });
+		const capture = await startRpcMode(harness);
+		try {
+			await harness.session.prompt("hi");
+
+			const updates = messageUpdateFrames(capture);
+			expect(updates.length).toBeGreaterThan(700);
+			for (const frame of updates) {
+				// Generic RPC consumers keep both cumulative fields.
+				expect(frame.message).toBeDefined();
+				const streamEvent = frame.assistantMessageEvent as Record<string, unknown>;
+				expect(streamEvent.partial).toBeDefined();
+			}
+		} finally {
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/test-harness.ts
+++ b/packages/coding-agent/test/test-harness.ts
@@ -332,6 +332,8 @@ export interface HarnessOptions {
 	tools?: AgentTool[];
 	/** Base tools override (replaces built-in read/bash/edit/write). */
 	baseToolsOverride?: Record<string, AgentTool>;
+	/** UI surface type passed to the session (e.g. "dashboard", "rpc"). */
+	uiType?: string;
 	/** Optional resource loader override. */
 	resourceLoader?: ResourceLoader;
 	/** Inline extensions to load into the session resource loader. */
@@ -400,6 +402,7 @@ function createHarnessWithResourceLoader(
 		modelRegistry,
 		resourceLoader,
 		baseToolsOverride: options.baseToolsOverride,
+		uiType: options.uiType,
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.55.4",
+  "version": "2.55.5",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.55.4",
+	"version": "2.55.5",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #448

High-rate model events carry cumulative assistant state (`message`, `assistantMessageEvent.partial`) across the internal dreb-child RPC JSONL pipe before the dashboard's EventHub projection runs, causing quadratic serialization and unbounded stdout queuing (observed: 6,401 events in a 3-second end-of-response burst). This PR projects dashboard-specific streaming events before RPC JSONL serialization (gated on `--ui dashboard`) and makes the child stdout queue explicitly bounded with backpressure handling.

Implementation plan posted as a comment below.
