### PR TITLE
Forward Qwen reasoning levels through chat template kwargs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.57.0",
+			"version": "2.57.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -794,7 +794,7 @@ interface OpenAICompletionsCompat {
   requiresToolResultName?: boolean;  // Whether tool results require the `name` field (default: false)
   requiresAssistantAfterToolResult?: boolean; // Whether tool results must be followed by an assistant message (default: false)
   requiresThinkingAsText?: boolean;  // Whether thinking blocks must be converted to text (default: false)
-  thinkingFormat?: 'openai' | 'openrouter' | 'zai' | 'qwen' | 'qwen-chat-template' | 'kimi'; // Format for reasoning param: 'openai' uses reasoning_effort, 'openrouter' uses reasoning: { effort }, 'zai' uses top-level enable_thinking: boolean, 'qwen' uses top-level enable_thinking: boolean, 'qwen-chat-template' uses chat_template_kwargs.enable_thinking plus a mapped chat_template_kwargs.reasoning_effort, and 'kimi' uses nested thinking: { type, effort? } plus prompt_cache_key (default: openai)
+  thinkingFormat?: 'openai' | 'openrouter' | 'zai' | 'qwen' | 'qwen-chat-template' | 'kimi'; // Format for reasoning param: 'openai' uses reasoning_effort, 'openrouter' uses reasoning: { effort }, 'zai' uses top-level enable_thinking: boolean, 'qwen' uses top-level enable_thinking: boolean, 'qwen-chat-template' uses chat_template_kwargs.enable_thinking plus a top-level mapped reasoning_effort (Qwen3.8+ models default-map dreb levels onto the native low/medium/xhigh tiers), and 'kimi' uses nested thinking: { type, effort? } plus prompt_cache_key (default: openai)
   openRouterRouting?: OpenRouterRouting; // OpenRouter routing preferences (default: {})
   vercelGatewayRouting?: VercelGatewayRouting; // Vercel AI Gateway routing preferences (default: {})
 }

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -794,7 +794,7 @@ interface OpenAICompletionsCompat {
   requiresToolResultName?: boolean;  // Whether tool results require the `name` field (default: false)
   requiresAssistantAfterToolResult?: boolean; // Whether tool results must be followed by an assistant message (default: false)
   requiresThinkingAsText?: boolean;  // Whether thinking blocks must be converted to text (default: false)
-  thinkingFormat?: 'openai' | 'openrouter' | 'zai' | 'qwen' | 'qwen-chat-template' | 'kimi'; // Format for reasoning param: 'openai' uses reasoning_effort, 'openrouter' uses reasoning: { effort }, 'zai' uses top-level enable_thinking: boolean, 'qwen' uses top-level enable_thinking: boolean, 'qwen-chat-template' uses chat_template_kwargs.enable_thinking, and 'kimi' uses nested thinking: { type, effort? } plus prompt_cache_key (default: openai)
+  thinkingFormat?: 'openai' | 'openrouter' | 'zai' | 'qwen' | 'qwen-chat-template' | 'kimi'; // Format for reasoning param: 'openai' uses reasoning_effort, 'openrouter' uses reasoning: { effort }, 'zai' uses top-level enable_thinking: boolean, 'qwen' uses top-level enable_thinking: boolean, 'qwen-chat-template' uses chat_template_kwargs.enable_thinking plus a mapped chat_template_kwargs.reasoning_effort, and 'kimi' uses nested thinking: { type, effort? } plus prompt_cache_key (default: openai)
   openRouterRouting?: OpenRouterRouting; // OpenRouter routing preferences (default: {})
   vercelGatewayRouting?: VercelGatewayRouting; // Vercel AI Gateway routing preferences (default: {})
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -163,10 +163,13 @@ function claudeFamilyVersion(modelId: string): ClaudeFamilyVersion | undefined {
 /**
  * Parse Qwen family versions without mistaking parameter counts for minor versions.
  * Only a dot separates major from minor (qwen3.8-27b, Qwen-3.8); a hyphen after the
- * major version introduces the parameter size (qwen3-32b → 3.0, not 3.32).
+ * major version introduces the parameter size (qwen3-32b → 3.0, not 3.32). A capture
+ * directly followed by a `b`-suffixed size token is a parameter count, not a version
+ * (qwen-32b, Qwen-7B-Chat, deepseek-r1-distill-qwen-32b), and Qwen majors never reach
+ * two digits, so only a single digit is accepted.
  */
 function qwenFamilyVersion(modelId: string): { major: number; minor: number } | undefined {
-	const match = modelId.match(/qwen[\s_-]*v?(\d+)(?:\.(\d+))?/i);
+	const match = modelId.match(/\bqwen[\s_-]*v?(\d)(?:\.(\d+))?(?![\d.]*b\b)/i);
 	if (!match) return undefined;
 	return {
 		major: Number.parseInt(match[1], 10),

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -161,15 +161,41 @@ function claudeFamilyVersion(modelId: string): ClaudeFamilyVersion | undefined {
 }
 
 /**
+ * Parse Qwen family versions without mistaking parameter counts for minor versions.
+ * Only a dot separates major from minor (qwen3.8-27b, Qwen-3.8); a hyphen after the
+ * major version introduces the parameter size (qwen3-32b → 3.0, not 3.32).
+ */
+function qwenFamilyVersion(modelId: string): { major: number; minor: number } | undefined {
+	const match = modelId.match(/qwen[\s_-]*v?(\d+)(?:\.(\d+))?/i);
+	if (!match) return undefined;
+	return {
+		major: Number.parseInt(match[1], 10),
+		minor: match[2] === undefined ? 0 : Number.parseInt(match[2], 10),
+	};
+}
+
+/**
+ * Check whether a model id belongs to Qwen 3.8 or a later Qwen generation — the first
+ * Qwen family with graded `reasoning_effort` tiers (low/medium/xhigh, default xhigh).
+ */
+export function isQwen38OrLater(modelId: string): boolean {
+	const qwen = qwenFamilyVersion(modelId);
+	if (!qwen) return false;
+	return qwen.major > 3 || (qwen.major === 3 && qwen.minor >= 8);
+}
+
+/**
  * Check if a model supports xhigh thinking level.
  *
  * Supported today:
  * - GPT-5.2 through GPT-5.6 model families
  * - Claude Opus 4.6–4.x and Claude 5 model families
  * - Kimi Code K3 (xhigh maps to its advertised "max" effort)
+ * - Qwen 3.8+ model families (xhigh is their top native effort tier)
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	if (model.provider === "kimi-coding-oauth" && model.id === "k3") return true;
+	if (isQwen38OrLater(model.id)) return true;
 	if (
 		model.id.includes("gpt-5.2") ||
 		model.id.includes("gpt-5.3") ||

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -417,7 +417,13 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
 	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
-		(params as any).chat_template_kwargs = { enable_thinking: !!options?.reasoningEffort };
+		const chatTemplateKwargs: Record<string, unknown> = {
+			enable_thinking: !!options?.reasoningEffort,
+		};
+		if (options?.reasoningEffort) {
+			chatTemplateKwargs.reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
+		}
+		(params as any).chat_template_kwargs = chatTemplateKwargs;
 	} else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -9,7 +9,7 @@ import type {
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { calculateCost, supportsXhigh } from "../models.js";
+import { calculateCost, isQwen38OrLater, supportsXhigh } from "../models.js";
 import type {
 	AssistantMessage,
 	Context,
@@ -417,13 +417,12 @@ function buildParams(model: Model<"openai-completions">, context: Context, optio
 	} else if (compat.thinkingFormat === "qwen" && model.reasoning) {
 		(params as any).enable_thinking = !!options?.reasoningEffort;
 	} else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
-		const chatTemplateKwargs: Record<string, unknown> = {
-			enable_thinking: !!options?.reasoningEffort,
-		};
+		// Qwen chat-template servers read the thinking toggle from chat_template_kwargs;
+		// effort is the canonical top-level OpenAI reasoning_effort field.
+		(params as any).chat_template_kwargs = { enable_thinking: !!options?.reasoningEffort };
 		if (options?.reasoningEffort) {
-			chatTemplateKwargs.reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
+			(params as any).reasoning_effort = mapReasoningEffort(options.reasoningEffort, compat.reasoningEffortMap);
 		}
-		(params as any).chat_template_kwargs = chatTemplateKwargs;
 	} else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
@@ -904,14 +903,42 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 }
 
 /**
+ * Default translation of dreb's five thinking levels onto Qwen3.8+'s three native
+ * `reasoning_effort` tiers (low/medium/xhigh, default xhigh). Applied only to
+ * qwen-chat-template models; an explicit per-model reasoningEffortMap wins.
+ */
+const QWEN38_PLUS_EFFORT_MAP: Record<NonNullable<OpenAICompletionsOptions["reasoningEffort"]>, string> = {
+	minimal: "low",
+	low: "low",
+	medium: "medium",
+	high: "xhigh",
+	xhigh: "xhigh",
+};
+
+/**
+ * Apply the default Qwen3.8+ effort translation for qwen-chat-template models.
+ * Older Qwen versions and non-Qwen models keep identity forwarding; a non-empty
+ * resolved map (e.g. a per-model reasoningEffortMap) is never overridden.
+ */
+function maybeApplyQwen38DefaultEffortMap(
+	model: Model<"openai-completions">,
+	compat: Required<OpenAICompletionsCompat>,
+): Required<OpenAICompletionsCompat> {
+	if (compat.thinkingFormat !== "qwen-chat-template") return compat;
+	if (!isQwen38OrLater(model.id)) return compat;
+	if (Object.keys(compat.reasoningEffortMap).length > 0) return compat;
+	return { ...compat, reasoningEffortMap: QWEN38_PLUS_EFFORT_MAP };
+}
+
+/**
  * Get resolved compatibility settings for a model.
  * Uses explicit model.compat if provided, otherwise auto-detects from provider/URL.
  */
 function getCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
 	const detected = detectCompat(model);
-	if (!model.compat) return detected;
+	if (!model.compat) return maybeApplyQwen38DefaultEffortMap(model, detected);
 
-	return {
+	return maybeApplyQwen38DefaultEffortMap(model, {
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
@@ -926,5 +953,5 @@ function getCompat(model: Model<"openai-completions">): Required<OpenAICompletio
 		openRouterRouting: model.compat.openRouterRouting ?? {},
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
 		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
-	};
+	});
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -289,7 +289,7 @@ export interface OpenAICompletionsCompat {
 	requiresAssistantAfterToolResult?: boolean;
 	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
 	requiresThinkingAsText?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking, and "kimi" uses nested thinking: { type, effort? } plus prompt_cache_key. Default: "openai". */
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking plus a mapped chat_template_kwargs.reasoning_effort, and "kimi" uses nested thinking: { type, effort? } plus prompt_cache_key. Default: "openai". */
 	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "kimi";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -289,7 +289,7 @@ export interface OpenAICompletionsCompat {
 	requiresAssistantAfterToolResult?: boolean;
 	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
 	requiresThinkingAsText?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking plus a mapped chat_template_kwargs.reasoning_effort, and "kimi" uses nested thinking: { type, effort? } plus prompt_cache_key. Default: "openai". */
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking plus a top-level mapped reasoning_effort (Qwen3.8+ models default-map dreb levels onto the native low/medium/xhigh tiers), and "kimi" uses nested thinking: { type, effort? } plus prompt_cache_key. Default: "openai". */
 	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "kimi";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;

--- a/packages/ai/test/openai-completions-qwen-chat-template.test.ts
+++ b/packages/ai/test/openai-completions-qwen-chat-template.test.ts
@@ -174,4 +174,13 @@ describe("openai-completions qwen-chat-template thinkingFormat (pre-3.8 Qwen and
 
 		expect(getParams().reasoning_effort).toBe("medium");
 	});
+
+	it("does not apply the Qwen3.8+ default map to ids whose digits are parameter counts", async () => {
+		// Qwen distills use the Qwen chat template, so this is a plausible local config —
+		// but 32 is a parameter count, not a Qwen 32.x family version.
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "deepseek-r1-distill-qwen-32b" };
+		await stream(model, "high");
+
+		expect(getParams().reasoning_effort).toBe("high");
+	});
 });

--- a/packages/ai/test/openai-completions-qwen-chat-template.test.ts
+++ b/packages/ai/test/openai-completions-qwen-chat-template.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { streamSimple } from "../src/stream.js";
+import type { Model } from "../src/types.js";
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: async (params: unknown) => {
+					mockState.lastParams = params;
+					return {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								choices: [{ delta: {}, finish_reason: "stop" }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							};
+						},
+					};
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+const QWEN_CHAT_TEMPLATE_MODEL: Model<"openai-completions"> = {
+	api: "openai-completions",
+	provider: "custom",
+	id: "qwen3.8",
+	name: "Qwen 3.8",
+	baseUrl: "http://localhost:8080/v1",
+	input: ["text"],
+	reasoning: true,
+	contextWindow: 65536,
+	maxTokens: 16384,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	compat: { thinkingFormat: "qwen-chat-template" },
+};
+
+type ChatTemplateKwargs = { enable_thinking?: boolean; reasoning_effort?: string };
+
+function getParams(): {
+	chat_template_kwargs?: ChatTemplateKwargs;
+	reasoning_effort?: string;
+} {
+	return mockState.lastParams as {
+		chat_template_kwargs?: ChatTemplateKwargs;
+		reasoning_effort?: string;
+	};
+}
+
+async function stream(model: Model<"openai-completions">, reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh") {
+	await streamSimple(
+		model,
+		{ messages: [{ role: "user", content: "Hi", timestamp: Date.now() }] },
+		{ apiKey: "test", reasoning },
+	).result();
+}
+
+describe("openai-completions qwen-chat-template thinkingFormat", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("forwards the mapped reasoning level inside chat_template_kwargs when enabled", async () => {
+		await stream(QWEN_CHAT_TEMPLATE_MODEL, "medium");
+
+		expect(getParams().chat_template_kwargs).toEqual({
+			enable_thinking: true,
+			reasoning_effort: "medium",
+		});
+	});
+
+	it("applies reasoningEffortMap before forwarding", async () => {
+		const model: Model<"openai-completions"> = {
+			...QWEN_CHAT_TEMPLATE_MODEL,
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				reasoningEffortMap: { high: "max" },
+			},
+		};
+		await stream(model, "high");
+
+		expect(getParams().chat_template_kwargs).toEqual({
+			enable_thinking: true,
+			reasoning_effort: "max",
+		});
+	});
+
+	it("sends enable_thinking: false and omits reasoning_effort when reasoning is disabled", async () => {
+		await stream(QWEN_CHAT_TEMPLATE_MODEL);
+
+		const kwargs = getParams().chat_template_kwargs;
+		expect(kwargs).toEqual({ enable_thinking: false });
+		expect(kwargs).not.toHaveProperty("reasoning_effort");
+	});
+
+	it("omits chat_template_kwargs entirely for non-reasoning models", async () => {
+		const nonReasoningModel: Model<"openai-completions"> = {
+			...QWEN_CHAT_TEMPLATE_MODEL,
+			reasoning: false,
+		};
+		await stream(nonReasoningModel, "medium");
+
+		expect(getParams().chat_template_kwargs).toBeUndefined();
+	});
+
+	it("never sets the top-level reasoning_effort field for this format", async () => {
+		await stream(QWEN_CHAT_TEMPLATE_MODEL, "high");
+
+		expect(getParams().reasoning_effort).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-completions-qwen-chat-template.test.ts
+++ b/packages/ai/test/openai-completions-qwen-chat-template.test.ts
@@ -33,11 +33,11 @@ vi.mock("openai", () => {
 	return { default: FakeOpenAI };
 });
 
-const QWEN_CHAT_TEMPLATE_MODEL: Model<"openai-completions"> = {
+const QWEN38_MODEL: Model<"openai-completions"> = {
 	api: "openai-completions",
 	provider: "custom",
-	id: "qwen3.8",
-	name: "Qwen 3.8",
+	id: "qwen3.8-27b",
+	name: "Qwen 3.8 27B",
 	baseUrl: "http://localhost:8080/v1",
 	input: ["text"],
 	reasoning: true,
@@ -59,7 +59,9 @@ function getParams(): {
 	};
 }
 
-async function stream(model: Model<"openai-completions">, reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh") {
+type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
+
+async function stream(model: Model<"openai-completions">, reasoning?: ReasoningLevel) {
 	await streamSimple(
 		model,
 		{ messages: [{ role: "user", content: "Hi", timestamp: Date.now() }] },
@@ -67,57 +69,109 @@ async function stream(model: Model<"openai-completions">, reasoning?: "minimal" 
 	).result();
 }
 
-describe("openai-completions qwen-chat-template thinkingFormat", () => {
+describe("openai-completions qwen-chat-template thinkingFormat (Qwen3.8+)", () => {
 	beforeEach(() => {
 		mockState.lastParams = undefined;
 	});
 
-	it("forwards the mapped reasoning level inside chat_template_kwargs when enabled", async () => {
-		await stream(QWEN_CHAT_TEMPLATE_MODEL, "medium");
+	it.each([
+		// Qwen3.8 natively exposes exactly three effort tiers: low, medium, xhigh.
+		["minimal", "low"],
+		["low", "low"],
+		["medium", "medium"],
+		["high", "xhigh"],
+		["xhigh", "xhigh"],
+	] as const)(
+		"maps dreb reasoning %s to top-level reasoning_effort %s with the default Qwen3.8+ map",
+		async (level, expectedEffort) => {
+			await stream(QWEN38_MODEL, level);
 
-		expect(getParams().chat_template_kwargs).toEqual({
-			enable_thinking: true,
-			reasoning_effort: "medium",
-		});
+			const params = getParams();
+			expect(params.reasoning_effort).toBe(expectedEffort);
+			expect(params.chat_template_kwargs).toEqual({ enable_thinking: true });
+			expect(params.chat_template_kwargs).not.toHaveProperty("reasoning_effort");
+		},
+	);
+
+	it("forwards xhigh unchanged (not through the xhigh→high clamp)", async () => {
+		// qwen3.8-27b must be recognized as xhigh-capable so streamSimple does not clamp first.
+		await stream(QWEN38_MODEL, "xhigh");
+
+		expect(getParams().reasoning_effort).toBe("xhigh");
 	});
 
-	it("applies reasoningEffortMap before forwarding", async () => {
-		const model: Model<"openai-completions"> = {
-			...QWEN_CHAT_TEMPLATE_MODEL,
-			compat: {
-				thinkingFormat: "qwen-chat-template",
-				reasoningEffortMap: { high: "max" },
-			},
-		};
+	it("applies the default map for custom qwen-3.8 id spellings", async () => {
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "qwen-3.8" };
 		await stream(model, "high");
 
-		expect(getParams().chat_template_kwargs).toEqual({
-			enable_thinking: true,
-			reasoning_effort: "max",
-		});
+		expect(getParams().reasoning_effort).toBe("xhigh");
 	});
 
 	it("sends enable_thinking: false and omits reasoning_effort when reasoning is disabled", async () => {
-		await stream(QWEN_CHAT_TEMPLATE_MODEL);
+		await stream(QWEN38_MODEL);
 
-		const kwargs = getParams().chat_template_kwargs;
-		expect(kwargs).toEqual({ enable_thinking: false });
-		expect(kwargs).not.toHaveProperty("reasoning_effort");
+		const params = getParams();
+		expect(params.chat_template_kwargs).toEqual({ enable_thinking: false });
+		expect(params.reasoning_effort).toBeUndefined();
 	});
 
 	it("omits chat_template_kwargs entirely for non-reasoning models", async () => {
 		const nonReasoningModel: Model<"openai-completions"> = {
-			...QWEN_CHAT_TEMPLATE_MODEL,
+			...QWEN38_MODEL,
 			reasoning: false,
 		};
 		await stream(nonReasoningModel, "medium");
 
-		expect(getParams().chat_template_kwargs).toBeUndefined();
+		const params = getParams();
+		expect(params.chat_template_kwargs).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
 	});
 
-	it("never sets the top-level reasoning_effort field for this format", async () => {
-		await stream(QWEN_CHAT_TEMPLATE_MODEL, "high");
+	it("lets an explicit per-model reasoningEffortMap override the Qwen3.8+ default", async () => {
+		const model: Model<"openai-completions"> = {
+			...QWEN38_MODEL,
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+				reasoningEffortMap: { medium: "low" },
+			},
+		};
+		await stream(model, "medium");
 
-		expect(getParams().reasoning_effort).toBeUndefined();
+		expect(getParams().reasoning_effort).toBe("low");
+	});
+});
+
+describe("openai-completions qwen-chat-template thinkingFormat (pre-3.8 Qwen and non-Qwen models)", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("keeps identity forwarding for older Qwen models (no default map)", async () => {
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "qwen3.6-27b" };
+		await stream(model, "medium");
+
+		expect(getParams().reasoning_effort).toBe("medium");
+		expect(getParams().chat_template_kwargs).toEqual({ enable_thinking: true });
+	});
+
+	it("keeps the xhigh→high clamp for older Qwen models", async () => {
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "qwen3.6-27b" };
+		await stream(model, "xhigh");
+
+		expect(getParams().reasoning_effort).toBe("high");
+	});
+
+	it("does not treat qwen3-32b (parameter count, not minor version) as Qwen3.8+", async () => {
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "qwen3-32b" };
+		await stream(model, "high");
+
+		expect(getParams().reasoning_effort).toBe("high");
+	});
+
+	it("keeps identity forwarding for non-Qwen qwen-chat-template models", async () => {
+		const model: Model<"openai-completions"> = { ...QWEN38_MODEL, id: "my-local-model" };
+		await stream(model, "medium");
+
+		expect(getParams().reasoning_effort).toBe("medium");
 	});
 });

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -78,6 +78,21 @@ describe("supportsXhigh", () => {
 		},
 	);
 
+	it.each([
+		"deepseek-r1-distill-qwen-32b",
+		"Qwen-7B-Chat",
+		"qwen-14b",
+		"qwen-32b",
+		"qwen4b",
+		"copyqwen4gate",
+	] as const)(
+		"returns false for model %s whose digits are a parameter count or embedded substring, not a Qwen version",
+		(id) => {
+			const base = getModel("openai-codex", "gpt-5.4")!;
+			expect(supportsXhigh({ ...base, id })).toBe(false);
+		},
+	);
+
 	it("returns true for GPT-5.4 models", () => {
 		const model = getModel("openai-codex", "gpt-5.4");
 		expect(model).toBeDefined();

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -62,6 +62,22 @@ describe("supportsXhigh", () => {
 		},
 	);
 
+	it.each(["qwen3.8-27b", "qwen-3.8", "qwen3.8-max", "qwen3.9", "qwen4.1"] as const)(
+		"returns true for Qwen 3.8+ model %s (xhigh is a native effort tier)",
+		(id) => {
+			const base = getModel("openai-codex", "gpt-5.4")!;
+			expect(supportsXhigh({ ...base, id })).toBe(true);
+		},
+	);
+
+	it.each(["qwen3.6-27b", "qwen3-32b", "qwen2.5-72b-instruct", "qwen-plus", "qwen3-235b-a22b"] as const)(
+		"returns false for pre-3.8 Qwen model %s",
+		(id) => {
+			const base = getModel("openai-codex", "gpt-5.4")!;
+			expect(supportsXhigh({ ...base, id })).toBe(false);
+		},
+	);
+
 	it("returns true for GPT-5.4 models", () => {
 		const model = getModel("openai-codex", "gpt-5.4");
 		expect(model).toBeDefined();

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -188,7 +188,7 @@ models: [{
   }]
 ```
 
-Use `qwen-chat-template` instead for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`.
+Use `qwen-chat-template` instead for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.
 
 > Migration note: Mistral moved from `openai-completions` to `mistral-conversations`.
 > Use `mistral-conversations` for native Mistral models.
@@ -630,4 +630,4 @@ interface ProviderModelConfig {
 }
 ```
 
-`qwen` is for DashScope-style top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`.
+`qwen` is for DashScope-style top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -188,7 +188,22 @@ models: [{
   }]
 ```
 
-Use `qwen-chat-template` instead for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.
+Use `qwen-chat-template` instead for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb sends the mapped effort as a top-level `reasoning_effort`; Qwen3.8+ models (which natively support exactly `low`/`medium`/`xhigh`, default `xhigh`) get this map by default:
+
+```typescript
+models: [{
+  id: "qwen3.8-27b",
+  // ...
+  compat: {
+    thinkingFormat: "qwen-chat-template"
+    // The Qwen3.8+ default map below is applied automatically; supply your own
+    // reasoningEffortMap to override it:
+    // reasoningEffortMap: { minimal: "low", low: "low", medium: "medium", high: "xhigh", xhigh: "xhigh" }
+  }
+}]
+```
+
+Older Qwen models and non-Qwen servers keep identity forwarding, so configure `reasoningEffortMap` yourself if your server's effort vocabulary differs.
 
 > Migration note: Mistral moved from `openai-completions` to `mistral-conversations`.
 > Use `mistral-conversations` for native Mistral models.
@@ -630,4 +645,4 @@ interface ProviderModelConfig {
 }
 ```
 
-`qwen` is for DashScope-style top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.
+`qwen` is for DashScope-style top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that read `chat_template_kwargs.enable_thinking`; effort is sent as a top-level `reasoning_effort`, and Qwen3.8+ models get a default map onto the native `low`/`medium`/`xhigh` tiers (see the example above).

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -320,7 +320,7 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 | `openRouterRouting` | OpenRouter routing config passed to OpenRouter for model/provider selection |
 | `vercelGatewayRouting` | Vercel AI Gateway routing config for provider selection (`only`, `order`) |
 
-`qwen` uses top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that require `chat_template_kwargs.enable_thinking`.
+`qwen` uses top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that require `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.
 
 Example:
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -320,7 +320,7 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 | `openRouterRouting` | OpenRouter routing config passed to OpenRouter for model/provider selection |
 | `vercelGatewayRouting` | Vercel AI Gateway routing config for provider selection (`only`, `order`) |
 
-`qwen` uses top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that require `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb also forwards the mapped level as `chat_template_kwargs.reasoning_effort`.
+`qwen` uses top-level `enable_thinking`. Use `qwen-chat-template` for local Qwen-compatible servers that require `chat_template_kwargs.enable_thinking`. When reasoning is enabled, dreb sends the mapped effort as a top-level `reasoning_effort`; Qwen3.8+ models default-map dreb's levels onto the three native tiers (`minimal`/`low` → `low`, `medium` → `medium`, `high`/`xhigh` → `xhigh`).
 
 Example:
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.57.0",
+  "version": "2.57.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.57.0",
+	"version": "2.57.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #465

Forward mapped Qwen reasoning levels through `chat_template_kwargs.reasoning_effort` so `qwen-chat-template` models no longer collapse every enabled dreb level to a single boolean.

Implementation plan posted as a comment below.
