### PR TITLE
Fix dashboard JSON upload corruption and dotfile download 404s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.58.0",
+			"version": "2.58.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/server/server.ts
+++ b/packages/dashboard/src/server/server.ts
@@ -260,8 +260,10 @@ export function createDashboardServer(options: DashboardServerOptions): Dashboar
 		// /api/files/upload pipes the raw request stream into the destination
 		// file, so the parser must not run first — it would drain the stream
 		// and the upload would commit 0 bytes. Express 5 matching is
-		// non-strict, so the route also accepts the trailing-slash variant.
-		if (req.path === "/api/files/upload" || req.path === "/api/files/upload/") return next();
+		// case-insensitive and non-strict, so the route also accepts
+		// case-variant and trailing-slash URLs; the skip must cover all of them.
+		const uploadPath = req.path.toLowerCase();
+		if (uploadPath === "/api/files/upload" || uploadPath === "/api/files/upload/") return next();
 		jsonBodyParser(req, res, next);
 	});
 	app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {

--- a/packages/dashboard/src/server/server.ts
+++ b/packages/dashboard/src/server/server.ts
@@ -255,7 +255,15 @@ export function createDashboardServer(options: DashboardServerOptions): Dashboar
 	// Authenticate before consuming request bodies. Diagnostics have their own
 	// small parser limit; the larger limit exists only for prompt image payloads.
 	app.use("/api/events/diagnostic", express.json({ limit: MAX_CLIENT_DIAGNOSTIC_BYTES }));
-	app.use(express.json({ limit: MAX_PROMPT_BODY_BYTES }));
+	const jsonBodyParser = express.json({ limit: MAX_PROMPT_BODY_BYTES });
+	app.use((req: Request, res: Response, next: NextFunction) => {
+		// /api/files/upload pipes the raw request stream into the destination
+		// file, so the parser must not run first — it would drain the stream
+		// and the upload would commit 0 bytes. Express 5 matching is
+		// non-strict, so the route also accepts the trailing-slash variant.
+		if (req.path === "/api/files/upload" || req.path === "/api/files/upload/") return next();
+		jsonBodyParser(req, res, next);
+	});
 	app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
 		if ((err as { type?: string }).type === "entity.too.large") {
 			res.status(413).json({ error: "Request body is too large" });
@@ -1229,7 +1237,11 @@ export function createDashboardServer(options: DashboardServerOptions): Dashboar
 		files
 			.resolveDownload(path)
 			.then(({ path: real }) => {
-				res.download(real);
+				// send's default (dotfiles: "ignore") would 404 any dot-prefixed
+				// component; resolveDownload already canonicalized and validated.
+				// The explicit filename keeps the Content-Disposition identical to
+				// the no-filename form (content-disposition basenames internally).
+				res.download(real, basename(real), { dotfiles: "allow" });
 			})
 			.catch((err) => res.status(err?.status ?? 500).json({ error: String(err?.message ?? err) }));
 	});

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -2254,6 +2254,43 @@ describe("dashboard server — files", () => {
 		const traversal = await fetch(`${base}/api/files?path=${encodeURIComponent("/tmp/%2e%2e/etc")}`);
 		expect(traversal.status).toBe(400);
 	});
+
+	it("uploads JSON payloads byte-for-byte without the body parser consuming the stream", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "dreb-dash-server-"));
+		tempDirs.push(dir);
+		const canonical = await realpath(dir);
+		const { base } = await startServer();
+		const payload = JSON.stringify({ name: "payload.json", nested: { values: [1, 2, 3] } });
+
+		const upload = await fetch(
+			`${base}/api/files/upload?dir=${encodeURIComponent(dir)}&name=${encodeURIComponent("payload.json")}`,
+			{ method: "POST", headers: { "content-type": "application/json" }, body: payload },
+		);
+		expect(upload.status).toBe(200);
+		await expect(upload.json()).resolves.toEqual({ path: join(canonical, "payload.json") });
+
+		// Pre-fix, the global express.json() middleware drained the request stream
+		// before the upload handler could pipe it, committing a 0-byte file.
+		expect(await readFile(join(canonical, "payload.json"), "utf8")).toBe(payload);
+	});
+
+	it("downloads files under dot-prefixed directory components", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "dreb-dash-server-"));
+		tempDirs.push(dir);
+		const uploadsDir = join(dir, ".dreb-dashboard-uploads", "nested");
+		await mkdir(uploadsDir, { recursive: true });
+		const content = "dot-prefixed directory download";
+		await writeFile(join(uploadsDir, "report.txt"), content);
+		const { base } = await startServer();
+
+		// Pre-fix, res.download() inherited send's dotfiles: "ignore" default and
+		// 404'd for any path containing a dot-prefixed component.
+		const download = await fetch(
+			`${base}/api/files/download?path=${encodeURIComponent(join(uploadsDir, "report.txt"))}`,
+		);
+		expect(download.status).toBe(200);
+		expect(await download.text()).toBe(content);
+	});
 });
 
 describe("dashboard server — remote pairing flow", () => {

--- a/packages/dashboard/test/server.test.ts
+++ b/packages/dashboard/test/server.test.ts
@@ -2272,6 +2272,24 @@ describe("dashboard server — files", () => {
 		// Pre-fix, the global express.json() middleware drained the request stream
 		// before the upload handler could pipe it, committing a 0-byte file.
 		expect(await readFile(join(canonical, "payload.json"), "utf8")).toBe(payload);
+
+		// Express 5 route matching is case-insensitive, so /API/files/upload is
+		// the same upload route. Pre-fix, the case-sensitive skip let the parser
+		// drain the stream and commit a 0-byte file on case-variant URLs.
+		const caseVariant = await fetch(
+			`${base}/API/files/upload?dir=${encodeURIComponent(dir)}&name=${encodeURIComponent("case-variant.json")}`,
+			{ method: "POST", headers: { "content-type": "application/json" }, body: payload },
+		);
+		expect(caseVariant.status).toBe(200);
+		expect(await readFile(join(canonical, "case-variant.json"), "utf8")).toBe(payload);
+
+		// Non-strict matching also accepts the trailing-slash variant.
+		const trailingSlash = await fetch(
+			`${base}/api/files/upload/?dir=${encodeURIComponent(dir)}&name=${encodeURIComponent("trailing-slash.json")}`,
+			{ method: "POST", headers: { "content-type": "application/json" }, body: payload },
+		);
+		expect(trailingSlash.status).toBe(200);
+		expect(await readFile(join(canonical, "trailing-slash.json"), "utf8")).toBe(payload);
 	});
 
 	it("downloads files under dot-prefixed directory components", async () => {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.58.0",
+  "version": "2.58.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.58.0",
+	"version": "2.58.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #472

Two latent bugs in the dashboard files API:

1. **Upload corruption** — the global `express.json()` parser consumes the request body for `/api/files/upload` when the Content-Type is `application/json`, so the handler's raw-stream pipe commits a 0-byte file and returns 200 (silent corruption).
2. **Dotfile download 404s** — `res.download()` uses `send`'s default `dotfiles: 'ignore'`, so any path containing a dot-prefixed component 404s. Since every dashboard session upload lives under `.dreb-dashboard-uploads/`, all of those downloads fail.

Implementation plan posted as a comment below.
