### PR TITLE
Send x-opencode-session on OpenCode requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10934,7 +10934,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10963,7 +10963,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11109,7 +11109,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11238,7 +11238,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11470,7 +11470,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11519,7 +11519,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11552,7 +11552,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.64.1",
+			"version": "2.64.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/src/providers/opencode-headers.ts
+++ b/packages/ai/src/providers/opencode-headers.ts
@@ -1,0 +1,60 @@
+import type { Api, Model, StreamOptions } from "../types.js";
+
+/**
+ * HTTP header OpenCode uses for per-conversation routing and optimization.
+ * Must be a stable identifier for the lifetime of one conversation (issue 500).
+ */
+export const OPENCODE_SESSION_HEADER = "x-opencode-session";
+
+/** Provider IDs of the built-in OpenCode endpoints. */
+const OPENCODE_PROVIDER_IDS = new Set(["opencode", "opencode-go"]);
+
+/**
+ * Returns true when the model points at an OpenCode endpoint: either one of the
+ * built-in OpenCode providers, or a custom provider whose base URL parses to
+ * exactly the `opencode.ai` hostname. Hostname equality is exact (case-insensitive,
+ * no substring matching) so lookalike domains never receive session IDs.
+ */
+export function isOpenCodeModel(model: Pick<Model<Api>, "provider" | "baseUrl">): boolean {
+	if (OPENCODE_PROVIDER_IDS.has(model.provider)) {
+		return true;
+	}
+	try {
+		return new URL(model.baseUrl).hostname.toLowerCase() === "opencode.ai";
+	} catch {
+		return false;
+	}
+}
+
+function hasHeader(headers: Record<string, string> | undefined, name: string): boolean {
+	if (!headers) return false;
+	const wanted = name.toLowerCase();
+	return Object.keys(headers).some((key) => key.toLowerCase() === wanted);
+}
+
+/**
+ * Returns options with `x-opencode-session` added for OpenCode models when a
+ * session ID is present. The input is never mutated; a new options object is
+ * returned when the header is added.
+ *
+ * Precedence: an explicit header in `model.headers` or `options.headers` wins
+ * case-insensitively, so no differently-cased duplicate of the generated header
+ * can be sent. OpenCode models without a session ID, missing options, and
+ * non-OpenCode models are returned unchanged.
+ */
+export function withOpenCodeSessionHeader<TOptions extends StreamOptions | undefined>(
+	model: Pick<Model<Api>, "provider" | "baseUrl" | "headers">,
+	options: TOptions,
+): TOptions {
+	if (!options) return options;
+	const sessionId = options.sessionId;
+	if (!sessionId) return options;
+	if (!isOpenCodeModel(model)) return options;
+	if (hasHeader(model.headers, OPENCODE_SESSION_HEADER) || hasHeader(options.headers, OPENCODE_SESSION_HEADER)) {
+		return options;
+	}
+	return {
+		...options,
+		headers: { ...options.headers, [OPENCODE_SESSION_HEADER]: sessionId },
+	} as TOptions;
+}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,6 +1,7 @@
 import "./providers/register-builtins.js";
 
 import { getApiProvider } from "./api-registry.js";
+import { withOpenCodeSessionHeader } from "./providers/opencode-headers.js";
 import type {
 	Api,
 	AssistantMessage,
@@ -28,7 +29,7 @@ export function stream<TApi extends Api>(
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.stream(model, context, options as StreamOptions);
+	return provider.stream(model, context, withOpenCodeSessionHeader(model, options) as StreamOptions);
 }
 
 export async function complete<TApi extends Api>(
@@ -46,7 +47,7 @@ export function streamSimple<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.streamSimple(model, context, options);
+	return provider.streamSimple(model, context, withOpenCodeSessionHeader(model, options));
 }
 
 export async function completeSimple<TApi extends Api>(

--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -122,9 +122,9 @@ describe("Context overflow error handling", () => {
 	describe("GitHub Copilot (OAuth)", () => {
 		// OpenAI model via Copilot
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should detect overflow via isContextOverflow",
+			"gpt-5.4 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 
@@ -137,9 +137,9 @@ describe("Context overflow error handling", () => {
 
 		// Anthropic model via Copilot
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-sonnet-4 - should detect overflow via isContextOverflow",
+			"claude-opus-4.8 - should detect overflow via isContextOverflow",
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 

--- a/packages/ai/test/empty.test.ts
+++ b/packages/ai/test/empty.test.ts
@@ -499,73 +499,73 @@ describe("AI Providers Empty Message Tests", () => {
 
 	describe("GitHub Copilot Provider Empty Messages", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle empty content array",
+			"gpt-5.4 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle empty string content",
+			"gpt-5.4 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle whitespace-only content",
+			"gpt-5.4 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle empty assistant message in conversation",
+			"gpt-5.4 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle empty content array",
+			"claude-opus-4.8 - should handle empty content array",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testEmptyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle empty string content",
+			"claude-opus-4.8 - should handle empty string content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testEmptyStringMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle whitespace-only content",
+			"claude-opus-4.8 - should handle whitespace-only content",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testWhitespaceOnlyMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle empty assistant message in conversation",
+			"claude-opus-4.8 - should handle empty assistant message in conversation",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testEmptyAssistantMessage(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -43,7 +43,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 });
 
 describe("Copilot Claude via Anthropic Messages", () => {
-	const copilotClaudeModelId = "claude-opus-4.5";
+	const copilotClaudeModelId = "claude-haiku-4.5";
 	const context: Context = {
 		systemPrompt: "You are a helpful assistant.",
 		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],

--- a/packages/ai/test/image-tool-result.test.ts
+++ b/packages/ai/test/image-tool-result.test.ts
@@ -357,37 +357,37 @@ describe("Tool Results with Images", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle tool result with only image",
+			"gpt-5.4 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle tool result with text and image",
+			"gpt-5.4 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle tool result with only image",
+			"claude-opus-4.8 - should handle tool result with only image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await handleToolWithImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle tool result with text and image",
+			"claude-opus-4.8 - should handle tool result with text and image",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await handleToolWithTextAndImageResult(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/opencode-session-headers.test.ts
+++ b/packages/ai/test/opencode-session-headers.test.ts
@@ -4,7 +4,7 @@ import {
 	OPENCODE_SESSION_HEADER,
 	withOpenCodeSessionHeader,
 } from "../src/providers/opencode-headers.js";
-import { complete } from "../src/stream.js";
+import { complete, completeSimple } from "../src/stream.js";
 import type { Api, Context, Model, ProviderStreamOptions, StreamOptions } from "../src/types.js";
 
 const SESSION_ID = "11111111-2222-4333-8444-555555555555";
@@ -349,5 +349,69 @@ describe("OpenCode session header on the wire", () => {
 		}
 		// The shared options object was never rewritten with the generated header
 		expect(shared.headers).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Protocol tests via completeSimple — the non-streaming path production agent
+// loops import from @dreb/ai. completeSimple strips sessionId from the options
+// object and merges the header before delegating to streamSimple, where the
+// injection happens — so it must be proven independently of complete().
+// ---------------------------------------------------------------------------
+
+describe("OpenCode session header on the wire (completeSimple path)", () => {
+	afterEach(() => {
+		global.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("sends x-opencode-session on openai-completions", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+		const model = makeModel({});
+
+		const result = await completeSimple(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on openai-responses", async () => {
+		const captured = installFetchCapture(responsesSse);
+		const model = makeModel<"openai-responses">({
+			api: "openai-responses",
+			baseUrl: "https://opencode.ai/zen/v1",
+		});
+
+		const result = await completeSimple(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on anthropic-messages", async () => {
+		const captured = installFetchCapture(anthropicSse);
+		const model = makeModel<"anthropic-messages">({
+			api: "anthropic-messages",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+
+		const result = await completeSimple(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on google-generative-ai", async () => {
+		const captured = installFetchCapture(googleSse);
+		const model = makeModel<"google-generative-ai">({
+			api: "google-generative-ai",
+			baseUrl: "https://opencode.ai/zen/v1",
+		});
+
+		const result = await completeSimple(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
 	});
 });

--- a/packages/ai/test/opencode-session-headers.test.ts
+++ b/packages/ai/test/opencode-session-headers.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	isOpenCodeModel,
+	OPENCODE_SESSION_HEADER,
+	withOpenCodeSessionHeader,
+} from "../src/providers/opencode-headers.js";
+import { complete } from "../src/stream.js";
+import type { Api, Context, Model, ProviderStreamOptions, StreamOptions } from "../src/types.js";
+
+const SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+// ---------------------------------------------------------------------------
+// Unit tests: OpenCode endpoint matching
+// ---------------------------------------------------------------------------
+
+describe("isOpenCodeModel", () => {
+	const pick = (provider: string, baseUrl: string) => ({ provider, baseUrl });
+
+	it("matches the built-in opencode and opencode-go provider ids", () => {
+		expect(isOpenCodeModel(pick("opencode", "https://opencode.ai/zen/v1"))).toBe(true);
+		expect(isOpenCodeModel(pick("opencode-go", "https://opencode.ai/zen/go/v1"))).toBe(true);
+	});
+
+	it("still matches built-in providers when baseUrl points at a configured proxy", () => {
+		expect(isOpenCodeModel(pick("opencode", "https://proxy.corp.example/v1"))).toBe(true);
+	});
+
+	it("matches custom providers whose base URL hostname is exactly opencode.ai", () => {
+		expect(isOpenCodeModel(pick("custom", "https://opencode.ai/zen/v1"))).toBe(true);
+		expect(isOpenCodeModel(pick("custom", "https://opencode.ai:8443/v1"))).toBe(true);
+		expect(isOpenCodeModel(pick("custom", "HTTPS://OPENCODE.AI/zen/v1"))).toBe(true);
+	});
+
+	it("does not match lookalike hostnames", () => {
+		expect(isOpenCodeModel(pick("custom", "https://evil-opencode.ai/v1"))).toBe(false);
+		expect(isOpenCodeModel(pick("custom", "https://opencode.ai.evil.com/v1"))).toBe(false);
+		expect(isOpenCodeModel(pick("custom", "https://notopencode.ai/v1"))).toBe(false);
+		expect(isOpenCodeModel(pick("custom", "https://sub.opencode.ai/v1"))).toBe(false);
+	});
+
+	it("treats malformed base URLs as non-OpenCode without throwing", () => {
+		expect(isOpenCodeModel(pick("custom", "not-a-url"))).toBe(false);
+		expect(isOpenCodeModel(pick("custom", ""))).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: case-insensitive low-precedence header merge
+// ---------------------------------------------------------------------------
+
+describe("withOpenCodeSessionHeader", () => {
+	const opencodeModel = {
+		provider: "opencode",
+		baseUrl: "https://opencode.ai/zen/v1",
+		headers: undefined,
+	};
+
+	it("adds the header for OpenCode models with a session ID without mutating inputs", () => {
+		const options: StreamOptions = { apiKey: "k", sessionId: SESSION_ID };
+		const result = withOpenCodeSessionHeader(opencodeModel, options);
+
+		expect(result).not.toBe(options);
+		expect(result?.headers).toEqual({ [OPENCODE_SESSION_HEADER]: SESSION_ID });
+		// The caller's original options stay untouched (concurrent-session isolation)
+		expect(options.headers).toBeUndefined();
+		// Non-header options are preserved
+		expect(result?.apiKey).toBe("k");
+	});
+
+	it("returns the same object when no session ID is supplied", () => {
+		const options: StreamOptions = { apiKey: "k" };
+		expect(withOpenCodeSessionHeader(opencodeModel, options)).toBe(options);
+		const empty: StreamOptions = { apiKey: "k", sessionId: "" };
+		expect(withOpenCodeSessionHeader(opencodeModel, empty)).toBe(empty);
+	});
+
+	it("returns the same object for non-OpenCode models", () => {
+		const options: StreamOptions = { apiKey: "k", sessionId: SESSION_ID };
+		expect(withOpenCodeSessionHeader({ provider: "anthropic", baseUrl: "https://api.anthropic.com" }, options)).toBe(
+			options,
+		);
+	});
+
+	it("returns the same object when options are missing", () => {
+		expect(withOpenCodeSessionHeader(opencodeModel, undefined)).toBeUndefined();
+	});
+
+	it("lets an explicit model header win case-insensitively", () => {
+		for (const casing of ["x-opencode-session", "X-OpenCode-Session", "X-OPENCODE-SESSION"]) {
+			const options: StreamOptions = { sessionId: SESSION_ID };
+			const model = {
+				provider: "opencode",
+				baseUrl: "https://opencode.ai/zen/v1",
+				headers: { [casing]: "explicit" },
+			};
+			expect(withOpenCodeSessionHeader(model, options)).toBe(options);
+		}
+	});
+
+	it("lets an explicit request header win case-insensitively", () => {
+		for (const casing of ["x-opencode-session", "X-OpenCode-Session", "X-OPENCODE-SESSION"]) {
+			const options: StreamOptions = { sessionId: SESSION_ID, headers: { [casing]: "explicit" } };
+			const result = withOpenCodeSessionHeader(opencodeModel, options);
+			expect(result).toBe(options);
+			expect(result?.headers).toEqual({ [casing]: "explicit" });
+		}
+	});
+
+	it("does not mutate an existing request headers object", () => {
+		const existing = { "x-custom": "yes" };
+		const options: StreamOptions = { sessionId: SESSION_ID, headers: existing };
+		const result = withOpenCodeSessionHeader(opencodeModel, options);
+
+		expect(existing).toEqual({ "x-custom": "yes" });
+		expect(result?.headers).toEqual({ "x-custom": "yes", [OPENCODE_SESSION_HEADER]: SESSION_ID });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Protocol tests: final outgoing HTTP headers via the real SDK clients
+// ---------------------------------------------------------------------------
+
+const originalFetch = global.fetch;
+const context: Context = {
+	systemPrompt: "You are helpful.",
+	messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+};
+
+type Capture = { headers: Headers[] };
+
+function installFetchCapture(body: string): Capture {
+	const captured: Capture = { headers: [] };
+	global.fetch = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+		captured.headers.push(new Headers(init?.headers));
+		return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+	}) as typeof fetch;
+	return captured;
+}
+
+const chatCompletionsSse = [
+	`data: ${JSON.stringify({
+		id: "chatcmpl-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "opencode-model",
+		choices: [{ index: 0, delta: { content: "hi" }, finish_reason: null }],
+	})}`,
+	"",
+	`data: ${JSON.stringify({
+		id: "chatcmpl-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "opencode-model",
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+	})}`,
+	"",
+	"data: [DONE]",
+	"",
+	"",
+].join("\n");
+
+const responsesSse = [
+	`event: response.created`,
+	`data: ${JSON.stringify({ type: "response.created", response: { id: "resp_1" } })}`,
+	"",
+	`event: response.output_item.added`,
+	`data: ${JSON.stringify({
+		type: "response.output_item.added",
+		item: { type: "message", id: "msg_1", content: [] },
+	})}`,
+	"",
+	`event: response.content_part.added`,
+	`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+	"",
+	`event: response.output_text.delta`,
+	`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}`,
+	"",
+	`event: response.completed`,
+	`data: ${JSON.stringify({
+		type: "response.completed",
+		response: {
+			id: "resp_1",
+			status: "completed",
+			usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+		},
+	})}`,
+	"",
+	"",
+].join("\n");
+
+const anthropicSse = [
+	"event: message_start",
+	`data: ${JSON.stringify({
+		type: "message_start",
+		message: {
+			id: "msg_test",
+			type: "message",
+			role: "assistant",
+			model: "opencode-model",
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 1, output_tokens: 0 },
+		},
+	})}`,
+	"",
+	"event: message_delta",
+	`data: ${JSON.stringify({
+		type: "message_delta",
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { input_tokens: 1, output_tokens: 1 },
+	})}`,
+	"",
+	"event: message_stop",
+	`data: ${JSON.stringify({ type: "message_stop" })}`,
+	"",
+	"",
+].join("\n");
+
+const googleSse = `data: ${JSON.stringify({
+	candidates: [{ content: { role: "model", parts: [{ text: "hi" }] }, finishReason: "STOP" }],
+	usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+})}
+
+`;
+
+function makeModel<TApi extends Api>(overrides: Partial<Model<TApi>> = {}): Model<TApi> {
+	const defaults: Model<"openai-completions"> = {
+		id: "opencode-model",
+		name: "OpenCode Model",
+		api: "openai-completions",
+		provider: "opencode",
+		baseUrl: "https://opencode.ai/zen/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+	return { ...defaults, ...overrides } as Model<TApi>;
+}
+
+function lastHeaders(captured: Capture): Headers {
+	expect(captured.headers.length).toBeGreaterThan(0);
+	return captured.headers.at(-1)!;
+}
+
+describe("OpenCode session header on the wire", () => {
+	afterEach(() => {
+		global.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("sends x-opencode-session on openai-completions", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+		const model = makeModel({});
+
+		const result = await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on openai-responses", async () => {
+		const captured = installFetchCapture(responsesSse);
+		const model = makeModel<"openai-responses">({
+			api: "openai-responses",
+			baseUrl: "https://opencode.ai/zen/v1",
+		});
+
+		const result = await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on anthropic-messages", async () => {
+		const captured = installFetchCapture(anthropicSse);
+		const model = makeModel<"anthropic-messages">({
+			api: "anthropic-messages",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+
+		const result = await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends x-opencode-session on google-generative-ai", async () => {
+		const captured = installFetchCapture(googleSse);
+		const model = makeModel<"google-generative-ai">({
+			api: "google-generative-ai",
+			baseUrl: "https://opencode.ai/zen/v1",
+		});
+
+		const result = await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(result.stopReason).toBe("stop");
+		expect(lastHeaders(captured).get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+	});
+
+	it("sends no session header when no session ID is supplied", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+
+		await complete(makeModel({}), context, { apiKey: "k" });
+
+		expect(lastHeaders(captured).has(OPENCODE_SESSION_HEADER)).toBe(false);
+	});
+
+	it("does not send the header for non-OpenCode models even with a session ID", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+		const model = makeModel({
+			provider: "some-other-provider",
+			baseUrl: "https://api.example.com/v1",
+		});
+
+		await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		expect(lastHeaders(captured).has(OPENCODE_SESSION_HEADER)).toBe(false);
+	});
+
+	it("lets an explicit mixed-case model header win with exactly one effective value", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+		const model = makeModel({
+			headers: { "X-OpenCode-Session": "explicit-value" },
+		});
+
+		await complete(model, context, { apiKey: "k", sessionId: SESSION_ID });
+
+		const headers = lastHeaders(captured);
+		expect(headers.get(OPENCODE_SESSION_HEADER)).toBe("explicit-value");
+		// No differently-cased duplicate of the generated header
+		expect(headers.get("X-OPENCODE-SESSION")).toBe("explicit-value"); // Headers lookup is case-insensitive
+	});
+
+	it("keeps one stable ID across repeated calls sharing the same options object", async () => {
+		const captured = installFetchCapture(chatCompletionsSse);
+		const model = makeModel({});
+		const shared: ProviderStreamOptions = { apiKey: "k", sessionId: SESSION_ID };
+
+		await complete(model, context, shared);
+		await complete(model, context, shared);
+
+		expect(captured.headers).toHaveLength(2);
+		for (const headers of captured.headers) {
+			expect(headers.get(OPENCODE_SESSION_HEADER)).toBe(SESSION_ID);
+		}
+		// The shared options object was never rewritten with the generated header
+		expect(shared.headers).toBeUndefined();
+	});
+});

--- a/packages/ai/test/responseid.test.ts
+++ b/packages/ai/test/responseid.test.ts
@@ -135,7 +135,7 @@ describe("responseId E2E Tests", () => {
 			"Anthropic path should expose responseId",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await expectResponseId(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -977,8 +977,8 @@ describe("Generate E2E Tests", () => {
 		);
 	});
 
-	describe("GitHub Copilot Provider (claude-sonnet-4 via Anthropic Messages)", () => {
-		const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+	describe("GitHub Copilot Provider (claude-opus-4.8 via Anthropic Messages)", () => {
+		const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
 			"should complete basic text generation",

--- a/packages/ai/test/tokens.test.ts
+++ b/packages/ai/test/tokens.test.ts
@@ -231,19 +231,19 @@ describe("Token Statistics on Abort", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should include token stats when aborted mid-stream",
+			"gpt-5.4 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-sonnet-4 - should include token stats when aborted mid-stream",
+			"claude-opus-4.8 - should include token stats when aborted mid-stream",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testTokensOnAbort(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/tool-call-without-result.test.ts
+++ b/packages/ai/test/tool-call-without-result.test.ts
@@ -279,19 +279,19 @@ describe("Tool Call Without Result Tests", () => {
 
 	describe("GitHub Copilot Provider", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should filter out tool calls without corresponding tool results",
+			"gpt-5.4 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-sonnet-4 - should filter out tool calls without corresponding tool results",
+			"claude-opus-4.8 - should filter out tool calls without corresponding tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const model = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testToolCallWithoutResult(model, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -521,10 +521,10 @@ describe("totalTokens field", () => {
 
 	describe("GitHub Copilot (OAuth)", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should return totalTokens equal to sum of components",
+			"gpt-5.4 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });
@@ -538,10 +538,10 @@ describe("totalTokens field", () => {
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-sonnet-4 - should return totalTokens equal to sum of components",
+			"claude-opus-4.8 - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 
 				console.log(`\nGitHub Copilot / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: githubCopilotToken });

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -408,55 +408,55 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 
 	describe("GitHub Copilot Provider Unicode Handling", () => {
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle emoji in tool results",
+			"gpt-5.4 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle real-world LinkedIn comment data with emoji",
+			"gpt-5.4 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"gpt-4.1 - should handle unpaired high surrogate (0xD83D) in tool results",
+			"gpt-5.4 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-4.1"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "gpt-5.4"), githubCopilotToken);
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle emoji in tool results",
+			"claude-opus-4.8 - should handle emoji in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testEmojiInToolResults(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle real-world LinkedIn comment data with emoji",
+			"claude-opus-4.8 - should handle real-world LinkedIn comment data with emoji",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testRealWorldLinkedInData(llm, { apiKey: githubCopilotToken });
 			},
 		);
 
 		it.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !githubCopilotToken)(
-			"claude-opus-4.5 - should handle unpaired high surrogate (0xD83D) in tool results",
+			"claude-opus-4.8 - should handle unpaired high surrogate (0xD83D) in tool results",
 			{ retry: 3, timeout: 30000 },
 			async () => {
-				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.5"), githubCopilotToken);
+				const llm = applyCopilotBaseUrl(getModel("github-copilot", "claude-opus-4.8"), githubCopilotToken);
 				await testUnpairedHighSurrogate(llm, { apiKey: githubCopilotToken });
 			},
 		);

--- a/packages/ai/test/zen.test.ts
+++ b/packages/ai/test/zen.test.ts
@@ -15,9 +15,15 @@ describe.skipIf(process.env.DREB_SKIP_LIVE_API === "1" || !process.env.OPENCODE_
 			const providerModels = Object.values(MODELS[key]);
 			providerModels.forEach((model) => {
 				it(`${label}: ${model.id}`, async () => {
-					const response = await complete(model as Model<any>, {
-						messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
-					});
+					// A stable ID for the whole live smoke conversation, mirroring how
+					// AgentSession passes one persisted UUID per conversation (issue 500).
+					const response = await complete(
+						model as Model<any>,
+						{
+							messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
+						},
+						{ sessionId: "dreb-zen-live-smoke-test" },
+					);
 
 					expect(response.content).toBeTruthy();
 					expect(response.stopReason).toBe("stop");

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -466,6 +466,7 @@ export class AgentSession {
 			getMessages: () => this.agent.state.messages,
 			getParentModel: () => this.model,
 			getSessionTitle: () => this.sessionName,
+			getSessionId: () => this.sessionId,
 			getRepoMetadata: (cwd) => {
 				const gitRoot = findGitRoot(cwd);
 				const isSessionCwd = resolve(cwd) === resolve(this._cwd);
@@ -2508,6 +2509,7 @@ export class AgentSession {
 					apiKey,
 					customInstructions,
 					this._compactionAbortController.signal,
+					this.sessionId,
 				);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
@@ -2806,6 +2808,7 @@ export class AgentSession {
 					apiKey,
 					undefined,
 					this._autoCompactionAbortController.signal,
+					this.sessionId,
 				);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;
@@ -3248,6 +3251,7 @@ export class AgentSession {
 						parentProvider: () => this.model?.provider,
 						parentModel: () => this.model?.id,
 						parentSessionFile: () => this.sessionFile,
+						parentSessionId: () => this.sessionId,
 						modelRegistry: this._modelRegistry,
 						getAgentModelsForAgent: (name: string) => this.settingsManager?.getAgentModelsForAgent(name),
 						defaultThinkingLevel: () => this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL,
@@ -3967,6 +3971,7 @@ export class AgentSession {
 					customInstructions,
 					replaceInstructions,
 					reserveTokens: branchSummarySettings.reserveTokens,
+					sessionId: this.sessionId,
 				});
 				if (result.aborted) {
 					return { cancelled: true, aborted: true };

--- a/packages/coding-agent/src/core/buddy/buddy-manager.ts
+++ b/packages/coding-agent/src/core/buddy/buddy-manager.ts
@@ -218,6 +218,7 @@ async function generateSoul(
 	bones: CompanionBones,
 	parentModel: Model<"openai-completions">,
 	apiKey: string,
+	sessionId?: string,
 ): Promise<{ name: string; personality: string; backstory: string }> {
 	const statsStr = STAT_NAMES.map((s) => `${s}: ${bones.stats[s]}`).join(", ");
 	const prompt = SOUL_GENERATION_PROMPT.replace("{species}", bones.species)
@@ -231,7 +232,7 @@ async function generateSoul(
 	};
 
 	try {
-		const response = await completeSimple(parentModel, context, { apiKey });
+		const response = await completeSimple(parentModel, context, { apiKey, ...(sessionId ? { sessionId } : {}) });
 		const text = response.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
 			.map((c) => c.text)
@@ -296,12 +297,17 @@ export class BuddyManager {
 	 * Hatch a new buddy. Generates bones, then uses parent LLM for soul.
 	 * Returns the new state.
 	 */
-	async hatch(parentModel: Model<"openai-completions">, apiKey: string): Promise<BuddyState> {
+	async hatch(
+		parentModel: Model<"openai-completions">,
+		apiKey: string,
+		/** Stable conversation UUID forwarded to the soul-generation request (issue 500). */
+		sessionId?: string,
+	): Promise<BuddyState> {
 		const stored = loadStored();
 		const rerollCount = stored?.rerollCount ?? 0;
 
 		const bones = rollBones(rerollCount);
-		const { name, personality, backstory } = await generateSoul(bones, parentModel, apiKey);
+		const { name, personality, backstory } = await generateSoul(bones, parentModel, apiKey, sessionId);
 
 		const newStored: StoredCompanion = {
 			rerollCount,
@@ -320,12 +326,17 @@ export class BuddyManager {
 	/**
 	 * Reroll the buddy — new bones + new soul.
 	 */
-	async reroll(parentModel: Model<"openai-completions">, apiKey: string): Promise<BuddyState> {
+	async reroll(
+		parentModel: Model<"openai-completions">,
+		apiKey: string,
+		/** Stable conversation UUID forwarded to the soul-generation request (issue 500). */
+		sessionId?: string,
+	): Promise<BuddyState> {
 		const stored = loadStored();
 		const newRerollCount = (stored?.rerollCount ?? 0) + 1;
 
 		const bones = rollBones(newRerollCount);
-		const { name, personality, backstory } = await generateSoul(bones, parentModel, apiKey);
+		const { name, personality, backstory } = await generateSoul(bones, parentModel, apiKey, sessionId);
 
 		const newStored: StoredCompanion = {
 			rerollCount: newRerollCount,

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -75,6 +75,8 @@ export interface GenerateBranchSummaryOptions {
 	replaceInstructions?: boolean;
 	/** Tokens reserved for prompt + LLM response (default 16384) */
 	reserveTokens?: number;
+	/** Stable conversation ID forwarded to providers that use session-based routing */
+	sessionId?: string;
 }
 
 // ============================================================================
@@ -282,7 +284,7 @@ export async function generateBranchSummary(
 	entries: SessionEntry[],
 	options: GenerateBranchSummaryOptions,
 ): Promise<BranchSummaryResult> {
-	const { model, apiKey, signal, customInstructions, replaceInstructions, reserveTokens = 16384 } = options;
+	const { model, apiKey, signal, customInstructions, replaceInstructions, reserveTokens = 16384, sessionId } = options;
 
 	// Token budget = context window minus reserved space for prompt + response
 	const contextWindow = model.contextWindow || 128000;
@@ -322,7 +324,7 @@ export async function generateBranchSummary(
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		{ apiKey, signal, maxTokens: 2048 },
+		{ apiKey, signal, maxTokens: 2048, ...(sessionId ? { sessionId } : {}) },
 	);
 
 	// Check if aborted or errored

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -528,6 +528,7 @@ export async function generateSummary(
 	signal?: AbortSignal,
 	customInstructions?: string,
 	previousSummary?: string,
+	sessionId?: string,
 ): Promise<string> {
 	const maxTokens = Math.floor(0.8 * reserveTokens);
 
@@ -557,9 +558,13 @@ export async function generateSummary(
 		},
 	];
 
-	const completionOptions = model.reasoning
-		? { maxTokens, signal, apiKey, reasoning: "high" as const }
-		: { maxTokens, signal, apiKey };
+	const completionOptions = {
+		maxTokens,
+		signal,
+		apiKey,
+		...(model.reasoning ? { reasoning: "high" as const } : {}),
+		...(sessionId ? { sessionId } : {}),
+	};
 
 	const response = await completeSimple(
 		model,
@@ -715,6 +720,7 @@ export async function compact(
 	apiKey: string,
 	customInstructions?: string,
 	signal?: AbortSignal,
+	sessionId?: string,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -742,9 +748,10 @@ export async function compact(
 						signal,
 						customInstructions,
 						previousSummary,
+						sessionId,
 					)
 				: Promise.resolve("No prior history."),
-			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal),
+			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal, sessionId),
 		]);
 		// Merge into single summary
 		summary = `${historyResult}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult}`;
@@ -758,6 +765,7 @@ export async function compact(
 			signal,
 			customInstructions,
 			previousSummary,
+			sessionId,
 		);
 	}
 
@@ -786,6 +794,7 @@ async function generateTurnPrefixSummary(
 	reserveTokens: number,
 	apiKey: string,
 	signal?: AbortSignal,
+	sessionId?: string,
 ): Promise<string> {
 	const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
 	const llmMessages = convertToLlm(messages);
@@ -802,7 +811,7 @@ async function generateTurnPrefixSummary(
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		{ maxTokens, signal, apiKey },
+		{ maxTokens, signal, apiKey, ...(sessionId ? { sessionId } : {}) },
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/core/dispatch-arbiter.ts
+++ b/packages/coding-agent/src/core/dispatch-arbiter.ts
@@ -92,6 +92,8 @@ export interface DispatchArbiterDeps {
 	getMessages: () => Array<{ role: string; content?: unknown }>;
 	getParentModel: () => Model<Api> | undefined;
 	getSessionTitle: () => string | undefined;
+	/** Get the parent session's stable conversation UUID, forwarded to arbiter requests (issue 500). */
+	getSessionId?: () => string | undefined;
 	getRepoMetadata: (cwd: string) => { repo?: string; cwd: string; branch?: string; dirtyCount?: number };
 	getExtraSecretPatterns?: () => SecretPattern[] | undefined;
 	complete?: typeof completeSimple;
@@ -339,6 +341,7 @@ export class DispatchArbiter {
 		}
 
 		const complete = this.deps.complete ?? completeSimple;
+		const sessionId = this.deps.getSessionId?.();
 		for (let attempt = 0; attempt < 2; attempt++) {
 			let response: AssistantMessage;
 			try {
@@ -348,6 +351,7 @@ export class DispatchArbiter {
 						maxRetryDelayMs: 0,
 						reasoning: thinkingLevelToReasoning(settings.thinking ?? "off"),
 						signal: combinedSignal,
+						...(sessionId ? { sessionId } : {}),
 					}),
 					combinedSignal,
 				);

--- a/packages/coding-agent/src/core/tab-title.ts
+++ b/packages/coding-agent/src/core/tab-title.ts
@@ -69,6 +69,8 @@ export interface TabTitleDeps {
 	getModelRegistry: () => ModelRegistry;
 	/** Get the parent provider name. */
 	getProvider: () => string | undefined;
+	/** Get the parent session's stable conversation UUID, forwarded to LLM requests (issue 500). */
+	getSessionId?: () => string | undefined;
 	/**
 	 * Get the user's agentModels settings override for a given agent name, if any.
 	 * Returns a non-empty fallback list when the user has configured an override.
@@ -202,10 +204,12 @@ export class TabTitleGenerator {
 	private async completeWithModel(model: Model<Api>, context: Context, signal: AbortSignal): Promise<unknown> {
 		const registry = this.deps.getModelRegistry();
 		const apiKey = await registry.getApiKey(model);
+		const sessionId = this.deps.getSessionId?.();
 		return completeSimple(model, context, {
 			apiKey,
 			maxRetryDelayMs: 0,
 			signal,
+			...(sessionId ? { sessionId } : {}),
 		});
 	}
 
@@ -236,6 +240,7 @@ export class TabTitleGenerator {
 				parentModel?.id,
 				signal,
 				"[tab-title]",
+				this.deps.getSessionId?.(),
 			);
 			if (resolution.ok) {
 				const found = resolution.provider

--- a/packages/coding-agent/src/core/tools/subagent.ts
+++ b/packages/coding-agent/src/core/tools/subagent.ts
@@ -876,6 +876,8 @@ export interface ProbeModelAvailabilityOptions {
 	registry?: ModelRegistry;
 	/** Override the default model availability probe timeout; primarily useful for tests. */
 	timeoutMs?: number;
+	/** Stable conversation ID forwarded to providers that use session-based routing. */
+	sessionId?: string;
 }
 
 export type ProbeModelAvailabilityResult = { ok: true } | { ok: false; reason: string; aborted?: boolean };
@@ -936,7 +938,7 @@ export async function probeModelAvailability(
 	model: Model<Api>,
 	options: ProbeModelAvailabilityOptions = {},
 ): Promise<ProbeModelAvailabilityResult> {
-	const { signal, registry, timeoutMs = DEFAULT_MODEL_AVAILABILITY_PROBE_TIMEOUT_MS } = options;
+	const { signal, registry, timeoutMs = DEFAULT_MODEL_AVAILABILITY_PROBE_TIMEOUT_MS, sessionId } = options;
 	if (signal?.aborted) return { ok: false, reason: "Aborted before spawn", aborted: true };
 
 	const probeSignal = makeProbeSignal(signal, timeoutMs);
@@ -963,6 +965,7 @@ export async function probeModelAvailability(
 				maxRetryDelayMs: 0,
 				reasoning,
 				signal: probeSignal.signal,
+				...(sessionId ? { sessionId } : {}),
 			}),
 			probeSignal.timeoutPromise,
 		]);
@@ -1002,6 +1005,8 @@ export async function resolveModelForSubagentSpawn(
 	signal?: AbortSignal,
 	/** Optional log prefix for warning messages (defaults to "[subagent]") */
 	logPrefix = "[subagent]",
+	/** Stable conversation ID forwarded to availability probes (issue 500). */
+	sessionId?: string,
 ): Promise<SubagentModelResolution> {
 	if (signal?.aborted) return { ok: false, error: "Aborted before spawn", skippedModels: [] };
 
@@ -1030,7 +1035,7 @@ export async function resolveModelForSubagentSpawn(
 
 		const modelObj = resolved.provider ? registry.find(resolved.provider, resolved.modelId) : undefined;
 		if (modelObj) {
-			const probe = await probeModelAvailability(modelObj, { signal, registry });
+			const probe = await probeModelAvailability(modelObj, { signal, registry, sessionId });
 			if (!probe.ok && probe.aborted) {
 				return { ok: false, error: "Aborted before spawn", skippedModels };
 			}
@@ -1197,6 +1202,8 @@ export async function executeSingle(
 	thinkingOverride?: ThinkingLevel,
 	arbitration?: SubagentArbitrationHooks,
 	onControlAvailable?: (client: RpcClient | undefined) => void,
+	/** Parent session UUID for spawn-time availability probes (issue 500). */
+	parentSessionId?: string,
 ): Promise<SubagentResult> {
 	let name = agentName || DEFAULT_AGENT;
 	let config = agents.get(name);
@@ -1234,7 +1241,15 @@ export async function executeSingle(
 
 	if (modelSpec) {
 		const parentFallback = configuredModelSpec ? parentModel : undefined;
-		const resolved = await resolveModelForSubagentSpawn(modelSpec, parentProvider, registry, parentFallback, signal);
+		const resolved = await resolveModelForSubagentSpawn(
+			modelSpec,
+			parentProvider,
+			registry,
+			parentFallback,
+			signal,
+			"[subagent]",
+			parentSessionId,
+		);
 		skippedModels = resolved.skippedModels;
 		if (!resolved.ok) {
 			const skippedDetails = formatSkippedModelFailureDetails(skippedModels);
@@ -1481,6 +1496,8 @@ async function executeChain(
 	onChildEvent?: (event: Record<string, unknown>) => void,
 	arbitration?: Omit<SubagentArbitrationHooks, "step">,
 	onControlAvailable?: (client: RpcClient | undefined) => void,
+	/** Parent session UUID for spawn-time availability probes (issue 500). */
+	parentSessionId?: string,
 ): Promise<SubagentResult[]> {
 	const results: SubagentResult[] = [];
 	let previousOutput = "";
@@ -1539,6 +1556,7 @@ async function executeChain(
 			resolveSubagentThinkingOverride(step.thinking, defaultThinking),
 			arbitration ? { ...arbitration, step: i + 1 } : undefined,
 			onControlAvailable,
+			parentSessionId,
 		);
 		results.push(result);
 
@@ -1934,6 +1952,12 @@ export interface SubagentToolOptions {
 	parentModel?: () => string | undefined;
 	/** Parent session's current session file path. Used to link subagent child sessions back to their parent session. */
 	parentSessionFile?: () => string | undefined;
+	/**
+	 * Parent session's stable conversation UUID. Forwarded to spawn-time model availability
+	 * probes so providers with session-based routing (e.g. OpenCode) can group the probe
+	 * with the parent conversation (issue 500).
+	 */
+	parentSessionId?: () => string | undefined;
 	/** Model registry for validating model names before spawning child processes. */
 	modelRegistry?: ModelRegistry;
 	/** Settings-based model override getter for mach6.models. */
@@ -2161,6 +2185,7 @@ export function createSubagentToolDefinition(
 	const getParentProvider = options?.parentProvider ?? (() => undefined);
 	const getParentModel = options?.parentModel ?? (() => undefined);
 	const getParentSessionFile = options?.parentSessionFile ?? (() => undefined);
+	const getParentSessionId = options?.parentSessionId ?? (() => undefined);
 	const modelRegistry = options?.modelRegistry;
 	const getAgentModelsForAgent = options?.getAgentModelsForAgent;
 	const arbitrate = options?.arbitrate;
@@ -2437,6 +2462,7 @@ export function createSubagentToolDefinition(
 										}
 									: undefined,
 								onControlAvailable,
+								getParentSessionId(),
 							),
 					);
 				};
@@ -2547,6 +2573,7 @@ export function createSubagentToolDefinition(
 										}
 									: undefined,
 								onControlAvailable,
+								getParentSessionId(),
 							);
 							const resultText = results
 								.map((r, i) => `### Step ${i + 1}\n${formatSingleResult(r)}`)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -321,14 +321,14 @@ export class InteractiveMode {
 				if (!model) throw new Error("No model available. Set a model first.");
 				const apiKey = await this.session.modelRegistry.getApiKey(model);
 				if (!apiKey) throw new Error("No API key available for the current model.");
-				return manager.hatch(model, apiKey);
+				return manager.hatch(model, apiKey, this.session.sessionId);
 			},
 			onReroll: async (manager) => {
 				const model = this.session.model;
 				if (!model) throw new Error("No model available. Set a model first.");
 				const apiKey = await this.session.modelRegistry.getApiKey(model);
 				if (!apiKey) throw new Error("No API key available for the current model.");
-				return manager.reroll(model, apiKey);
+				return manager.reroll(model, apiKey, this.session.sessionId);
 			},
 			onVisibilityChange: (visible) => this.syncBuddyWidget(visible),
 		});
@@ -696,6 +696,7 @@ export class InteractiveMode {
 			getModel: () => this.session.model,
 			getModelRegistry: () => this.session.modelRegistry,
 			getProvider: () => this.session.model?.provider,
+			getSessionId: () => this.session.sessionId,
 			getAgentModelsOverride: (name) => this.settingsManager.getAgentModelsForAgent(name),
 			getBranch: () => this.footerDataProvider.getGitBranch(),
 			getRepo: () => path.basename(process.cwd()),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1872,6 +1872,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 					getModel: () => session.model,
 					getModelRegistry: () => session.modelRegistry,
 					getProvider: () => session.model?.provider,
+					getSessionId: () => session.sessionId,
 					getAgentModelsOverride: (name) => session.settingsManager.getAgentModelsForAgent(name),
 					getBranch: () => getGitBranch(cwd),
 					getRepo: () => basename(cwd),
@@ -2086,7 +2087,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				}
 				const { BuddyManager } = await import("../../core/buddy/buddy-manager.js");
 				const manager = new BuddyManager();
-				const state = await manager.hatch(model, apiKey);
+				const state = await manager.hatch(model, apiKey, session.sessionId);
 				return success(id, "buddy_hatch", { state });
 			}
 
@@ -2104,7 +2105,7 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				if (!manager.hasStoredBuddy()) {
 					return error(id, "buddy_reroll", "No buddy to reroll. Use hatch first.");
 				}
-				const state = await manager.reroll(model, apiKey);
+				const state = await manager.reroll(model, apiKey, session.sessionId);
 				return success(id, "buddy_reroll", { state });
 			}
 

--- a/packages/coding-agent/test/agent-session-session-id-wiring.test.ts
+++ b/packages/coding-agent/test/agent-session-session-id-wiring.test.ts
@@ -1,0 +1,216 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@dreb/agent-core";
+import type { AssistantMessage } from "@dreb/ai";
+import { findModel } from "@dreb/ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { assistantMsg, createTestResourceLoader, userMsg } from "./utilities.js";
+
+/**
+ * Non-live regression tests for the final AgentSession → LLM session-ID wiring.
+ *
+ * The earlier session-ID coverage in this PR was helper-level: tests passed an
+ * explicit sessionId into generateBranchSummary()/compact()/hatch() with
+ * @dreb/ai mocked, so deleting `this.sessionId` from an AgentSession call site
+ * (manual/auto compaction, branch summarization) would keep the entire suite
+ * green while stripping the x-opencode-session header from real OpenCode
+ * requests. These tests construct a real AgentSession (in-memory harness),
+ * mock only the LLM boundary (completeSimple), and assert that
+ * session.sessionId reaches every LLM call the auxiliary flows make. Driving
+ * the real compact() also covers all of its sessionId fan-out sites at once,
+ * including the turn-prefix summary path.
+ */
+
+const { completeSimpleMock } = vi.hoisted(() => ({
+	completeSimpleMock: vi.fn(),
+}));
+
+vi.mock("@dreb/ai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@dreb/ai")>();
+	return {
+		...actual,
+		completeSimple: completeSimpleMock,
+	};
+});
+
+const mockSummaryResponse: AssistantMessage = {
+	role: "assistant",
+	content: [{ type: "text", text: "Mock summary" }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	usage: {
+		input: 10,
+		output: 10,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 20,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: Date.now(),
+};
+
+interface LlmCall {
+	model: unknown;
+	prompt: { messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }> };
+	options: Record<string, unknown>;
+}
+
+function llmCalls(): LlmCall[] {
+	return completeSimpleMock.mock.calls.map(([model, prompt, options]) => ({ model, prompt, options }));
+}
+
+function promptText(call: LlmCall): string {
+	return call.prompt.messages
+		.map((message) =>
+			typeof message.content === "string"
+				? message.content
+				: message.content.map((block) => block.text ?? "").join(""),
+		)
+		.join("\n");
+}
+
+/**
+ * The stable ID the in-memory session was created with. Asserting the UUID
+ * shape guards against an empty/undefined session ID silently satisfying
+ * equality assertions.
+ */
+function sessionIdOf(session: AgentSession): string {
+	const id = session.sessionId;
+	expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+	return id;
+}
+
+describe("AgentSession session ID wiring (non-live, LLM boundary mocked)", () => {
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let settingsManager: SettingsManager;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `dreb-session-id-wiring-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		completeSimpleMock.mockReset();
+		completeSimpleMock.mockResolvedValue(mockSummaryResponse);
+
+		const model = findModel("anthropic", "sonnet")!;
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [],
+			},
+		});
+
+		sessionManager = SessionManager.inMemory();
+		settingsManager = SettingsManager.create(tempDir, tempDir);
+		// Force a deep cut point so compaction exercises both summary paths
+		// (normal history summary and split-turn summary) deterministically.
+		settingsManager.applyOverrides({ compaction: { keepRecentTokens: 1 } });
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+	});
+
+	afterEach(() => {
+		session.dispose();
+		vi.restoreAllMocks();
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	it("forwards the session ID to the summary LLM call on manual compaction", async () => {
+		sessionManager.appendMessage(userMsg("first question"));
+		sessionManager.appendMessage(assistantMsg("first answer"));
+		sessionManager.appendMessage(userMsg("second question"));
+
+		await session.compact();
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		const [call] = llmCalls();
+		expect(call.model).toBe(session.model);
+		expect(call.options).toMatchObject({ apiKey: "test-key", sessionId: sessionIdOf(session) });
+		// Normal (non-split) path: history summary prompt, no turn-prefix prompt
+		expect(promptText(call)).toContain("a conversation to summarize");
+		expect(promptText(call)).not.toContain("PREFIX of a turn that was too large to keep");
+	});
+
+	it("forwards the session ID to both LLM calls when a manual compaction splits a turn", async () => {
+		// u1 → a1 | u2 → a2 → a3: with keepRecentTokens=1 the cut lands on the
+		// final assistant (mid-turn), so compact() fans out to BOTH the history
+		// generateSummary and the turn-prefix generateTurnPrefixSummary.
+		sessionManager.appendMessage(userMsg("first question"));
+		sessionManager.appendMessage(assistantMsg("first answer"));
+		sessionManager.appendMessage(userMsg("second question"));
+		sessionManager.appendMessage(assistantMsg("second answer"));
+		sessionManager.appendMessage(assistantMsg("third answer"));
+
+		await session.compact();
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(2);
+		const calls = llmCalls();
+		for (const call of calls) {
+			expect(call.model).toBe(session.model);
+			expect(call.options).toMatchObject({ apiKey: "test-key", sessionId: sessionIdOf(session) });
+		}
+		const texts = calls.map(promptText);
+		expect(texts.filter((text) => text.includes("a conversation to summarize"))).toHaveLength(1);
+		expect(texts.filter((text) => text.includes("PREFIX of a turn that was too large to keep"))).toHaveLength(1);
+	});
+
+	it("forwards the session ID to the summary LLM call on auto compaction", async () => {
+		sessionManager.appendMessage(userMsg("first question"));
+		sessionManager.appendMessage(assistantMsg("first answer"));
+		sessionManager.appendMessage(userMsg("second question"));
+
+		const runAutoCompaction = (
+			session as unknown as {
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+			}
+		)._runAutoCompaction.bind(session);
+
+		await runAutoCompaction("threshold", false);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		const [call] = llmCalls();
+		expect(call.model).toBe(session.model);
+		expect(call.options).toMatchObject({ apiKey: "test-key", sessionId: sessionIdOf(session) });
+		expect(promptText(call)).toContain("a conversation to summarize");
+	});
+
+	it("forwards the session ID to the branch summary LLM call on tree navigation", async () => {
+		const firstUser = sessionManager.appendMessage(userMsg("original question"));
+		sessionManager.appendMessage(assistantMsg("original answer"));
+
+		const result = await session.navigateTree(firstUser, { summarize: true });
+
+		expect(result.cancelled).toBe(false);
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		const [call] = llmCalls();
+		expect(call.model).toBe(session.model);
+		expect(call.options).toMatchObject({
+			apiKey: "test-key",
+			maxTokens: 2048,
+			sessionId: sessionIdOf(session),
+		});
+		expect(promptText(call)).toContain("summary of this conversation branch");
+	});
+});

--- a/packages/coding-agent/test/agent-session-session-id-wiring.test.ts
+++ b/packages/coding-agent/test/agent-session-session-id-wiring.test.ts
@@ -1,6 +1,9 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { Agent } from "@dreb/agent-core";
 import type { AssistantMessage } from "@dreb/ai";
 import { findModel } from "@dreb/ai";
@@ -10,6 +13,7 @@ import { AuthStorage } from "../src/core/auth-storage.js";
 import { ModelRegistry } from "../src/core/model-registry.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
+import { abortBackgroundAgents } from "../src/core/tools/subagent.js";
 import { assistantMsg, createTestResourceLoader, userMsg } from "./utilities.js";
 
 /**
@@ -37,6 +41,13 @@ vi.mock("@dreb/ai", async (importOriginal) => {
 		...actual,
 		completeSimple: completeSimpleMock,
 	};
+});
+
+// The subagent tool spawns a child CLI process; replace it with a fake that
+// emits one assistant turn and exits 0 so spawn paths run without a real CLI.
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return { ...actual, spawn: vi.fn() };
 });
 
 const mockSummaryResponse: AssistantMessage = {
@@ -88,7 +99,48 @@ function sessionIdOf(session: AgentSession): string {
 	return id;
 }
 
+/** Fake subagent child: emits one assistant turn and exits 0, no real CLI process. */
+function mockSubagentSpawn(model: { provider: string; id: string }): void {
+	vi.mocked(spawn).mockImplementation(((_command: string, _args: readonly string[]) => {
+		const stdout = new PassThrough();
+		const stderr = new PassThrough();
+		const proc = new EventEmitter() as ReturnType<typeof spawn> & {
+			stdout: PassThrough;
+			stderr: PassThrough;
+			killed: boolean;
+		};
+		proc.stdout = stdout;
+		proc.stderr = stderr;
+		proc.killed = false;
+		proc.kill = vi.fn(() => true) as ReturnType<typeof spawn>["kill"];
+		process.nextTick(() => {
+			stdout.write(
+				`${JSON.stringify({
+					type: "agent_start",
+					model: { provider: model.provider, id: model.id },
+					thinkingLevel: "low",
+				})}\n`,
+			);
+			stdout.write(
+				`${JSON.stringify({
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "done" }],
+						stopReason: "stop",
+					},
+				})}\n`,
+			);
+			stdout.end();
+			stderr.end();
+			proc.emit("close", 0);
+		});
+		return proc;
+	}) as unknown as typeof spawn);
+}
+
 describe("AgentSession session ID wiring (non-live, LLM boundary mocked)", () => {
+	let agent: Agent;
 	let session: AgentSession;
 	let sessionManager: SessionManager;
 	let settingsManager: SettingsManager;
@@ -102,13 +154,16 @@ describe("AgentSession session ID wiring (non-live, LLM boundary mocked)", () =>
 		completeSimpleMock.mockResolvedValue(mockSummaryResponse);
 
 		const model = findModel("anthropic", "sonnet")!;
-		const agent = new Agent({
+		agent = new Agent({
 			initialState: {
 				model,
 				systemPrompt: "Test",
 				tools: [],
 			},
 		});
+
+		vi.mocked(spawn).mockReset();
+		mockSubagentSpawn(model);
 
 		sessionManager = SessionManager.inMemory();
 		settingsManager = SettingsManager.create(tempDir, tempDir);
@@ -126,10 +181,13 @@ describe("AgentSession session ID wiring (non-live, LLM boundary mocked)", () =>
 			cwd: tempDir,
 			modelRegistry,
 			resourceLoader: createTestResourceLoader(),
+			// The subagent probe wiring test drives the session's own subagent tool.
+			initialActiveToolNames: ["subagent"],
 		});
 	});
 
 	afterEach(() => {
+		abortBackgroundAgents();
 		session.dispose();
 		vi.restoreAllMocks();
 		if (tempDir && existsSync(tempDir)) {
@@ -212,5 +270,49 @@ describe("AgentSession session ID wiring (non-live, LLM boundary mocked)", () =>
 			sessionId: sessionIdOf(session),
 		});
 		expect(promptText(call)).toContain("summary of this conversation branch");
+	});
+
+	it("forwards the session ID to the subagent spawn availability probe", async () => {
+		// A model fallback LIST forces the runtime-probing branch of spawn-time
+		// model resolution (a single model skips probing entirely), so this
+		// drives the AgentSession → subagent tool → probe sessionId wiring.
+		const sonnet = findModel("anthropic", "sonnet")!;
+		const opus = findModel("anthropic", "opus")!;
+		const agentDir = join(tempDir, ".dreb", "agents");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "probe-agent.md"),
+			[
+				"---",
+				"name: probe-agent",
+				"description: probe wiring",
+				`model: ${sonnet.provider}/${sonnet.id}, ${opus.provider}/${opus.id}`,
+				"---",
+				"Probe prompt",
+				"",
+			].join("\n"),
+		);
+
+		// Background delivery calls agent.prompt() after probe + spawn + child exit,
+		// so waiting on it proves the whole chain ran.
+		const promptSpy = vi.spyOn(agent, "prompt").mockResolvedValue(undefined as never);
+
+		const tool = agent.state.tools.find((candidate) => candidate.name === "subagent");
+		expect(tool).toBeDefined();
+		await tool!.execute(
+			"call",
+			{ agent: "probe-agent", task: "run the availability probe" },
+			new AbortController().signal,
+			() => {},
+		);
+		await vi.waitFor(() => expect(promptSpy).toHaveBeenCalledTimes(1));
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		const [probeModel, probeContext, probeOptions] = completeSimpleMock.mock.calls[0];
+		expect(probeModel).toEqual(sonnet);
+		// This LLM call is the spawn-time availability probe, not a summary call.
+		expect(probeContext.systemPrompt).toBe("Reply with the single word OK.");
+		expect(probeOptions).toMatchObject({ apiKey: "test-key", sessionId: sessionIdOf(session) });
+		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/branch-summarization.test.ts
+++ b/packages/coding-agent/test/branch-summarization.test.ts
@@ -1,0 +1,93 @@
+import type { AssistantMessage, Model } from "@dreb/ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateBranchSummary } from "../src/core/compaction/branch-summarization.js";
+import type { SessionEntry } from "../src/core/session-manager.js";
+
+const { completeSimpleMock } = vi.hoisted(() => ({
+	completeSimpleMock: vi.fn(),
+}));
+
+vi.mock("@dreb/ai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@dreb/ai")>();
+	return {
+		...actual,
+		completeSimple: completeSimpleMock,
+	};
+});
+
+function createModel(): Model<"anthropic-messages"> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	};
+}
+
+const mockSummaryResponse: AssistantMessage = {
+	role: "assistant",
+	content: [{ type: "text", text: "Branch summary" }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "test-model",
+	usage: {
+		input: 10,
+		output: 10,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 20,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: Date.now(),
+};
+
+const entries: SessionEntry[] = [
+	{
+		type: "message",
+		id: "1",
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		message: { role: "user", content: "Fix the auth bug", timestamp: Date.now() },
+	},
+];
+
+describe("generateBranchSummary session ID forwarding", () => {
+	beforeEach(() => {
+		completeSimpleMock.mockReset();
+		completeSimpleMock.mockResolvedValue(mockSummaryResponse);
+	});
+
+	it("forwards the stable session ID to the branch summary completion", async () => {
+		const result = await generateBranchSummary(entries, {
+			model: createModel(),
+			apiKey: "test-key",
+			signal: new AbortController().signal,
+			sessionId: "branch-summary-uuid",
+		});
+
+		expect(result.summary).toContain("Branch summary");
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			sessionId: "branch-summary-uuid",
+		});
+	});
+
+	it("omits sessionId when none is provided", async () => {
+		await generateBranchSummary(entries, {
+			model: createModel(),
+			apiKey: "test-key",
+			signal: new AbortController().signal,
+		});
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("sessionId");
+	});
+});

--- a/packages/coding-agent/test/buddy-manager.test.ts
+++ b/packages/coding-agent/test/buddy-manager.test.ts
@@ -264,6 +264,22 @@ describe("BuddyManager.hatch()", () => {
 		expect(vi.mocked(completeSimple)).toHaveBeenCalledOnce();
 	});
 
+	it("forwards the stable session ID to soul generation on hatch", async () => {
+		const restore = withTestEnv();
+		mockSoulResponse("Sparky", "A feisty little companion.");
+
+		const mgr = new BuddyManager();
+		await mgr.hatch(createTestModel(), "test-key", "buddy-hatch-uuid");
+
+		restore();
+
+		expect(vi.mocked(completeSimple)).toHaveBeenCalledOnce();
+		expect(vi.mocked(completeSimple).mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			sessionId: "buddy-hatch-uuid",
+		});
+	});
+
 	it("persists buddy to disk", async () => {
 		const restore = withTestEnv();
 		mockSoulResponse("Rex", "Bold and brave.");
@@ -376,6 +392,23 @@ describe("BuddyManager.reroll()", () => {
 		expect(state.rerollCount).toBe(1);
 		expect(state.name).toBe("Phoenix");
 		expect(state.personality).toBe("Reborn from ashes.");
+	});
+
+	it("forwards the stable session ID to soul generation on reroll", async () => {
+		const restore = withTestEnv();
+		writeStoredBuddy({ rerollCount: 0, name: "OldBuddy" });
+		mockSoulResponse("Phoenix", "Reborn from ashes.");
+
+		const mgr = new BuddyManager();
+		await mgr.reroll(createTestModel(), "test-key", "buddy-reroll-uuid");
+
+		restore();
+
+		expect(vi.mocked(completeSimple)).toHaveBeenCalledOnce();
+		expect(vi.mocked(completeSimple).mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			sessionId: "buddy-reroll-uuid",
+		});
 	});
 
 	it("increments from existing rerollCount", async () => {

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -75,4 +75,51 @@ describe("generateSummary reasoning options", () => {
 		});
 		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
 	});
+
+	it("forwards the stable session ID to the summary completion on the reasoning path", async () => {
+		await generateSummary(
+			messages,
+			createModel(true),
+			2000,
+			"test-key",
+			undefined,
+			undefined,
+			undefined,
+			"compaction-session-uuid",
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			reasoning: "high",
+			sessionId: "compaction-session-uuid",
+		});
+	});
+
+	it("forwards the stable session ID to the summary completion on the non-reasoning path", async () => {
+		await generateSummary(
+			messages,
+			createModel(false),
+			2000,
+			"test-key",
+			undefined,
+			undefined,
+			undefined,
+			"compaction-session-uuid",
+		);
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			sessionId: "compaction-session-uuid",
+		});
+		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
+	});
+
+	it("omits sessionId when no session ID is provided", async () => {
+		await generateSummary(messages, createModel(false), 2000, "test-key");
+
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("sessionId");
+	});
 });

--- a/packages/coding-agent/test/dispatch-arbiter.test.ts
+++ b/packages/coding-agent/test/dispatch-arbiter.test.ts
@@ -116,6 +116,7 @@ function createArbiter(
 	candidateModels = [{ model: workerModel }, { model: cheapModel }],
 	timeoutMs?: number,
 	getSettings: () => SubagentArbiterSettings | undefined = () => settings,
+	getSessionId: () => string | undefined = () => undefined,
 ) {
 	return new DispatchArbiter({
 		getSettings,
@@ -127,6 +128,7 @@ function createArbiter(
 		],
 		getParentModel: () => workerModel,
 		getSessionTitle: () => "Implement routing",
+		getSessionId,
 		getRepoMetadata: () => ({ repo: "project", cwd: "/tmp/project", branch: "feature/test", dirtyCount: 2 }),
 		getExtraSecretPatterns: () => [{ name: "auth_secret", pattern: /AUTH_SECRET_[0-9]+/g }],
 		complete: complete as never,
@@ -194,6 +196,18 @@ describe("DispatchArbiter", () => {
 		const retryContext = complete.mock.calls[1][1];
 		expect(retryContext.messages[1].content).toContain("previous response did not match");
 		expect(retryContext.messages[1].content).not.toContain("```json");
+	});
+
+	test("forwards the stable session ID on every arbiter attempt", async () => {
+		complete
+			.mockResolvedValueOnce(response("```json\n{}\n```"))
+			.mockResolvedValueOnce(response({ agent: "Explore", model: "provider/worker", thinking: "high" }));
+		const arbiter = createArbiter(undefined, undefined, undefined, () => "arbiter-session-uuid");
+		const result = await arbiter.arbitrate(request);
+		expect(result).toMatchObject({ enabled: true, ok: true });
+		expect(complete).toHaveBeenCalledTimes(2);
+		expect(complete.mock.calls[0][2]).toMatchObject({ sessionId: "arbiter-session-uuid" });
+		expect(complete.mock.calls[1][2]).toMatchObject({ sessionId: "arbiter-session-uuid" });
 	});
 
 	test("rejects otherwise valid decisions containing model-authored extra keys", async () => {

--- a/packages/coding-agent/test/subagent-arbiter.test.ts
+++ b/packages/coding-agent/test/subagent-arbiter.test.ts
@@ -560,6 +560,7 @@ describe("pre-spawn subagent arbitration", () => {
 			secretOutputPatterns: [{ name: "custom_arbiter_secret", pattern: "CUSTOM_SECRET_[0-9]+" }],
 		});
 		const providerContexts: unknown[] = [];
+		const arbiterOptions: unknown[] = [];
 		const session = new AgentSession({
 			agent: parentAgent,
 			sessionManager,
@@ -569,8 +570,9 @@ describe("pre-spawn subagent arbitration", () => {
 			resourceLoader: createTestResourceLoader(),
 			scopedModels: [{ model: workerModel }],
 			initialActiveToolNames: ["subagent"],
-			dispatchArbiterComplete: async (_model, context) => {
+			dispatchArbiterComplete: async (_model, context, options) => {
 				providerContexts.push(context);
+				arbiterOptions.push(options);
 				return {
 					content: [
 						{
@@ -605,6 +607,14 @@ describe("pre-spawn subagent arbitration", () => {
 			() => {},
 		);
 		await eventsPromise;
+
+		// The session ID is wired into every arbiter LLM call (issue 500):
+		// AgentSession → DispatchArbiter.getSessionId → injected complete options.
+		expect(arbiterOptions).toHaveLength(2);
+		for (const options of arbiterOptions) {
+			expect(options).toMatchObject({ sessionId: session.sessionId });
+		}
+
 		const arbiterInputs = providerContexts.map((providerContext) => {
 			const providerMessage = (providerContext as { messages: Array<{ content: string }> }).messages[0].content;
 			return JSON.parse(providerMessage.slice(providerMessage.indexOf("\n") + 1)) as {

--- a/packages/coding-agent/test/subagent-model-fallback.test.ts
+++ b/packages/coding-agent/test/subagent-model-fallback.test.ts
@@ -990,6 +990,20 @@ describe("spawn-time model availability probing", () => {
 		expect(callOptions).toHaveProperty("reasoning", "high");
 	});
 
+	test("probeModelAvailability forwards the stable session ID", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await probeModelAvailability(probeModels[0], {
+			registry: probeRegistry(),
+			timeoutMs: 100,
+			sessionId: "subagent-probe-uuid",
+		});
+
+		expect(result).toEqual({ ok: true });
+		const callOptions = vi.mocked(completeSimple).mock.calls[0][2];
+		expect(callOptions).toHaveProperty("sessionId", "subagent-probe-uuid");
+	});
+
 	test("probeModelAvailability reports thrown errors", async () => {
 		vi.mocked(completeSimple).mockRejectedValueOnce(new Error("rate limit exceeded"));
 
@@ -1076,6 +1090,24 @@ describe("spawn-time model availability probing", () => {
 		expect(isRuntimeUnavailableError(new Error("timeout"))).toBe(true);
 		expect(isRuntimeUnavailableError("HTTP 500")).toBe(true);
 		expect(isRuntimeUnavailableError(assistantResult("stop"))).toBe(false);
+	});
+
+	test("fallback loop forwards the session ID to the probe", async () => {
+		vi.mocked(completeSimple).mockResolvedValueOnce(assistantResult("stop"));
+
+		const result = await resolveModelForSubagentSpawn(
+			["primary-model", "fallback-model"],
+			"anthropic",
+			probeRegistry(),
+			"parent-model",
+			undefined,
+			"[subagent]",
+			"spawn-session-uuid",
+		);
+
+		expect(result.ok).toBe(true);
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(completeSimple).mock.calls[0][2]).toHaveProperty("sessionId", "spawn-session-uuid");
 	});
 
 	test("fallback loop uses the first model when its probe succeeds", async () => {

--- a/packages/coding-agent/test/tab-title.test.ts
+++ b/packages/coding-agent/test/tab-title.test.ts
@@ -364,6 +364,22 @@ describe("TabTitleGenerator", () => {
 			expect(content).toContain("Repo: dreb");
 			expect(content).toContain("Cwd: /home/user/dreb");
 		});
+
+		it("forwards the stable session ID to the title completion", async () => {
+			mockCompleteSimple.mockResolvedValue(makeAssistantResponse("Fix auth bug") as any);
+
+			const deps = createMockDeps({ getSessionId: () => "stable-tab-title-uuid" });
+			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
+
+			gen.onToolEnd();
+
+			await vi.waitFor(() => {
+				expect(mockCompleteSimple).toHaveBeenCalled();
+			});
+
+			const options = mockCompleteSimple.mock.calls[0][2] as Record<string, unknown>;
+			expect(options.sessionId).toBe("stable-tab-title-uuid");
+		});
 	});
 
 	describe("title sanitization", () => {
@@ -710,7 +726,7 @@ describe("TabTitleGenerator", () => {
 				skippedModels: [],
 			});
 
-			const deps = createMockDeps();
+			const deps = createMockDeps({ getSessionId: () => "tab-title-session-uuid" });
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
 			gen.onToolEnd();
@@ -723,6 +739,7 @@ describe("TabTitleGenerator", () => {
 					"test-model",
 					expect.any(AbortSignal),
 					"[tab-title]",
+					"tab-title-session-uuid",
 				);
 			});
 		});
@@ -747,7 +764,10 @@ describe("TabTitleGenerator", () => {
 			const getAgentModelsOverride = vi.fn((name: string) =>
 				name === "Explore" ? ["override/model-a", "override/model-b"] : undefined,
 			);
-			const deps = createMockDeps({ getAgentModelsOverride });
+			const deps = createMockDeps({
+				getAgentModelsOverride,
+				getSessionId: () => "tab-title-session-uuid",
+			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
 			gen.onToolEnd();
@@ -760,6 +780,7 @@ describe("TabTitleGenerator", () => {
 					"test-model",
 					expect.any(AbortSignal),
 					"[tab-title]",
+					"tab-title-session-uuid",
 				);
 			});
 			expect(getAgentModelsOverride).toHaveBeenCalledWith("Explore");
@@ -781,7 +802,10 @@ describe("TabTitleGenerator", () => {
 				skippedModels: [],
 			});
 
-			const deps = createMockDeps({ getAgentModelsOverride: () => [] });
+			const deps = createMockDeps({
+				getAgentModelsOverride: () => [],
+				getSessionId: () => "tab-title-session-uuid",
+			});
 			const gen = new TabTitleGenerator({ triggerAfter: 1 }, deps);
 
 			gen.onToolEnd();
@@ -794,6 +818,7 @@ describe("TabTitleGenerator", () => {
 					"test-model",
 					expect.any(AbortSignal),
 					"[tab-title]",
+					"tab-title-session-uuid",
 				);
 			});
 		});

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.64.1",
+  "version": "2.64.2",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.64.1",
+	"version": "2.64.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #500

Ensure OpenCode Zen and Go requests carry a stable per-conversation session header across all supported provider protocols and internal LLM request paths.

Implementation plan posted as a comment below.
