### PR TITLE
Return only final GitHub CI check results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10934,7 +10934,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10963,7 +10963,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11109,7 +11109,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11238,7 +11238,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11470,7 +11470,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11519,7 +11519,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11552,7 +11552,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.61.1",
+			"version": "2.61.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -414,7 +414,7 @@ Set `backgroundAgents.maxConcurrentSubagents` in `/settings`, dashboard Settings
 
 ### Waiting for GitHub CI
 
-Use `watch_github_ci` to monitor pull-request checks without asking the user to return later or constructing a polling loop. It runs `gh pr checks --watch --fail-fast`, defaults to the pull request for the current branch, accepts an optional PR number/URL/branch, and returns when checks pass or definitively fail. The call is cancellable and requires an installed, authenticated [GitHub CLI](https://cli.github.com/).
+Use `watch_github_ci` to monitor pull-request checks without asking the user to return later or constructing a polling loop. It runs `gh pr checks --watch --fail-fast`, defaults to the pull request for the current branch, accepts an optional PR number/URL/branch, and returns when checks pass or definitively fail. After the watch completes, it makes a plain `gh pr checks` query so the model receives one clean final check listing rather than the repeated polling snapshots shown in live progress. The call is cancellable and requires an installed, authenticated [GitHub CLI](https://cli.github.com/).
 
 The separate `wait` tool is an immediate no-op used when explicitly told to wait or while background subagents are running. It does not monitor CI and must not be used as a sleep or delay.
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/tools/watch-github-ci.ts
+++ b/packages/coding-agent/src/core/tools/watch-github-ci.ts
@@ -116,13 +116,47 @@ export function createLocalGithubCiOperations(): GithubCiOperations {
 	};
 }
 
-function formatOutput(chunks: readonly Buffer[], omittedEarlierOutput: boolean): { text: string; truncated: boolean } {
-	const rendered = renderTerminalOutput(Buffer.concat(chunks).toString("utf-8"));
-	const truncation = truncateTail(rendered);
-	const prefix = omittedEarlierOutput ? "[Earlier watch output omitted]\n" : "";
+interface OutputBuffer {
+	append(data: Buffer): void;
+	format(): { text: string; truncated: boolean };
+	hasOutput(): boolean;
+}
+
+function createOutputBuffer(omittedPrefix: string): OutputBuffer {
+	const chunks: Buffer[] = [];
+	let chunksBytes = 0;
+	let omittedEarlierOutput = false;
+	const maxBufferedBytes = DEFAULT_MAX_BYTES * 2;
+
 	return {
-		text: `${prefix}${truncation.content || "(no output)"}`,
-		truncated: omittedEarlierOutput || truncation.truncated,
+		append(data) {
+			chunks.push(data);
+			chunksBytes += data.length;
+			while (chunksBytes > maxBufferedBytes) {
+				const excess = chunksBytes - maxBufferedBytes;
+				const first = chunks[0];
+				if (first.length <= excess) {
+					chunks.shift();
+					chunksBytes -= first.length;
+				} else {
+					chunks[0] = first.subarray(excess);
+					chunksBytes -= excess;
+				}
+				omittedEarlierOutput = true;
+			}
+		},
+		format() {
+			const rendered = renderTerminalOutput(Buffer.concat(chunks).toString("utf-8"));
+			const truncation = truncateTail(rendered);
+			const prefix = omittedEarlierOutput ? `${omittedPrefix}\n` : "";
+			return {
+				text: `${prefix}${truncation.content || "(no output)"}`,
+				truncated: omittedEarlierOutput || truncation.truncated,
+			};
+		},
+		hasOutput() {
+			return chunks.length > 0;
+		},
 	};
 }
 
@@ -152,60 +186,41 @@ export function createWatchGithubCiToolDefinition(
 				throw new Error("Pull request selector must not begin with '-'.");
 			}
 
-			const args = ["pr", "checks", ...(selector ? [selector] : []), "--watch", "--fail-fast"];
-			const chunks: Buffer[] = [];
-			let chunksBytes = 0;
-			let omittedEarlierOutput = false;
-			let outputTruncated = false;
-			const maxBufferedBytes = DEFAULT_MAX_BYTES * 2;
-
-			const details = (status: WatchGithubCiToolDetails["status"], exitCode?: number) => ({
+			const watchArgs = ["pr", "checks", ...(selector ? [selector] : []), "--watch", "--fail-fast"];
+			const finalArgs = ["pr", "checks", ...(selector ? [selector] : [])];
+			const env = {
+				...getShellEnv(),
+				GH_PAGER: "cat",
+				GH_EDITOR: "cat",
+				NO_COLOR: "1",
+			};
+			const details = (status: WatchGithubCiToolDetails["status"], outputTruncated: boolean, exitCode?: number) => ({
 				status,
 				exitCode,
 				outputTruncated,
 			});
-			const currentOutput = (): string => {
-				const formatted = formatOutput(chunks, omittedEarlierOutput);
-				outputTruncated = formatted.truncated;
-				return formatted.text;
-			};
-			const onData = (data: Buffer) => {
-				chunks.push(data);
-				chunksBytes += data.length;
-				while (chunksBytes > maxBufferedBytes) {
-					const excess = chunksBytes - maxBufferedBytes;
-					const first = chunks[0];
-					if (first.length <= excess) {
-						chunks.shift();
-						chunksBytes -= first.length;
-					} else {
-						chunks[0] = first.subarray(excess);
-						chunksBytes -= excess;
-					}
-					omittedEarlierOutput = true;
-				}
+
+			const watchOutput = createOutputBuffer("[Earlier watch output omitted]");
+			const onWatchData = (data: Buffer) => {
+				watchOutput.append(data);
+				const formatted = watchOutput.format();
 				onUpdate?.({
-					content: [{ type: "text", text: currentOutput() }],
-					details: details("watching"),
+					content: [{ type: "text", text: formatted.text }],
+					details: details("watching", formatted.truncated),
 				});
 			};
 
-			onUpdate?.({ content: [], details: details("watching") });
+			onUpdate?.({ content: [], details: details("watching", false) });
 
-			let exitCode: number | null;
+			let watchExitCode: number | null;
 			try {
-				({ exitCode } = await operations.exec(args, cwd, {
-					onData,
+				({ exitCode: watchExitCode } = await operations.exec(watchArgs, cwd, {
+					onData: onWatchData,
 					signal,
-					env: {
-						...getShellEnv(),
-						GH_PAGER: "cat",
-						GH_EDITOR: "cat",
-						NO_COLOR: "1",
-					},
+					env,
 				}));
 			} catch (error) {
-				const output = chunks.length > 0 ? `${currentOutput()}\n\n` : "";
+				const output = watchOutput.hasOutput() ? `${watchOutput.format().text}\n\n` : "";
 				if (error instanceof Error && error.message === "aborted") {
 					throw new Error(`${output}GitHub CI watch aborted.`);
 				}
@@ -213,38 +228,80 @@ export function createWatchGithubCiToolDefinition(
 				throw new Error(`${output}GitHub CI watch could not run: ${message}`);
 			}
 
-			const output = currentOutput();
-			if (exitCode === 0) {
-				return {
-					content: [{ type: "text", text: `GitHub CI checks passed.\n\n${output}` }],
-					details: details("passed", exitCode),
-				};
-			}
-			if (exitCode === 1) {
-				const cliFailure = detectGhCliFailure(output);
+			const formattedWatchOutput = watchOutput.format();
+			if (watchExitCode === 1) {
+				const cliFailure = detectGhCliFailure(formattedWatchOutput.text);
 				if (cliFailure !== null) {
 					throw new Error(
-						`GitHub CI watch could not query checks: the GitHub CLI reported an error (matched "${cliFailure}"). This is a CLI-level failure such as a bad pull-request selector, no pull request for the branch, a missing repository, or an authentication problem — not a failed-check result. Re-check the selector and \`gh auth status\`.\n\n${output}`,
+						`GitHub CI watch could not query checks: the GitHub CLI reported an error (matched "${cliFailure}"). This is a CLI-level failure such as a bad pull-request selector, no pull request for the branch, a missing repository, or an authentication problem — not a failed-check result. Re-check the selector and \`gh auth status\`.\n\n${formattedWatchOutput.text}`,
 					);
 				}
-				return {
-					content: [
-						{
-							type: "text",
-							text: `GitHub CI checks did not pass. The GitHub CLI exited with code 1.\n\n${output}`,
-						},
-					],
-					details: details("failed", exitCode),
-				};
-			}
-			if (exitCode === 8) {
+			} else if (watchExitCode === 8) {
 				throw new Error(
-					`GitHub CI watch exited while checks were still pending (exit code 8); refusing to treat this as a terminal result.\n\n${output}`,
+					`GitHub CI watch exited while checks were still pending (exit code 8); refusing to treat this as a terminal result.\n\n${formattedWatchOutput.text}`,
+				);
+			} else if (watchExitCode !== 0) {
+				throw new Error(
+					`GitHub CI watch exited unexpectedly${watchExitCode === null ? " without an exit code" : ` with code ${watchExitCode}`}.\n\n${formattedWatchOutput.text}`,
 				);
 			}
-			throw new Error(
-				`GitHub CI watch exited unexpectedly${exitCode === null ? " without an exit code" : ` with code ${exitCode}`}.\n\n${output}`,
-			);
+
+			const finalOutput = createOutputBuffer("[Earlier final checks output omitted]");
+			let finalExitCode: number | null;
+			try {
+				({ exitCode: finalExitCode } = await operations.exec(finalArgs, cwd, {
+					onData: (data) => finalOutput.append(data),
+					signal,
+					env,
+				}));
+			} catch (error) {
+				const output = finalOutput.hasOutput() ? `${finalOutput.format().text}\n\n` : "";
+				if (error instanceof Error && error.message === "aborted") {
+					throw new Error(`${output}GitHub CI final checks query aborted.`);
+				}
+				const message = error instanceof Error ? error.message : String(error);
+				throw new Error(`${output}GitHub CI final checks query could not run: ${message}`);
+			}
+
+			const formattedFinalOutput = finalOutput.format();
+			if (finalExitCode === 1) {
+				const cliFailure = detectGhCliFailure(formattedFinalOutput.text);
+				if (cliFailure !== null) {
+					throw new Error(
+						`GitHub CI final checks query failed: the GitHub CLI reported an error (matched "${cliFailure}"). Re-check the selector and \`gh auth status\`.\n\n${formattedFinalOutput.text}`,
+					);
+				}
+			} else if (finalExitCode === 8) {
+				throw new Error(
+					`GitHub CI final checks query found checks still pending (exit code 8) after the watch reported a terminal result.\n\n${formattedFinalOutput.text}`,
+				);
+			} else if (finalExitCode !== 0) {
+				throw new Error(
+					`GitHub CI final checks query exited unexpectedly${finalExitCode === null ? " without an exit code" : ` with code ${finalExitCode}`}.\n\n${formattedFinalOutput.text}`,
+				);
+			}
+
+			if (watchExitCode !== finalExitCode) {
+				throw new Error(
+					`GitHub CI status changed between watch completion (exit code ${watchExitCode}) and the final checks query (exit code ${finalExitCode}); refusing to report a contradictory result.\n\n${formattedFinalOutput.text}`,
+				);
+			}
+
+			if (finalExitCode === 0) {
+				return {
+					content: [{ type: "text", text: `GitHub CI checks passed.\n\n${formattedFinalOutput.text}` }],
+					details: details("passed", formattedFinalOutput.truncated, finalExitCode),
+				};
+			}
+			return {
+				content: [
+					{
+						type: "text",
+						text: `GitHub CI checks did not pass. The GitHub CLI exited with code 1.\n\n${formattedFinalOutput.text}`,
+					},
+				],
+				details: details("failed", formattedFinalOutput.truncated, finalExitCode),
+			};
 		},
 	};
 }

--- a/packages/coding-agent/test/tools/watch-github-ci.test.ts
+++ b/packages/coding-agent/test/tools/watch-github-ci.test.ts
@@ -10,13 +10,30 @@ import {
 } from "../../src/core/tools/watch-github-ci.js";
 import * as shellModule from "../../src/utils/shell.js";
 
-function operationsResult(exitCode: number | null, output = "checks output"): GithubCiOperations {
+interface OperationStep {
+	exitCode: number | null;
+	output?: string | string[];
+	error?: Error;
+}
+
+function operationsSequence(...steps: OperationStep[]): GithubCiOperations {
+	let callIndex = 0;
 	return {
 		exec: vi.fn(async (_args, _cwd, { onData }) => {
-			if (output) onData(Buffer.from(output));
-			return { exitCode };
+			const step = steps[callIndex++];
+			if (!step) throw new Error(`Unexpected GitHub CI operation ${callIndex}`);
+			const outputs = Array.isArray(step.output) ? step.output : [step.output];
+			for (const output of outputs) {
+				if (output) onData(Buffer.from(output));
+			}
+			if (step.error) throw step.error;
+			return { exitCode: step.exitCode };
 		}),
 	};
+}
+
+function completedOperations(exitCode: 0 | 1, finalOutput: string, watchOutput = "watch output"): GithubCiOperations {
+	return operationsSequence({ exitCode, output: watchOutput }, { exitCode, output: finalOutput });
 }
 
 async function execute(
@@ -30,61 +47,85 @@ async function execute(
 }
 
 describe("watch_github_ci tool", () => {
-	it("uses the current branch pull request by default", async () => {
-		const operations = operationsResult(0);
+	it("watches and then queries the current branch pull request by default", async () => {
+		const operations = completedOperations(0, "build passed");
 		await execute(operations);
 
-		expect(operations.exec).toHaveBeenCalledOnce();
-		const [args, cwd, options] = vi.mocked(operations.exec).mock.calls[0];
-		expect(args).toEqual(["pr", "checks", "--watch", "--fail-fast"]);
-		expect(cwd).toBe("/repo");
-		expect(options.env).toMatchObject({ GH_PAGER: "cat", GH_EDITOR: "cat", NO_COLOR: "1" });
+		expect(operations.exec).toHaveBeenCalledTimes(2);
+		const [watchArgs, watchCwd, watchOptions] = vi.mocked(operations.exec).mock.calls[0];
+		const [finalArgs, finalCwd, finalOptions] = vi.mocked(operations.exec).mock.calls[1];
+		expect(watchArgs).toEqual(["pr", "checks", "--watch", "--fail-fast"]);
+		expect(finalArgs).toEqual(["pr", "checks"]);
+		expect(watchCwd).toBe("/repo");
+		expect(finalCwd).toBe("/repo");
+		expect(watchOptions.env).toMatchObject({ GH_PAGER: "cat", GH_EDITOR: "cat", NO_COLOR: "1" });
+		expect(finalOptions.env).toBe(watchOptions.env);
 	});
 
-	it("forwards a trimmed explicit pull request selector as one argument", async () => {
-		const operations = operationsResult(0);
+	it("forwards a trimmed explicit pull request selector to both commands", async () => {
+		const operations = completedOperations(0, "build passed");
 		await execute(operations, { pr: "  426  " });
 
 		expect(vi.mocked(operations.exec).mock.calls[0][0]).toEqual(["pr", "checks", "426", "--watch", "--fail-fast"]);
+		expect(vi.mocked(operations.exec).mock.calls[1][0]).toEqual(["pr", "checks", "426"]);
 	});
 
 	it("rejects a blank pull request selector", async () => {
-		const operations = operationsResult(0);
+		const operations = operationsSequence({ exitCode: 0 });
 		await expect(execute(operations, { pr: "   " })).rejects.toThrow("must not be blank");
 		expect(operations.exec).not.toHaveBeenCalled();
 	});
 
 	it("rejects option-like selectors before spawning", async () => {
-		const operations = operationsResult(0);
+		const operations = operationsSequence({ exitCode: 0 });
 		await expect(execute(operations, { pr: "--repo" })).rejects.toThrow("must not begin with '-'");
 		expect(operations.exec).not.toHaveBeenCalled();
 	});
 
-	it("returns final output and passed details for exit code zero", async () => {
-		const result = await execute(operationsResult(0, "build passed"));
+	it("returns only clean final output and passed details for exit code zero", async () => {
+		const operations = completedOperations(
+			0,
+			"build passed",
+			"Refreshing checks status every 10 seconds.\n\nbuild\tpending\t0\thttps://example.test/watch",
+		);
+		const result = await execute(operations);
 
-		expect(result.content[0]).toEqual({ type: "text", text: "GitHub CI checks passed.\n\nbuild passed" });
+		expect(result.content[0]).toEqual({
+			type: "text",
+			text: "GitHub CI checks passed.\n\nbuild passed",
+		});
+		expect((result.content[0] as { text: string }).text).not.toContain("Refreshing checks status");
 		expect(result.details).toEqual({ status: "passed", exitCode: 0, outputTruncated: false });
 		expect(result.endTurn).toBeUndefined();
 	});
 
-	it("returns failed check output without turning it into a tool execution error", async () => {
-		const result = await execute(operationsResult(1, "build failed"));
+	it("returns only clean failed-check output without turning it into a tool execution error", async () => {
+		const operations = completedOperations(
+			1,
+			"build failed",
+			"Refreshing checks status every 10 seconds.\n\nbuild\tpending\t0\thttps://example.test/watch",
+		);
+		const result = await execute(operations);
 
 		expect(result.content[0]).toEqual({
 			type: "text",
 			text: "GitHub CI checks did not pass. The GitHub CLI exited with code 1.\n\nbuild failed",
 		});
+		expect((result.content[0] as { text: string }).text).not.toContain("Refreshing checks status");
 		expect(result.details).toEqual({ status: "failed", exitCode: 1, outputTruncated: false });
 	});
 
-	it("rejects a no-pull-request CLI error as a tool error instead of status failed", async () => {
-		await expect(execute(operationsResult(1, 'no pull requests found for branch "ghost-branch"'))).rejects.toThrow(
-			"could not query checks",
-		);
+	it("rejects a no-pull-request watch error without running the final query", async () => {
+		const operations = operationsSequence({
+			exitCode: 1,
+			output: 'no pull requests found for branch "ghost-branch"',
+		});
 
-		const operations = operationsResult(1, 'no pull requests found for branch "ghost-branch"');
-		await expect(execute(operations)).rejects.toThrow("no pull requests found");
+		await expect(execute(operations)).rejects.toThrow("could not query checks");
+		await expect(execute(operationsSequence({ exitCode: 1, output: "no pull requests found" }))).rejects.toThrow(
+			"no pull requests found",
+		);
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
 	it.each([
@@ -92,34 +133,38 @@ describe("watch_github_ci tool", () => {
 		"failed to run git: fatal: not a git repository",
 		"HTTP 401: Bad credentials (https://api.github.com/graphql)",
 		"could not parse the pull request selector",
-	])("rejects CLI failure output %s as a tool error, not status failed", async (output) => {
-		await expect(execute(operationsResult(1, output))).rejects.toThrow("could not query checks");
+	])("rejects watch CLI failure output %s without running the final query", async (output) => {
+		const operations = operationsSequence({ exitCode: 1, output });
+		await expect(execute(operations)).rejects.toThrow("could not query checks");
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
-	it("refuses to treat pending exit code 8 as terminal success", async () => {
-		await expect(execute(operationsResult(8, "checks pending"))).rejects.toThrow(
-			"checks were still pending (exit code 8)",
-		);
+	it("refuses to query final results after pending watch exit code 8", async () => {
+		const operations = operationsSequence({ exitCode: 8, output: "checks pending" });
+		await expect(execute(operations)).rejects.toThrow("checks were still pending (exit code 8)");
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
-	it.each([null, 2, 4])("surfaces unexpected exit code %s loudly", async (exitCode) => {
-		await expect(execute(operationsResult(exitCode, "gh diagnostic"))).rejects.toThrow("exited unexpectedly");
+	it.each([null, 2, 4])("surfaces unexpected watch exit code %s without a final query", async (exitCode) => {
+		const operations = operationsSequence({ exitCode, output: "gh diagnostic" });
+		await expect(execute(operations)).rejects.toThrow("exited unexpectedly");
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
-	it("preserves buffered output when process execution fails", async () => {
-		const operations: GithubCiOperations = {
-			exec: vi.fn(async (_args, _cwd, { onData }) => {
-				onData(Buffer.from("authentication required"));
-				throw new Error("spawn failed");
-			}),
-		};
+	it("preserves buffered watch output when process execution fails", async () => {
+		const operations = operationsSequence({
+			exitCode: null,
+			output: "authentication required",
+			error: new Error("spawn failed"),
+		});
 
 		await expect(execute(operations)).rejects.toThrow(
 			"authentication required\n\nGitHub CI watch could not run: spawn failed",
 		);
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
-	it("reports cancellation distinctly and forwards the AbortSignal", async () => {
+	it("reports watch cancellation distinctly and forwards the AbortSignal", async () => {
 		const controller = new AbortController();
 		const operations: GithubCiOperations = {
 			exec: vi.fn(async (_args, _cwd, { signal }) => {
@@ -129,30 +174,130 @@ describe("watch_github_ci tool", () => {
 		};
 
 		await expect(execute(operations, {}, controller.signal)).rejects.toThrow("GitHub CI watch aborted");
+		expect(operations.exec).toHaveBeenCalledOnce();
 	});
 
-	it("streams watching updates and bounds retained output", async () => {
+	it("forwards the same AbortSignal to the watch and final query", async () => {
+		const controller = new AbortController();
+		const operations = completedOperations(0, "build passed");
+		await execute(operations, {}, controller.signal);
+
+		expect(vi.mocked(operations.exec).mock.calls[0][2].signal).toBe(controller.signal);
+		expect(vi.mocked(operations.exec).mock.calls[1][2].signal).toBe(controller.signal);
+	});
+
+	it("keeps repeated watch output in live updates but not the final result", async () => {
 		const updates: any[] = [];
-		const operations: GithubCiOperations = {
-			exec: vi.fn(async (_args, _cwd, { onData }) => {
-				onData(Buffer.from("x".repeat(DEFAULT_MAX_BYTES * 2)));
-				onData(Buffer.from("y".repeat(DEFAULT_MAX_BYTES * 2)));
-				return { exitCode: 0 };
-			}),
-		};
+		const watchSnapshots = [
+			"Refreshing checks status every 10 seconds.\n\nbuild\tpending\t0\thttps://example.test/build\n",
+			"Refreshing checks status every 10 seconds.\n\nbuild\tpass\t1m\thttps://example.test/build\n",
+		];
+		const operations = operationsSequence(
+			{ exitCode: 0, output: watchSnapshots },
+			{ exitCode: 0, output: "build\tpass\t1m\thttps://example.test/build" },
+		);
 		const result = await execute(operations, {}, undefined, (update) => updates.push(update));
 
 		expect(updates[0]).toEqual({
 			content: [],
 			details: { status: "watching", exitCode: undefined, outputTruncated: false },
 		});
-		expect(updates.at(-1).details.status).toBe("watching");
+		const lastUpdateText = updates.at(-1).content[0].text as string;
+		expect(lastUpdateText).toMatch(/build\s+pending/);
+		expect(lastUpdateText).toMatch(/build\s+pass/);
+		expect((result.content[0] as { text: string }).text).not.toContain("Refreshing checks status");
+	});
+
+	it("keeps watch truncation independent from the final result", async () => {
+		const updates: any[] = [];
+		const operations = operationsSequence(
+			{
+				exitCode: 0,
+				output: ["x".repeat(DEFAULT_MAX_BYTES * 2), "y".repeat(DEFAULT_MAX_BYTES * 2)],
+			},
+			{ exitCode: 0, output: "build passed" },
+		);
+		const result = await execute(operations, {}, undefined, (update) => updates.push(update));
+
+		expect(updates.at(-1).details).toMatchObject({ status: "watching", outputTruncated: true });
+		expect(result.details).toEqual({ status: "passed", exitCode: 0, outputTruncated: false });
+		expect(result.content[0]).toEqual({ type: "text", text: "GitHub CI checks passed.\n\nbuild passed" });
+	});
+
+	it("bounds and reports truncation of the separate final query output", async () => {
+		const updates: any[] = [];
+		const operations = completedOperations(0, "z".repeat(DEFAULT_MAX_BYTES * 3), "watch output");
+		const result = await execute(operations, {}, undefined, (update) => updates.push(update));
+		const resultText = (result.content[0] as { text: string }).text;
+
+		expect(updates.at(-1).details.outputTruncated).toBe(false);
 		expect(result.details?.outputTruncated).toBe(true);
-		expect((result.content[0] as { text: string }).text.length).toBeLessThan(DEFAULT_MAX_BYTES + 500);
+		expect(resultText).toContain("[Earlier final checks output omitted]");
+		expect(resultText.length).toBeLessThan(DEFAULT_MAX_BYTES + 500);
+	});
+
+	it("preserves final query output when that process fails", async () => {
+		const operations = operationsSequence(
+			{ exitCode: 0, output: "watch complete" },
+			{ exitCode: null, output: "final diagnostic", error: new Error("spawn failed") },
+		);
+
+		await expect(execute(operations)).rejects.toThrow(
+			"final diagnostic\n\nGitHub CI final checks query could not run: spawn failed",
+		);
+	});
+
+	it("reports final query cancellation distinctly", async () => {
+		const controller = new AbortController();
+		const operations = operationsSequence(
+			{ exitCode: 0, output: "watch complete" },
+			{ exitCode: null, error: new Error("aborted") },
+		);
+
+		await expect(execute(operations, {}, controller.signal)).rejects.toThrow("final checks query aborted");
+	});
+
+	it("rejects a CLI-level failure from the final query", async () => {
+		const operations = operationsSequence(
+			{ exitCode: 1, output: "build failed" },
+			{ exitCode: 1, output: "HTTP 401: Bad credentials" },
+		);
+
+		await expect(execute(operations)).rejects.toThrow("final checks query failed");
+	});
+
+	it("rejects pending final query results", async () => {
+		const operations = operationsSequence(
+			{ exitCode: 0, output: "watch complete" },
+			{ exitCode: 8, output: "checks pending again" },
+		);
+
+		await expect(execute(operations)).rejects.toThrow("checks still pending (exit code 8)");
+	});
+
+	it.each([null, 2, 4])("surfaces unexpected final query exit code %s loudly", async (exitCode) => {
+		const operations = operationsSequence(
+			{ exitCode: 0, output: "watch complete" },
+			{ exitCode, output: "final diagnostic" },
+		);
+		await expect(execute(operations)).rejects.toThrow("final checks query exited unexpectedly");
+	});
+
+	it.each([
+		{ watchExitCode: 0 as const, finalExitCode: 1 as const },
+		{ watchExitCode: 1 as const, finalExitCode: 0 as const },
+	])("rejects contradictory watch $watchExitCode and final $finalExitCode states", async (testCase) => {
+		const operations = operationsSequence(
+			{ exitCode: testCase.watchExitCode, output: "watch complete" },
+			{ exitCode: testCase.finalExitCode, output: "final state" },
+		);
+		await expect(execute(operations)).rejects.toThrow("status changed between watch completion");
 	});
 
 	it("has prompt metadata that forbids wait and polling", () => {
-		const tool = createWatchGithubCiToolDefinition("/repo", { operations: operationsResult(0) });
+		const tool = createWatchGithubCiToolDefinition("/repo", {
+			operations: completedOperations(0, "build passed"),
+		});
 		const guidance = tool.promptGuidelines?.join(" ") ?? "";
 
 		expect(tool.name).toBe("watch_github_ci");

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.61.1",
+  "version": "2.61.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.61.1",
+	"version": "2.61.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #478

Separate live GitHub CI watch output from the clean final check result returned to the model.

Implementation plan posted as a comment below.
