### PR TITLE
Restore compaction status and summary in dashboard on session re-entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dreb",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dreb",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"workspaces": [
 				"packages/*",
 				"packages/coding-agent/examples/extensions/with-deps",
@@ -10934,7 +10934,7 @@
 		},
 		"packages/agent": {
 			"name": "@dreb/agent-core",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/ai": "*"
@@ -10963,7 +10963,7 @@
 		},
 		"packages/ai": {
 			"name": "@dreb/ai",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
@@ -11109,7 +11109,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@dreb/coding-agent",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/agent-core": "*",
@@ -11238,7 +11238,7 @@
 		},
 		"packages/dashboard": {
 			"name": "@dreb/dashboard",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11470,7 +11470,7 @@
 		},
 		"packages/semantic-search": {
 			"name": "@dreb/semantic-search",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@huggingface/transformers": "^4.0.1",
@@ -11519,7 +11519,7 @@
 		},
 		"packages/telegram": {
 			"name": "@dreb/telegram",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@dreb/coding-agent": "*",
@@ -11552,7 +11552,7 @@
 		},
 		"packages/tui": {
 			"name": "@dreb/tui",
-			"version": "2.64.2",
+			"version": "2.64.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"node": "22.x"
 	},
 	"packageManager": "npm@11.5.1",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"dependencies": {
 		"@dreb/coding-agent": "*",
 		"@mariozechner/jiti": "^2.6.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/agent-core",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/ai",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/coding-agent",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"type": "module",
 	"drebConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/dashboard",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Web dashboard for dreb — fleet overview, chat parity, subagent observability",
 	"license": "MIT",
 	"type": "module",

--- a/packages/dashboard/src/client/state/reducer.ts
+++ b/packages/dashboard/src/client/state/reducer.ts
@@ -436,6 +436,17 @@ export function messagesToEntries(messages: MessageLike[]): TranscriptEntry[] {
 				tag: m.customType ?? "extension",
 				text: m.displayText ?? contentToText(message.content),
 			});
+		} else if (message.role === "compactionSummary") {
+			// Persisted compaction summaries ride snapshot messages as their own
+			// role; render them the same way the live auto_compaction_end handler
+			// does so the card survives leaving and re-entering the session view.
+			const m = message as { summary?: string; tokensBefore?: number };
+			entries.push({
+				kind: "summary",
+				label: "compaction",
+				text: m.summary ?? "context compacted",
+				tokensBefore: m.tokensBefore,
+			});
 		}
 	}
 	return entries;
@@ -451,6 +462,23 @@ let statusEntryCounter = 0;
 export function createStatusLineEntry(entry: Omit<StatusLineEntry, "id" | "dismissed">): StatusLineEntry {
 	statusEntryCounter += 1;
 	return { id: statusEntryCounter, ...entry };
+}
+
+/**
+ * Keep the "compacting context…" status entry in sync with the authoritative
+ * `compacting` flag. Live start/end events and every snapshot-apply path
+ * (drill-in hydrate, full resync) converge on this so the banner — and the
+ * "stop compaction" control driven by it — exists whenever compaction is in
+ * flight, even when the start event was consumed before the snapshot barrier
+ * and is no longer replayed. The entry is re-created rather than revived,
+ * including after dismissal, so re-entering a compacting session restores
+ * the indication.
+ */
+export function syncCompactionStatusEntry(state: SessionViewState): void {
+	state.statusEntries = state.statusEntries.filter((entry) => entry.key !== "compaction");
+	if (state.compacting) {
+		state.statusEntries.push(createStatusLineEntry({ key: "compaction", text: "compacting context…", tone: "info" }));
+	}
 }
 
 // The UI renders only the newest few global toasts; keep a bounded per-session
@@ -768,22 +796,34 @@ export function applySessionEvent(state: SessionViewState, event: any): void {
 			// Context-overflow errors are provisional while automatic compaction
 			// recovers the turn, just like provider errors entering auto-retry.
 			if (event.reason === "overflow") clearProviderErrorState(state);
-			state.statusEntries.push(
-				createStatusLineEntry({ key: "compaction", text: "compacting context…", tone: "info" }),
-			);
+			syncCompactionStatusEntry(state);
 			break;
 		}
 		case "auto_compaction_end": {
 			state.compacting = false;
-			state.statusEntries = state.statusEntries.filter((s) => s.key !== "compaction");
+			syncCompactionStatusEntry(state);
 			const result = event.result as { tokensBefore?: number; summary?: string } | undefined;
 			if (result && !event.aborted) {
-				state.entries.push({
-					kind: "summary",
-					label: "compaction",
-					text: result.summary ?? "context compacted",
-					tokensBefore: result.tokensBefore,
-				});
+				const text = result.summary ?? "context compacted";
+				// The same compaction can surface twice when it completes between
+				// the snapshot barrier and the snapshot read: the snapshot
+				// messages already carry the summary, and this (replayed) event
+				// would otherwise add a second identical card.
+				const alreadyPresent = state.entries.some(
+					(entry) =>
+						entry.kind === "summary" &&
+						entry.label === "compaction" &&
+						entry.text === text &&
+						entry.tokensBefore === result.tokensBefore,
+				);
+				if (!alreadyPresent) {
+					state.entries.push({
+						kind: "summary",
+						label: "compaction",
+						text,
+						tokensBefore: result.tokensBefore,
+					});
+				}
 			}
 			if (event.errorMessage) {
 				state.statusEntries.push(

--- a/packages/dashboard/src/client/state/store.ts
+++ b/packages/dashboard/src/client/state/store.ts
@@ -29,6 +29,7 @@ import {
 	messagesToEntries,
 	resolveUiRequest as resolveReducerUiRequest,
 	type SessionViewState,
+	syncCompactionStatusEntry,
 	type Toast,
 	updateAttention,
 } from "./reducer.js";
@@ -151,6 +152,11 @@ function restoreSnapshotOutcomeState(session: SessionViewState, messages: any[],
 			}),
 		);
 	}
+	// The snapshot's `compacting` flag is authoritative: sync the matching
+	// status entry so re-entering a compacting session restores the banner
+	// and its stop control even when the start event was not replayed.
+	// session.compacting was set from the same snapshot state by both callers.
+	syncCompactionStatusEntry(session);
 	deriveProviderErrorState(
 		session,
 		messages,

--- a/packages/dashboard/test/client/store.test.ts
+++ b/packages/dashboard/test/client/store.test.ts
@@ -461,6 +461,31 @@ describe("app store SSE sync", () => {
 		expect(store.sessions.a?.needsAttention).toBe(true);
 	});
 
+	it("restores the compaction status entry from a compacting resync snapshot", async () => {
+		const snapshot = runtimeSnapshot("a", false);
+		snapshot.state.isCompacting = true;
+		vi.mocked(api.resync).mockResolvedValueOnce({
+			fleet: { runtimes: [snapshot], diskSessions: [] },
+			active: {
+				key: "a",
+				state: snapshot.state,
+				messages: [],
+				backgroundAgents: [],
+				barrierSeq: 0,
+			},
+			barrierSeq: 0,
+		});
+		const store = await makeStartedStore();
+
+		emit("", { type: "dashboard_resync", reason: "buffer_gap" });
+		await vi.waitFor(() => expect(store.resyncing()).toBe(false));
+
+		expect(store.sessions.a?.compacting).toBe(true);
+		expect(store.sessions.a?.statusEntries).toContainEqual(
+			expect.objectContaining({ key: "compaction", text: "compacting context…", tone: "info" }),
+		);
+	});
+
 	it("restores retry backoff without turning the failed attempt terminal during resync", async () => {
 		const snapshot = runtimeSnapshot("a", false);
 		snapshot.state.isRetrying = true;
@@ -1508,6 +1533,96 @@ describe("app store hydration", () => {
 		});
 		expect(store.sessions.s1?.streaming).toBe(true);
 		expect(store.sessions.s1?.workingSince).toEqual(expect.any(Number));
+	});
+
+	it("restores the compaction status entry when the snapshot is compacting", async () => {
+		const snapshot = hydrationSnapshot("s1", false);
+		snapshot.state.isCompacting = true;
+		vi.mocked(api.hydrate).mockResolvedValueOnce(snapshot);
+		const store = createAppStore();
+
+		await store.hydrateSession("s1");
+
+		expect(store.sessions.s1?.compacting).toBe(true);
+		expect(store.sessions.s1?.statusEntries).toContainEqual(
+			expect.objectContaining({ key: "compaction", text: "compacting context…", tone: "info" }),
+		);
+	});
+
+	it("does not duplicate the compaction status entry when the start event is replayed after hydration", async () => {
+		const snapshot = hydrationSnapshot("s1", false);
+		snapshot.state.isCompacting = true;
+		vi.mocked(api.hydrate).mockResolvedValueOnce(snapshot);
+		const store = await makeStartedStore();
+
+		// Envelope seq 1 > barrierSeq 0, so it is replayed after the snapshot.
+		emit("s1", { type: "auto_compaction_start", reason: "threshold" });
+		await store.hydrateSession("s1");
+
+		expect(store.sessions.s1?.statusEntries.filter((s) => s.key === "compaction")).toHaveLength(1);
+	});
+
+	it("clears the compaction status entry when live compaction ends after hydration", async () => {
+		const snapshot = hydrationSnapshot("s1", false);
+		snapshot.state.isCompacting = true;
+		vi.mocked(api.hydrate).mockResolvedValueOnce(snapshot);
+		const store = await makeStartedStore();
+
+		await store.hydrateSession("s1");
+		expect(store.sessions.s1?.statusEntries.some((s) => s.key === "compaction")).toBe(true);
+
+		emit("s1", {
+			type: "auto_compaction_end",
+			result: { tokensBefore: 52410, summary: "earlier work summarized" },
+			aborted: false,
+			willRetry: false,
+		});
+
+		expect(store.sessions.s1?.compacting).toBe(false);
+		expect(store.sessions.s1?.statusEntries.some((s) => s.key === "compaction")).toBe(false);
+		expect(store.sessions.s1?.entries).toContainEqual(
+			expect.objectContaining({ kind: "summary", label: "compaction", tokensBefore: 52410 }),
+		);
+	});
+
+	it("hydrates compactionSummary messages as transcript summary entries", async () => {
+		const snapshot = hydrationSnapshot("s1", false);
+		snapshot.messages = [
+			{ role: "compactionSummary", summary: "earlier work summarized", tokensBefore: 52410 },
+			{ role: "user", content: "after compaction" },
+		];
+		vi.mocked(api.hydrate).mockResolvedValueOnce(snapshot);
+		const store = createAppStore();
+
+		await store.hydrateSession("s1");
+
+		expect(store.sessions.s1?.entries).toMatchObject([
+			{ kind: "summary", label: "compaction", text: "earlier work summarized", tokensBefore: 52410 },
+			{ kind: "user", text: "after compaction" },
+		]);
+	});
+
+	it("does not duplicate the summary card when a replayed end event matches the snapshot summary", async () => {
+		const snapshot = hydrationSnapshot("s1", false);
+		snapshot.messages = [{ role: "compactionSummary", summary: "earlier work summarized", tokensBefore: 52410 }];
+		vi.mocked(api.hydrate).mockResolvedValueOnce(snapshot);
+		const store = await makeStartedStore();
+
+		// Envelope seq 1 > barrierSeq 0, so it is replayed after the snapshot —
+		// the barrier race where the same compaction surfaces twice.
+		emit("s1", {
+			type: "auto_compaction_end",
+			result: { tokensBefore: 52410, summary: "earlier work summarized" },
+			aborted: false,
+			willRetry: false,
+		});
+		await store.hydrateSession("s1");
+
+		const summaries = (store.sessions.s1?.entries ?? []).filter(
+			(e) => e.kind === "summary" && e.label === "compaction",
+		);
+		expect(summaries).toHaveLength(1);
+		expect(summaries[0]).toMatchObject({ text: "earlier work summarized", tokensBefore: 52410 });
 	});
 
 	it("restores a pending ask and attention when drilling into a session", async () => {

--- a/packages/dashboard/test/reducer.test.ts
+++ b/packages/dashboard/test/reducer.test.ts
@@ -8,6 +8,7 @@ import {
 	messagesToEntries,
 	pendingQuestionsReason,
 	resolveUiRequest,
+	syncCompactionStatusEntry,
 } from "../src/client/state/reducer.js";
 import type { BackgroundAgentDto } from "../src/shared/protocol.js";
 
@@ -69,6 +70,28 @@ describe("messagesToEntries — hydration", () => {
 			],
 			model: "m1",
 		});
+	});
+
+	it("hydrates compactionSummary messages as compaction summary entries", () => {
+		const entries = messagesToEntries([
+			{ role: "compactionSummary", summary: "earlier work summarized", tokensBefore: 52410 },
+			{ role: "user", content: "after compaction", timestamp: 3 },
+		]);
+
+		expect(entries.map((e) => e.kind)).toEqual(["summary", "user"]);
+		expect(entries[0]).toMatchObject({
+			kind: "summary",
+			label: "compaction",
+			text: "earlier work summarized",
+			tokensBefore: 52410,
+		});
+	});
+
+	it("falls back to a generic compaction summary when the message has no text", () => {
+		const entries = messagesToEntries([{ role: "compactionSummary", tokensBefore: 1000 }]);
+		expect(entries).toEqual([
+			{ kind: "summary", label: "compaction", text: "context compacted", tokensBefore: 1000 },
+		]);
 	});
 
 	it("retains uploaded-image references on hydrated user transcript entries", () => {
@@ -798,6 +821,41 @@ describe("applySessionEvent — session-level events", () => {
 		expect(state.entries[0]).toMatchObject({ kind: "summary", label: "compaction", tokensBefore: 52410 });
 	});
 
+	it("does not duplicate a summary entry already present from snapshot hydration", () => {
+		const state = makeState();
+		state.entries = messagesToEntries([
+			{ role: "compactionSummary", summary: "earlier work summarized", tokensBefore: 52410 },
+		]);
+		applySessionEvent(state, { type: "auto_compaction_start", reason: "threshold" });
+		applySessionEvent(state, {
+			type: "auto_compaction_end",
+			result: { tokensBefore: 52410, summary: "earlier work summarized" },
+			aborted: false,
+			willRetry: false,
+		});
+
+		const summaries = state.entries.filter((e) => e.kind === "summary" && e.label === "compaction");
+		expect(summaries).toHaveLength(1);
+	});
+
+	it("still appends a summary entry when an earlier compaction differs", () => {
+		const state = makeState();
+		state.entries = messagesToEntries([
+			{ role: "compactionSummary", summary: "first compaction", tokensBefore: 1000 },
+		]);
+		applySessionEvent(state, { type: "auto_compaction_start", reason: "threshold" });
+		applySessionEvent(state, {
+			type: "auto_compaction_end",
+			result: { tokensBefore: 2000, summary: "second compaction" },
+			aborted: false,
+			willRetry: false,
+		});
+
+		const summaries = state.entries.filter((e) => e.kind === "summary" && e.label === "compaction");
+		expect(summaries).toHaveLength(2);
+		expect(summaries[1]).toMatchObject({ text: "second compaction", tokensBefore: 2000 });
+	});
+
 	it("clears provisional provider state while overflow compaction recovers", () => {
 		const state = makeState();
 		applySessionEvent(state, {
@@ -958,6 +1016,54 @@ describe("applySessionEvent — session-level events", () => {
 		expect(secondRetry).toMatchObject({ id: expect.any(Number), key: "retry" });
 		expect(paused).toMatchObject({ id: expect.any(Number), key: "paused" });
 		expect(new Set([firstRetry?.id, secondRetry?.id, paused?.id]).size).toBe(3);
+	});
+});
+
+describe("syncCompactionStatusEntry", () => {
+	it("creates the compaction status entry when compacting is true", () => {
+		const state = makeState();
+		state.compacting = true;
+		syncCompactionStatusEntry(state);
+		expect(state.statusEntries).toEqual([
+			expect.objectContaining({ key: "compaction", text: "compacting context…", tone: "info" }),
+		]);
+	});
+
+	it("keeps exactly one compaction status entry when called repeatedly", () => {
+		const state = makeState();
+		state.compacting = true;
+		syncCompactionStatusEntry(state);
+		syncCompactionStatusEntry(state);
+		expect(state.statusEntries.filter((s) => s.key === "compaction")).toHaveLength(1);
+	});
+
+	it("re-exposes the entry after dismissal while still compacting", () => {
+		const state = makeState();
+		state.compacting = true;
+		syncCompactionStatusEntry(state);
+		const previous = state.statusEntries.find((s) => s.key === "compaction");
+		previous!.dismissed = true;
+		syncCompactionStatusEntry(state);
+		const current = state.statusEntries.find((s) => s.key === "compaction");
+		expect(current?.dismissed).toBeUndefined();
+		expect(current?.id).not.toBe(previous!.id);
+	});
+
+	it("removes the compaction status entry when compacting is false", () => {
+		const state = makeState();
+		state.compacting = true;
+		syncCompactionStatusEntry(state);
+		state.compacting = false;
+		syncCompactionStatusEntry(state);
+		expect(state.statusEntries.some((s) => s.key === "compaction")).toBe(false);
+	});
+
+	it("leaves other status entries untouched", () => {
+		const state = makeState();
+		applySessionEvent(state, { type: "parent_paused_for_background_agents", runningAgentCount: 1 });
+		state.compacting = true;
+		syncCompactionStatusEntry(state);
+		expect(state.statusEntries.map((s) => s.key).sort()).toEqual(["compaction", "paused"]);
 	});
 });
 

--- a/packages/semantic-search/.claude-plugin/plugin.json
+++ b/packages/semantic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "semantic-search",
   "description": "Semantic codebase search — natural language queries over code and docs using embeddings, tree-sitter parsing, and POEM multi-signal ranking",
-  "version": "2.64.2",
+  "version": "2.64.3",
   "author": {
     "name": "Drew Brereton"
   },

--- a/packages/semantic-search/package.json
+++ b/packages/semantic-search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/semantic-search",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Semantic codebase search engine with embedding-based ranking and MCP server",
 	"publishConfig": {
 		"access": "public"

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/telegram",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Telegram bot frontend for dreb coding agent",
 	"license": "MIT",
 	"type": "module",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dreb/tui",
-	"version": "2.64.2",
+	"version": "2.64.3",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Closes #502

Restore the compaction indication and the compaction summary in the dashboard when a session view is left and re-entered: the "compacting" status entry is synced from the authoritative snapshot state on hydrate/resync, and `compactionSummary` transcript messages are rendered as summary cards.

Implementation plan posted as a comment below.
