### PR TITLE
Keep session view and send button on-screen in mobile portrait

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10955,7 +10955,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10984,7 +10984,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11040,7 +11040,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11169,7 +11169,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11401,7 +11401,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11450,7 +11450,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11483,7 +11483,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.59.0",
+			"version": "2.59.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/client/composer-sizing.ts
+++ b/packages/dashboard/src/client/composer-sizing.ts
@@ -1,0 +1,4 @@
+export function composerTextareaMaxHeight(innerHeightPx: number | undefined, narrow: boolean): number {
+	const viewportHeight = innerHeightPx || 800;
+	return Math.max(120, Math.floor(viewportHeight * (narrow ? 0.26 : 0.4)));
+}

--- a/packages/dashboard/src/client/screens/session.tsx
+++ b/packages/dashboard/src/client/screens/session.tsx
@@ -25,6 +25,7 @@ import { api } from "../api.js";
 import { commandMatches, dispatchBuiltinCommand, parseDashboardBuiltin } from "../builtin-commands.js";
 import { type BannerItem, BannerRegion, ConnectionIndicator, Modal } from "../components/common.js";
 import { MarkdownBody, Transcript } from "../components/transcript.js";
+import { composerTextareaMaxHeight } from "../composer-sizing.js";
 import { isAbortError } from "../errors.js";
 import { bindStickToBottom, createStickToBottom } from "../scrolling.js";
 import {
@@ -137,9 +138,12 @@ function groupedModels(models: ModelChoice[]): Array<{ provider: string; models:
 	return [...groups.entries()].map(([provider, group]) => ({ provider, models: group }));
 }
 
+export { composerTextareaMaxHeight };
+
 export function autoGrowTextarea(textarea: HTMLTextAreaElement): void {
 	textarea.style.height = "auto";
-	const maxHeight = Math.max(120, Math.floor((window.innerHeight || 800) * 0.4));
+	const narrow = window.matchMedia?.("(max-width: 700px)")?.matches ?? false;
+	const maxHeight = composerTextareaMaxHeight(window.innerHeight, narrow);
 	const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
 	if (nextHeight > 0) textarea.style.height = `${nextHeight}px`;
 	textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden";
@@ -2010,100 +2014,120 @@ export function SessionScreen(props: { store: AppStore; sessionKey: string }): J
 				</div>
 				<Show when={!bottomDockCollapsed()}>
 					<div class="dock-inner">
-						<Show when={tasks().length > 0}>
-							<details class="tasks" open={!isMobile()}>
-								<summary>
-									tasks — {tasksDone()} of {tasks().length} done
-								</summary>
-								<ul>
-									<For each={tasks()}>
-										{(task) => (
-											<li
-												classList={{
-													done: task.status === "completed",
-													active: task.status === "in_progress",
-												}}
-											>
-												{task.status === "completed" ? "☑" : task.status === "in_progress" ? "⧖" : "☐"}{" "}
-												{task.title}
-											</li>
-										)}
-									</For>
-								</ul>
-							</details>
-						</Show>
+						<Show
+							when={
+								tasks().length > 0 ||
+								liveAgents().length + doneAgents().length > 0 ||
+								showStopControls() ||
+								abortableStatuses().length > 0
+							}
+						>
+							<div class="dock-panels">
+								<Show when={tasks().length > 0}>
+									<details class="tasks" open={!isMobile()}>
+										<summary>
+											tasks — {tasksDone()} of {tasks().length} done
+										</summary>
+										<ul>
+											<For each={tasks()}>
+												{(task) => (
+													<li
+														classList={{
+															done: task.status === "completed",
+															active: task.status === "in_progress",
+														}}
+													>
+														{task.status === "completed"
+															? "☑"
+															: task.status === "in_progress"
+																? "⧖"
+																: "☐"}{" "}
+														{task.title}
+													</li>
+												)}
+											</For>
+										</ul>
+									</details>
+								</Show>
 
-						<Show when={liveAgents().length + doneAgents().length > 0}>
-							<details class="tasks subagents" open={!isMobile()}>
-								<summary>
-									subagents — {liveAgents().length} running · {doneAgents().length} done
-								</summary>
-								<ul class="subagent-list">
-									<For each={sortedAgents()}>
-										{(agent) => (
-											<li>
+								<Show when={liveAgents().length + doneAgents().length > 0}>
+									<details class="tasks subagents" open={!isMobile()}>
+										<summary>
+											subagents — {liveAgents().length} running · {doneAgents().length} done
+										</summary>
+										<ul class="subagent-list">
+											<For each={sortedAgents()}>
+												{(agent) => (
+													<li>
+														<button
+															type="button"
+															class="agent-chip"
+															title="view this subagent's session"
+															onClick={() =>
+																props.store.navigate({
+																	screen: "subagent",
+																	key: props.sessionKey,
+																	agentId: agent.agentId,
+																})
+															}
+														>
+															<span class={agent.status === "running" && !closed() ? "live" : "done"}>
+																{agent.status === "running"
+																	? closed()
+																		? "○"
+																		: "●"
+																	: agent.status === "completed"
+																		? "✓"
+																		: "✕"}
+															</span>
+															<span class="task">
+																{agent.agentType} — {agent.taskSummary}
+																<Show when={agent.arbitrations?.at(-1)}>
+																	{(record) =>
+																		record().status === "failure"
+																			? " · arbitration failed"
+																			: ` · ${record().final?.model ?? record().proposed.model} @ ${record().final?.thinking ?? record().proposed.thinking}`
+																	}
+																</Show>
+															</span>
+														</button>
+													</li>
+												)}
+											</For>
+										</ul>
+									</details>
+								</Show>
+
+								<Show when={showStopControls() || abortableStatuses().length > 0}>
+									<div class="status-line">
+										<Show when={streaming()}>
+											<span class="working">
+												● working{session()?.workingText ? ` — ${session()!.workingText}` : ""}
+												{elapsed() > 2 ? ` (${elapsed()}s)` : ""}
+											</span>
+										</Show>
+										<For each={abortableStatuses()}>
+											{(status) => (
 												<button
 													type="button"
-													class="agent-chip"
-													title="view this subagent's session"
-													onClick={() =>
-														props.store.navigate({
-															screen: "subagent",
-															key: props.sessionKey,
-															agentId: agent.agentId,
-														})
-													}
+													class="btn btn-small btn-danger inline-stop"
+													onClick={() => abortStatus(status.key)}
 												>
-													<span class={agent.status === "running" && !closed() ? "live" : "done"}>
-														{agent.status === "running"
-															? closed()
-																? "○"
-																: "●"
-															: agent.status === "completed"
-																? "✓"
-																: "✕"}
-													</span>
-													<span class="task">
-														{agent.agentType} — {agent.taskSummary}
-														<Show when={agent.arbitrations?.at(-1)}>
-															{(record) =>
-																record().status === "failure"
-																	? " · arbitration failed"
-																	: ` · ${record().final?.model ?? record().proposed.model} @ ${record().final?.thinking ?? record().proposed.thinking}`
-															}
-														</Show>
-													</span>
+													stop {status.key}
 												</button>
-											</li>
-										)}
-									</For>
-								</ul>
-							</details>
-						</Show>
-
-						<Show when={showStopControls() || abortableStatuses().length > 0}>
-							<div class="status-line">
-								<Show when={streaming()}>
-									<span class="working">
-										● working{session()?.workingText ? ` — ${session()!.workingText}` : ""}
-										{elapsed() > 2 ? ` (${elapsed()}s)` : ""}
-									</span>
-								</Show>
-								<For each={abortableStatuses()}>
-									{(status) => (
-										<button
-											type="button"
-											class="btn btn-small btn-danger inline-stop"
-											onClick={() => abortStatus(status.key)}
-										>
-											stop {status.key}
-										</button>
-									)}
-								</For>
-								<Show when={showStopControls()}>
-									<button type="button" class="btn btn-small btn-danger" disabled={stopping()} onClick={abort}>
-										{stopping() ? "stopping…" : "■ stop"}
-									</button>
+											)}
+										</For>
+										<Show when={showStopControls()}>
+											<button
+												type="button"
+												class="btn btn-small btn-danger"
+												disabled={stopping()}
+												onClick={abort}
+											>
+												{stopping() ? "stopping…" : "■ stop"}
+											</button>
+										</Show>
+									</div>
 								</Show>
 							</div>
 						</Show>

--- a/packages/dashboard/src/client/styles/app.css
+++ b/packages/dashboard/src/client/styles/app.css
@@ -44,9 +44,20 @@ body,
 	min-width: 0;
 }
 
+/* Anchor full-viewport sizing to the initial containing block (percentage
+   chain from html) instead of viewport units. In installed Android PWAs
+   (display: standalone/fullscreen), Chromium can pin vh/dvh resolution to a
+   transitional launch viewport and never re-resolve it (no resize event
+   fires), leaving every vh/dvh-sized element ~system-chrome-height too tall
+   and the document scrollable (chromium issue 453570183). Percentage heights
+   resolve against the ICB, which is correct in that state. */
+html,
+body {
+	height: 100%;
+}
+
 #root {
-	min-height: 100vh;
-	min-height: 100dvh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 }
@@ -278,8 +289,11 @@ body,
 	width: 100%;
 	max-width: 100%;
 	min-width: 0;
-	height: 100vh;
-	height: 100dvh;
+	/* Percentage of #root's definite height — see the html/body height note
+	   in the app shell section. Do not reintroduce vh/dvh here: stale
+	   viewport-unit resolution in installed Android PWAs reopens the
+	   document-scroll bug this screen's overflow: hidden cannot contain. */
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -2227,7 +2241,7 @@ details.thinking .thinking-body {
 /* ---------------------------------------------------------------- pairing */
 
 .pair-wrap {
-	min-height: 100vh;
+	min-height: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/dashboard/src/client/styles/app.css
+++ b/packages/dashboard/src/client/styles/app.css
@@ -2989,6 +2989,11 @@ details.thinking .thinking-body {
 		overscroll-behavior: contain;
 	}
 
+	/* Keep the mobile command menu in the composer's scroll area instead of clipping it. */
+	.command-popover {
+		position: static;
+	}
+
 	.composer {
 		flex: 0 0 auto;
 		min-height: 0;

--- a/packages/dashboard/src/client/styles/app.css
+++ b/packages/dashboard/src/client/styles/app.css
@@ -46,6 +46,7 @@ body,
 
 #root {
 	min-height: 100vh;
+	min-height: 100dvh;
 	display: flex;
 	flex-direction: column;
 }
@@ -473,6 +474,7 @@ body,
 .chat {
 	flex: 1;
 	overflow-y: auto;
+	overscroll-behavior: contain;
 	min-height: 0;
 }
 
@@ -1440,6 +1442,7 @@ details.thinking .thinking-body {
 	display: flex;
 	flex-direction: column;
 	gap: var(--space-2);
+	overscroll-behavior: contain;
 }
 
 .banner {
@@ -2951,6 +2954,56 @@ details.thinking .thinking-body {
 		max-width: 100%;
 	}
 
+	.session-bar {
+		flex-shrink: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.dock {
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.dock-collapse-row {
+		flex: 0 0 auto;
+	}
+
+	.dock-inner {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.dock-panels {
+		display: flex;
+		flex: 0 1 auto;
+		flex-direction: column;
+		gap: var(--space-2);
+		min-height: 0;
+		max-height: 30vh;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+	}
+
+	.composer {
+		flex: 0 0 auto;
+		min-height: 0;
+		max-height: 100%;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+	}
+
+	.composer-row {
+		position: sticky;
+		bottom: 0;
+		z-index: 1;
+		background: var(--bg);
+	}
+
 	.entry.user {
 		max-width: 100%;
 	}
@@ -3015,6 +3068,38 @@ details.thinking .thinking-body {
 	.toast-region {
 		width: 100%;
 		max-width: 100%;
+	}
+
+	.banner-region {
+		flex: 0 1 auto;
+		min-height: 0;
+		max-height: 20vh;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+	}
+
+	.banner-text {
+		max-height: 18vh;
+	}
+
+	.queued-message-row {
+		max-height: 8vh;
+		overflow-y: auto;
+	}
+
+	.attachment-strip {
+		max-height: 10vh;
+		overflow-y: auto;
+	}
+
+	.pending-chips {
+		display: block;
+		max-height: 8vh;
+		overflow-y: auto;
+	}
+
+	.composer textarea {
+		max-height: 26vh;
 	}
 
 	.toast-region {

--- a/packages/dashboard/test/client/composer-sizing.test.ts
+++ b/packages/dashboard/test/client/composer-sizing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { composerTextareaMaxHeight } from "../../src/client/composer-sizing.js";
+
+describe("composerTextareaMaxHeight", () => {
+	it.each([
+		{ innerHeight: 844, narrow: true, expected: 219 },
+		{ innerHeight: 844, narrow: false, expected: 337 },
+		{ innerHeight: 400, narrow: true, expected: 120 },
+		{ innerHeight: 400, narrow: false, expected: 160 },
+		{ innerHeight: 1000, narrow: true, expected: 260 },
+	])("uses the $narrow fraction for $innerHeight px", ({ innerHeight, narrow, expected }) => {
+		expect(composerTextareaMaxHeight(innerHeight, narrow)).toBe(expected);
+	});
+
+	it.each([undefined, 0])("uses the 800px fallback for an invalid height (%s)", (innerHeight) => {
+		expect(composerTextareaMaxHeight(innerHeight, true)).toBe(208);
+		expect(composerTextareaMaxHeight(innerHeight, false)).toBe(320);
+	});
+});

--- a/packages/dashboard/test/client/screens.test.tsx
+++ b/packages/dashboard/test/client/screens.test.tsx
@@ -2300,6 +2300,28 @@ describe("screen smoke tests", () => {
 		expect(el.textContent).toContain("compose ▴");
 	});
 
+	it("keeps dock panels together and the composer outside their scroll wrapper", () => {
+		const store = makeStore() as any;
+		const session = populatedSession("k-dock-layout");
+		const fakeStore = {
+			...store,
+			sessions: { "k-dock-layout": session },
+			fleet: () => ({ runtimes: [], diskSessions: [] }),
+			hydrateSession: async () => {},
+		};
+		const el = mount(() => <SessionScreen store={fakeStore} sessionKey="k-dock-layout" />);
+		const dockInner = el.querySelector(".dock-inner");
+		const dockPanels = dockInner?.querySelector(".dock-panels");
+		const composer = dockInner?.querySelector(".composer");
+
+		expect(dockPanels?.parentElement).toBe(dockInner);
+		expect(dockPanels?.querySelector("details.tasks:not(.subagents)")).not.toBeNull();
+		expect(dockPanels?.querySelector("details.subagents")).not.toBeNull();
+		expect(dockPanels?.querySelector(".status-line")).not.toBeNull();
+		expect(composer?.parentElement).toBe(dockInner);
+		expect(dockPanels?.contains(composer ?? null)).toBe(false);
+	});
+
 	it("in-session subagent panel collapses with the task-tracker details pattern", () => {
 		const store = makeStore() as any;
 		const session = populatedSession("k-subpanel");

--- a/packages/dashboard/test/client/session-mobile-layout.browser.test.ts
+++ b/packages/dashboard/test/client/session-mobile-layout.browser.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Real-browser mobile layout regression coverage for the session screen.
+ *
+ * jsdom cannot measure the flex shrinking and nested overflow that keeps the
+ * composer visible, so this test loads the production stylesheets in order and
+ * measures a hand-built copy of the session chrome in Chromium.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { type Browser, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const tokensCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/tokens.css", import.meta.url)), "utf8");
+const appCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/app.css", import.meta.url)), "utf8");
+const themesCss = readFileSync(fileURLToPath(new URL("../../src/client/styles/themes.css", import.meta.url)), "utf8");
+
+const longText = "A deliberately long dashboard message that exercises mobile wrapping and internal scrolling. ".repeat(
+	4,
+);
+const taskItems = Array.from({ length: 15 }, (_, index) => `<li>☐ task ${index + 1} with a long description</li>`).join(
+	"",
+);
+const agentItems = Array.from(
+	{ length: 10 },
+	(_, index) =>
+		`<li><button type="button" class="agent-chip"><span class="live">●</span><span class="task">Explore — background task ${index + 1}</span></button></li>`,
+).join("");
+const banners = Array.from(
+	{ length: 4 },
+	(_, index) =>
+		`<div class="banner warning"><span class="banner-glyph">◆</span><span class="banner-text">banner ${index + 1}: ${longText}</span><span class="banner-actions"><button type="button" class="btn btn-small">action</button></span><button type="button" class="btn btn-small banner-dismiss">dismiss</button></div>`,
+).join("");
+
+interface SessionLayoutState {
+	composerMaxed: boolean;
+	bannerCount: 0 | 4;
+	tasksOpen: boolean;
+	subagentsOpen: boolean;
+	headerCollapsed: boolean;
+	overflowOpen: boolean;
+}
+
+function sessionFixture(state: SessionLayoutState): string {
+	const headerOverflow = state.overflowOpen
+		? `<div class="session-bar-inner" style="justify-content:flex-end;gap:8px"><button type="button" class="btn btn-small">export HTML</button><button type="button" class="btn btn-small">compact now</button><button type="button" class="btn btn-small">expand tools</button><button type="button" class="btn btn-small">rename</button><button type="button" class="btn btn-small">stop runtime</button></div>`
+		: "";
+	const headerDetails = state.headerCollapsed
+		? ""
+		: `<div class="session-bar-inner session-info-bar"><span class="session-info-left">/home/test/project</span><button type="button" class="session-info-right stats-trigger"><span>messages 99</span><span>tokens 999k</span></button></div>${headerOverflow}`;
+	const tasks = `<details class="tasks"${state.tasksOpen ? " open" : ""}><summary>tasks — 3 of 15 done</summary><ul>${taskItems}</ul></details>`;
+	const subagents = `<details class="tasks subagents"${state.subagentsOpen ? " open" : ""}><summary>subagents — 10 running · 0 done</summary><ul class="subagent-list">${agentItems}</ul></details>`;
+	const status = `<div class="status-line"><span class="working">● working — ${longText}</span><button type="button" class="btn btn-small btn-danger">stop compaction</button><button type="button" class="btn btn-small btn-danger">■ stop</button></div>`;
+	const textarea = state.composerMaxed
+		? `<textarea style="height: 600px">${longText.repeat(8)}</textarea>`
+		: "<textarea></textarea>";
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<style>${tokensCss}</style>
+<style>${appCss}</style>
+<style>${themesCss}</style>
+</head>
+<body>
+<div id="root">
+	<div class="session-screen">
+		<header class="session-bar${state.headerCollapsed ? " collapsed" : ""}">
+			<div class="session-bar-inner session-bar-main">
+				<a class="back" href="#/">← fleet</a>
+				<span class="title">Long running session title</span>
+				<span class="project">/home/test/project</span>
+				<output class="session-connection-indicator switcher">● live</output>
+				<span class="right"><button type="button" class="switcher model-switcher"><span class="label">model</span> provider/long-model</button><button type="button" class="switcher"><span class="label">think</span> high</button><button type="button" class="switcher">⋯</button></span>
+				<button type="button" class="chrome-toggle">details ▴</button>
+			</div>
+			${headerDetails}
+		</header>
+		${state.bannerCount > 0 ? `<div class="container banner-region" aria-live="polite">${banners}</div>` : ""}
+		<main class="chat"><div class="chat-inner"><p>${longText}</p><p>${longText}</p><p>${longText}</p></div></main>
+		<footer class="dock">
+			<div class="dock-collapse-row"><button type="button" class="chrome-toggle">compose ▾</button></div>
+			<div class="dock-inner">
+				<div class="dock-panels">${tasks}${subagents}${status}</div>
+				<div class="composer">
+					<div class="queued-message-row"><span class="queued-chip">steer: ${longText}</span><span class="queued-chip">follow-up: ${longText}</span><button type="button" class="btn btn-small">restore to composer</button></div>
+					<div class="attachment-strip"><span class="attachment-file">📎 ${longText}</span><span class="attachment-file">📎 ${longText}</span></div>
+					${textarea}
+					<div class="composer-row">
+						<button type="button" class="btn btn-small" data-composer-action>📎 file</button>
+						<button type="button" class="btn btn-small" data-composer-action>🖼 photo</button>
+						<span class="mode-toggle" role="radiogroup"><button type="button">steer</button><button type="button">follow-up</button></span>
+						<button type="button" class="btn btn-primary btn-small send" data-composer-action>send ↵</button>
+					</div>
+				</div>
+			</div>
+		</footer>
+	</div>
+</div>
+</body>
+</html>`;
+}
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+	browser = await chromium.launch();
+	page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+}, 60_000);
+
+afterAll(async () => {
+	await browser?.close();
+});
+
+type SessionMeasurements = {
+	documentFits: boolean;
+	sendVisible: boolean;
+	composerActionsVisible: boolean;
+	headerAtViewportTop: boolean;
+};
+
+async function measureSession(): Promise<SessionMeasurements> {
+	return page.evaluate(() => {
+		const tolerance = 1;
+		const visibleInViewport = (element: Element) => {
+			const rect = element.getBoundingClientRect();
+			return rect.width > 0 && rect.height > 0 && rect.top >= -tolerance && rect.bottom <= innerHeight + tolerance;
+		};
+		const send = document.querySelector(".composer-row .send");
+		const actions = [...document.querySelectorAll("[data-composer-action]")];
+		const header = document.querySelector(".session-bar");
+		return {
+			documentFits: document.documentElement.scrollHeight <= innerHeight + tolerance,
+			sendVisible: send !== null && visibleInViewport(send),
+			composerActionsVisible: actions.length === 3 && actions.every(visibleInViewport),
+			headerAtViewportTop: header !== null && header.getBoundingClientRect().top >= -tolerance,
+		};
+	});
+}
+
+const acceptanceStates: SessionLayoutState[] = [];
+for (const composerMaxed of [false, true]) {
+	for (const bannerCount of [0, 4] as const) {
+		for (const tasksOpen of [false, true]) {
+			for (const subagentsOpen of [false, true]) {
+				for (const headerCollapsed of [false, true]) {
+					for (const overflowOpen of [false, true]) {
+						acceptanceStates.push({
+							composerMaxed,
+							bannerCount,
+							tasksOpen,
+							subagentsOpen,
+							headerCollapsed,
+							overflowOpen: headerCollapsed ? false : overflowOpen,
+						});
+					}
+				}
+			}
+		}
+	}
+}
+
+describe("session layout in a real browser", () => {
+	it.each(acceptanceStates)("keeps the composer visible for state %#", async (state) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.setContent(sessionFixture(state));
+		const measured = await measureSession();
+
+		expect(measured.documentFits).toBe(true);
+		expect(measured.sendVisible).toBe(true);
+		expect(measured.composerActionsVisible).toBe(true);
+		expect(measured.headerAtViewportTop).toBe(true);
+	});
+
+	it("keeps the composer visible in the worst-case keyboard-sized viewport", async () => {
+		await page.setViewportSize({ width: 390, height: 400 });
+		await page.setContent(
+			sessionFixture({
+				composerMaxed: true,
+				bannerCount: 4,
+				tasksOpen: true,
+				subagentsOpen: true,
+				headerCollapsed: false,
+				overflowOpen: true,
+			}),
+		);
+		const measured = await measureSession();
+
+		expect(measured.documentFits).toBe(true);
+		expect(measured.sendVisible).toBe(true);
+		expect(measured.composerActionsVisible).toBe(true);
+	});
+});

--- a/packages/dashboard/test/client/session-mobile-layout.browser.test.ts
+++ b/packages/dashboard/test/client/session-mobile-layout.browser.test.ts
@@ -39,9 +39,13 @@ interface SessionLayoutState {
 	subagentsOpen: boolean;
 	headerCollapsed: boolean;
 	overflowOpen: boolean;
+	commandMenuOpen?: boolean;
 }
 
 function sessionFixture(state: SessionLayoutState): string {
+	const commandMenu = state.commandMenuOpen
+		? `<div class="command-popover" role="listbox" id="command-listbox" aria-label="slash commands"><button type="button" class="command-option" role="option">/compact</button></div>`
+		: "";
 	const headerOverflow = state.overflowOpen
 		? `<div class="session-bar-inner" style="justify-content:flex-end;gap:8px"><button type="button" class="btn btn-small">export HTML</button><button type="button" class="btn btn-small">compact now</button><button type="button" class="btn btn-small">expand tools</button><button type="button" class="btn btn-small">rename</button><button type="button" class="btn btn-small">stop runtime</button></div>`
 		: "";
@@ -87,6 +91,7 @@ function sessionFixture(state: SessionLayoutState): string {
 				<div class="composer">
 					<div class="queued-message-row"><span class="queued-chip">steer: ${longText}</span><span class="queued-chip">follow-up: ${longText}</span><button type="button" class="btn btn-small">restore to composer</button></div>
 					<div class="attachment-strip"><span class="attachment-file">📎 ${longText}</span><span class="attachment-file">📎 ${longText}</span></div>
+					${commandMenu}
 					${textarea}
 					<div class="composer-row">
 						<button type="button" class="btn btn-small" data-composer-action>📎 file</button>
@@ -173,6 +178,32 @@ describe("session layout in a real browser", () => {
 		expect(measured.sendVisible).toBe(true);
 		expect(measured.composerActionsVisible).toBe(true);
 		expect(measured.headerAtViewportTop).toBe(true);
+	});
+
+	it("keeps the slash-command popover visible on mobile", async () => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.setContent(
+			sessionFixture({
+				composerMaxed: true,
+				bannerCount: 4,
+				tasksOpen: true,
+				subagentsOpen: true,
+				headerCollapsed: false,
+				overflowOpen: true,
+				commandMenuOpen: true,
+			}),
+		);
+		const visible = await page.evaluate(() => {
+			const popover = document.querySelector<HTMLElement>(".command-popover");
+			if (!popover) return false;
+			const rect = popover.getBoundingClientRect();
+			if (rect.bottom <= 0 || rect.top >= innerHeight) return false;
+			const x = (rect.left + rect.right) / 2;
+			const y = Math.max(0, Math.min(innerHeight - 1, (rect.top + rect.bottom) / 2));
+			return popover.contains(document.elementFromPoint(x, y));
+		});
+
+		expect(visible).toBe(true);
 	});
 
 	it("keeps the composer visible in the worst-case keyboard-sized viewport", async () => {

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.59.0",
+  "version": "2.59.1",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.59.0",
+	"version": "2.59.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #476

In narrow portrait (mobile) viewports, the dashboard session view's fixed chrome — session bar, banner region, tasks/subagents panels, and the composer — can together exceed the viewport height. The send button (lowest element in the DOM) gets clipped below the viewport, and the whole view can slide up and down in the window.

This PR makes the session view fit the viewport in all mobile states: caps each growing chrome element, adds a flexbox safety net so the composer (and send button) can never be clipped, and stops the document from scrolling behind the fixed-height session screen.

Implementation plan posted as a comment below.
